### PR TITLE
Allow capital args in function and capital variable names

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dev = [
 
 [tool.ruff]
 line-length = 88
+ignore = ["N803", "N806"]
 target-version = "py310"  # Match your `>=3.10` requirement
 
 # Choose what to check for


### PR DESCRIPTION
Solves #42 by bypassing rules [N803](https://docs.astral.sh/ruff/rules/invalid-argument-name/) and [N806](https://docs.astral.sh/ruff/rules/non-lowercase-variable-in-function/)