### PR TITLE
Suppress warning thrown during `ruff format .`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ line-length = 88
 target-version = "py310"  # Match your `>=3.10` requirement
 
 # Choose what to check for
-select = ["E", "F", "B", "I", "UP", "N", "C4"]
+lint.select = ["E", "F", "B", "I", "UP", "N", "C4"]
 
 exclude = ["__pycache__", ".venv", "build", "dist", ".git"]
 


### PR DESCRIPTION
fixes #38 by simply adding `lint.` before `select`