### PR TITLE
feat: add Structure `dataclass` and residue-metadata core to MAWS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "[MNT] [Dependabot]"
+      include: "scope"
+    labels:
+      - "maintenance"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "[MNT] [Dependabot]"
+      include: "scope"
+    labels:
+      - "maintenance"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,97 @@
+name: Test
+
+on:
+  push:
+    paths-ignore:
+      - 'docs/**'
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+    types: [opened, synchronize]
+
+  # Allows workflows to be manually triggered
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  code-quality:
+    name: code-quality
+    runs-on: ubuntu-latest
+    steps:
+      - name: repository checkout step
+        uses: actions/checkout@v4
+
+      - name: python environment step
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: install pre-commit
+        run: python3 -m pip install pre-commit
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get changed files
+        id: changed-files
+        run: |
+          CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | tr '\n' ' ')
+          echo "CHANGED_FILES=${CHANGED_FILES}" >> $GITHUB_ENV
+
+      - name: Print changed files
+        run: |
+          echo "Changed files: $CHANGED_FILES"
+
+      - name: Run pre-commit on changed files
+        run: |
+          if [ -n "$CHANGED_FILES" ]; then
+            pre-commit run --color always --files $CHANGED_FILES --show-diff-on-failure
+          else
+            echo "No changed files to check."
+          fi
+
+  run-tests-no-extras:
+    needs: code-quality
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: git remote set-branches origin 'main'
+
+      - run: git fetch --depth 1
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+
+      - name: Install package and dependencies
+        run: |
+          python -m pip install .[dev] --no-cache-dir
+
+      - name: Show dependencies
+        run: python -m pip list
+
+      - name: Show available branches
+        run: git branch -a
+
+      - name: Run tests
+        run: |
+          python -m pytest pyaptamer -p no:warnings

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.0
+    hooks:
+      - id: ruff-format
+      - id: ruff
+        args: [--fix]

--- a/pyaptamer/__init__.py
+++ b/pyaptamer/__init__.py
@@ -1,0 +1,3 @@
+"""pyaptamer: Python library for aptamer design."""
+
+__version__ = "0.0.1.dev0"

--- a/pyaptamer/maws/structure.py
+++ b/pyaptamer/maws/structure.py
@@ -70,7 +70,14 @@ class Structure:
     # ------------------------------------------------------------------
     def __post_init__(self) -> None:  # noqa: D401
         """Validate inputs and build defaults, then compose `init_string`."""
-        self._validate_residue_names()
+        Structure._validate_residue_names(
+            set(self.residue_names),
+            self.residue_length,
+            self.connect,
+            self.alias,
+            self.rotating_elements,
+            self.backbone_elements,
+        )
         self._fill_defaults()
         self.init_string = self._build_init_string()
 
@@ -120,17 +127,24 @@ class Structure:
     # ==================================================================
     # private helpers
     # ==================================================================
-    def _validate_residue_names(self) -> None:
-        """Raise early if any dict key refers to an unknown residue."""
-        known = set(self.residue_names)
-        for name_set, label in [
-            (self.residue_length, "residue_length"),
-            (self.connect, "connect"),
-            (self.alias, "alias"),
-            (self.rotating_elements, "rotating_elements"),
-            (self.backbone_elements, "backbone_elements"),
+    @staticmethod
+    def _validate_residue_names(
+        allowed: set[str],
+        residue_length: dict[str, int],
+        connect: dict[str, ConnectSpec],
+        alias: dict[str, list[str]],
+        rotating: dict[str, RotationList],
+        backbone: dict[str, list[list[int]]],
+    ) -> None:
+        """Raise if any mapping contains a name not present in *allowed*."""
+        for mapping, label in [
+            (residue_length, "residue_length"),
+            (connect, "connect"),
+            (alias, "alias"),
+            (rotating, "rotating_elements"),
+            (backbone, "backbone_elements"),
         ]:
-            unknown = set(name_set) - known
+            unknown = set(mapping) - allowed
             if unknown:
                 raise ValueError(f"{label}: unknown residue(s): {', '.join(unknown)}")
 

--- a/pyaptamer/maws/structure.py
+++ b/pyaptamer/maws/structure.py
@@ -1,0 +1,174 @@
+"""
+structure.py
+
+Defines the `Structure` dataclass to model chemical residue-based molecular
+structures, including rotation and backbone definitions.  Integrates with OpenMM.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TypeAlias, Sequence, Union
+
+# ── compact, self-documenting type aliases ───────────────────────────
+RotSpec: TypeAlias = tuple[str, int, int, int | None]  # (res, i, j, k)
+BackboneSpec: TypeAlias = tuple[str, int, int, int, int, int]  # (res, s, mp, b, mpo, e)
+
+# heterogenous entry types -------------------------------------------------------
+RotationTriplet: TypeAlias = list[int | None]  # [i, j, k] indices
+RotationEntry: TypeAlias = Union[RotationTriplet, str]  # numeric OR tag string
+RotationList: TypeAlias = list[RotationEntry]
+
+ConnectEntry: TypeAlias = Union[list[int], float]  # inner bond list or distance
+ConnectSpec: TypeAlias = list[ConnectEntry]
+
+
+log = logging.getLogger(__name__)
+
+
+# ----------------------------------------------------------------------
+# main dataclass
+# ----------------------------------------------------------------------
+@dataclass(slots=True)
+class Structure:
+    """
+    Defines chemical properties for molecules based on residues.
+
+    Attributes
+    ----------
+    residue_names : list[str]
+        All residue identifiers handled by this Structure.
+    residue_length : dict[str, int]
+        Number of atoms per residue.
+    rotating_elements : dict[str, list[list[int | None]]]
+        [start, bond, end] triplets that may rotate.
+    backbone_elements : dict[str, list[list[int]]]
+        Two substructures per residue: [[s, mp, b], [mpo, e]]
+    connect : dict[str, list[list[int | float]]]
+        Bond indices and default distances for linking residues.
+    alias : dict[str, list[str]]
+        Four-entry translation for each residue (N-term, mid, mid, C-term).
+    init_string : str
+        TLeap commands for loading each residue force-field file.
+    """
+
+    # ------------------------------- core data ------------------------
+    residue_names: list[str]
+    residue_path: str = "."
+    residue_length: dict[str, int] = field(default_factory=dict)
+    connect: dict[str, ConnectSpec] = field(default_factory=dict)
+    alias: dict[str, list[str]] = field(default_factory=dict)
+    rotating_elements: dict[str, RotationList] = field(default_factory=dict)
+    backbone_elements: dict[str, list[list[int]]] = field(default_factory=dict)
+
+    # ------------------------------- derived --------------------------
+    init_string: str = field(init=False)
+
+    # ------------------------------------------------------------------
+    # post-init = light validation + default filling
+    # ------------------------------------------------------------------
+    def __post_init__(self) -> None:  # noqa: D401
+        """Validate inputs and build defaults, then compose `init_string`."""
+        self._validate_residue_names()
+        self._fill_defaults()
+        self.init_string = self._build_init_string()
+
+    # ==================================================================
+    # public helpers
+    # ==================================================================
+    def add_rotation(self, residue: str, rot: str | Sequence[str]) -> RotationList:
+        """
+        Append one or many rotation specifications to *residue*.
+
+        Parameters
+        ----------
+        residue : str
+            Residue to modify.
+        rot : str | list[str]
+            Either a single rotation spec or a list of them.
+
+        Returns
+        -------
+        list[list[int | None]]
+            Updated rotation table for the residue.
+        """
+        if isinstance(rot, str):
+            rot = [rot]
+        self.rotating_elements[residue].extend(rot)
+        return self.rotating_elements[residue]
+
+    def translate(self, sequence: str) -> str:
+        """
+        Convert a space-separated residue string to its alias form.
+
+        Notes
+        -----
+        * single residue  → alias[0]
+        * multi-residue   → N-term alias[1], middle alias[2], C-term alias[3]
+        """
+        parts = sequence.split()
+        if len(parts) == 1:
+            return self.alias[parts[0]][0]
+
+        return " ".join(
+            [self.alias[parts[0]][1]]
+            + [self.alias[p][2] for p in parts[1:-1]]
+            + [self.alias[parts[-1]][3]]
+        )
+
+    # ==================================================================
+    # private helpers
+    # ==================================================================
+    def _validate_residue_names(self) -> None:
+        """Raise early if any dict key refers to an unknown residue."""
+        known = set(self.residue_names)
+        for name_set, label in [
+            (self.residue_length, "residue_length"),
+            (self.connect, "connect"),
+            (self.alias, "alias"),
+            (self.rotating_elements, "rotating_elements"),
+            (self.backbone_elements, "backbone_elements"),
+        ]:
+            unknown = set(name_set) - known
+            if unknown:
+                raise ValueError(f"{label}: unknown residue(s): {', '.join(unknown)}")
+
+    def _fill_defaults(self) -> None:
+        """Populate missing per-residue entries with safe defaults."""
+        for name in self.residue_names:
+            self.residue_length.setdefault(name, 0)
+            self.connect.setdefault(name, [[0, -1], [-2, 0], 1.6, 1.6])
+            self.alias.setdefault(name, [name] * 4)
+            self.rotating_elements.setdefault(name, [])
+            self.backbone_elements.setdefault(name, [])
+
+    def _build_init_string(self) -> str:
+        """Compose TLeap commands for each residue."""
+        lines: list[str] = []
+        for name in self.residue_names:
+            path = f"{self.residue_path}/{name}"
+            log.debug("Building force-field load string for %s", path)
+            lines.append(f"loadoff {path}.lib\nloadamberparams {path}.frcmod")
+        return "\n".join(lines)
+
+
+# ----------------------------------------------------------------------
+#  quick check
+# ----------------------------------------------------------------------
+if __name__ == "__main__":
+    # 1. build the tiniest valid Structure (one residue, aliases required)
+    s = Structure(
+        residue_names=["ALA"],
+        alias={"ALA": ["ALA", "ALA", "ALA", "ALA"]},
+    )
+
+    # 2. sanity: defaults were filled
+    assert s.connect["ALA"][2:] == [1.6, 1.6]
+
+    # 3. public helpers still work
+    assert s.translate("ALA") == "ALA"
+    s.add_rotation("ALA", "chi1")
+    assert s.rotating_elements["ALA"][-1] == "chi1"
+
+    print("check passed")

--- a/pyaptamer/maws/structure.py
+++ b/pyaptamer/maws/structure.py
@@ -165,24 +165,3 @@ class Structure:
             log.debug("Building force-field load string for %s", path)
             lines.append(f"loadoff {path}.lib\nloadamberparams {path}.frcmod")
         return "\n".join(lines)
-
-
-# ----------------------------------------------------------------------
-#  quick check
-# ----------------------------------------------------------------------
-if __name__ == "__main__":
-    # 1. build the tiniest valid Structure (one residue, aliases required)
-    s = Structure(
-        residue_names=["ALA"],
-        alias={"ALA": ["ALA", "ALA", "ALA", "ALA"]},
-    )
-
-    # 2. sanity: defaults were filled
-    assert s.connect["ALA"][2:] == [1.6, 1.6]
-
-    # 3. public helpers still work
-    assert s.translate("ALA") == "ALA"
-    s.add_rotation("ALA", "chi1")
-    assert s.rotating_elements["ALA"][-1] == "chi1"
-
-    print("check passed")

--- a/pyaptamer/tests/__init__.py
+++ b/pyaptamer/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the pyaptamer package."""

--- a/pyaptamer/tests/test_dummy.py
+++ b/pyaptamer/tests/test_dummy.py
@@ -1,0 +1,6 @@
+"""Single dummy test to ensure pytest is working."""
+
+
+def test_dummy():
+    """A dummy test that always passes."""
+    assert True, "This is a dummy test that should always pass."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Python library for aptamer simulation"
 readme = "README.md"
 requires-python = ">=3.10"
 authors = [
-    { name="Your Name", email="your@email.com" }
+    {name="German Center for Open Source AI", email="info@gcos.ai"}
 ]
 
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ line-length = 88
 target-version = "py310"  # Match your `>=3.10` requirement
 
 # Choose what to check for
-select = ["E", "F", "B", "I", "UP", "N", "C4"]
+lint.select = ["E", "F", "B", "I", "UP", "N", "C4"]
 
 exclude = ["__pycache__", ".venv", "build", "dist", ".git"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,21 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "ruff>=0.12.0",
-    "black>=25.0",
-    "pytest>=8.0.0"
+    "pytest>=8.0.0",
+    "pre-commit"
 ]
+
+[tool.ruff]
+line-length = 88
+target-version = "py310"  # Match your `>=3.10` requirement
+
+# Choose what to check for
+select = ["E", "F", "B", "I", "UP", "N", "C4"]
+
+exclude = ["__pycache__", ".venv", "build", "dist", ".git"]
+
+[tool.ruff.format]
+quote-style = "double"
+line-ending = "lf"
+indent-style = "space"
+docstring-code-format = true

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -1,0 +1,155 @@
+# tests/test_structure.py
+
+import pytest
+from pyaptamer.maws.structure import Structure
+
+def test_fill_defaults_and_init_string(tmp_path):
+    """
+    Test that when only residue_names is provided (with a custom residue_path),
+    all per-residue dicts get the correct defaults, and init_string contains
+    exactly two lines per residue in the right order.
+    """
+    # Create a Structure with two residues and point residue_path at tmp_path
+    s = Structure(
+        residue_names=["A", "B"],
+        residue_path=str(tmp_path),
+    )
+
+    # --- Defaults from _fill_defaults() ---
+    # residue_length should default to 0 for each residue
+    assert s.residue_length["A"] == 0
+    assert s.residue_length["B"] == 0
+
+    # connect should default to [[0,-1],[-2,0],1.6,1.6]
+    assert s.connect["A"] == [[0, -1], [-2, 0], 1.6, 1.6]
+    assert s.connect["B"] == [[0, -1], [-2, 0], 1.6, 1.6]
+
+    # alias should default to [name]*4
+    assert s.alias["A"] == ["A", "A", "A", "A"]
+    assert s.alias["B"] == ["B", "B", "B", "B"]
+
+    # rotating_elements and backbone_elements should default to empty lists
+    assert s.rotating_elements["A"] == []
+    assert s.rotating_elements["B"] == []
+    assert s.backbone_elements["A"] == []
+    assert s.backbone_elements["B"] == []
+
+    # --- init_string via _build_init_string() ---
+    # Expect 2 lines per residue: one loadoff, one loadamberparams
+    lines = s.init_string.splitlines()
+    assert len(lines) == 2 * len(s.residue_names)
+
+    # Check content and order
+    for idx, name in enumerate(["A", "B"]):
+        loadoff_line = lines[2 * idx]
+        params_line = lines[2 * idx + 1]
+        expected_path = f"{tmp_path}/{name}"
+        assert loadoff_line == f"loadoff {expected_path}.lib"
+        assert params_line == f"loadamberparams {expected_path}.frcmod"
+
+
+def test_validation_raises_for_unknown_mappings():
+    """
+    If any of the provided dicts contain keys not in residue_names,
+    __post_init__ should immediately raise a ValueError naming the bad keys.
+    """
+    # Unknown key in residue_length
+    with pytest.raises(ValueError) as exc:
+        Structure(
+            residue_names=["X"],
+            residue_length={"Y": 3},
+        )
+    assert "residue_length: unknown residue(s): Y" in str(exc.value)
+
+    # Unknown key in connect
+    with pytest.raises(ValueError) as exc2:
+        Structure(
+            residue_names=["A"],
+            connect={"B": [[0,1],[2,3],1.6,1.6]},
+        )
+    assert "connect: unknown residue(s): B" in str(exc2.value)
+
+
+def test_custom_initial_mappings_are_respected(tmp_path):
+    """
+    Passing custom residue_length, connect, alias, rotating_elements,
+    and backbone_elements at init-time should be preserved (and not
+    overwritten by defaults).
+    """
+    names = ["Z"]
+    path = tmp_path / "res"
+    path.mkdir()
+    # create dummy lib/frcmod files for init_string
+    (path / "Z.lib").write_text("")
+    (path / "Z.frcmod").write_text("")
+
+    # Prepare custom dicts
+    length = {"Z": 42}
+    connect = {"Z": [[9,8],[7,6],2.0,2.1]}
+    alias = {"Z": ["n0","n1","n2","n3"]}
+    rotating = {"Z": [[1, 2, 3]]}
+    backbone = {"Z": [[4,5,6],[7,8]]}
+
+    s = Structure(
+        residue_names=names,
+        residue_path=str(path),
+        residue_length=length,
+        connect=connect,
+        alias=alias,
+        rotating_elements=rotating,
+        backbone_elements=backbone,
+    )
+
+    # Check that nothing was clobbered by _fill_defaults
+    assert s.residue_length["Z"] == 42
+    assert s.connect["Z"] == [[9,8],[7,6],2.0,2.1]
+    assert s.alias["Z"] == ["n0","n1","n2","n3"]
+    assert s.rotating_elements["Z"] == [[1,2,3]]
+    assert s.backbone_elements["Z"] == [[4,5,6],[7,8]]
+
+
+def test_add_rotation_behaviour():
+    """
+    Test that add_rotation appends new entries to rotating_elements[residue]:
+    - a single string becomes a one-element list
+    - a list of strings extends the list
+    - a list of ints (numeric triplet) is also extended (flattened) per current implementation
+    """
+    s = Structure(residue_names=["R"])
+    # initially empty
+    assert s.rotating_elements["R"] == []
+
+    # add a single tag
+    result = s.add_rotation("R", "phi")
+    assert result == ["phi"], "Single-string should be wrapped and appended"
+
+    # add multiple tags
+    result = s.add_rotation("R", ["psi", "omega"])
+    assert result[-2:] == ["psi", "omega"], "List of strings should extend"
+
+    # add a numeric triplet (current behavior: extend flattens them)
+    result = s.add_rotation("R", [1, 2, 3])
+    assert result[-3:] == [1, 2, 3], "Numeric triplet is flattened by extend()"
+
+
+def test_translate_single_and_multi():
+    """
+    Test translate() for:
+    - a singleton sequence → alias[name][0]
+    - a two-residue and three-residue chain
+    """
+    s = Structure(residue_names=["A","B"])
+    # override alias mapping for clarity
+    s.alias = {
+        "A": ["A0", "A1", "A2", "A3"],
+        "B": ["B0", "B1", "B2", "B3"],
+    }
+
+    # single residue → N-term form alias[0]
+    assert s.translate("A") == "A0"
+
+    # two residues → N-term of A, C-term of B
+    assert s.translate("A B") == "A1 B3"
+
+    # three residues → N-term of A, mid of B, C-term of A
+    assert s.translate("A B A") == "A1 B2 A3"


### PR DESCRIPTION
###  What’s new

* **`pyaptamer/maws/structure.py`**
  * Introduces the `Structure` dataclass (`slots=True`) that holds all residue-level
    metadata required by the MAWS pipeline.
  * Provides:
    * type aliases for clearer static typing (`RotSpec`, `BackboneSpec`,
      `RotationList`, `ConnectSpec`)
    * validation of residue keys (`_validate_residue_names`)
    * default-value population (`_fill_defaults`)
    * automatic generation of tleap force-field load strings (`init_string`)
    * public helpers:  
      * `add_rotation()` – append rotation specs (string or list)  
      * `translate()` – resolve aliases for residue sequences
  * Uses `logging.debug` instead of `print`; **no heavy deps** 
  
  

#### Checklist 

- [x] `ruff` / `black` clean
- [ ] Unit tests (next PR)
- [ ] Docs reference
