### PR TITLE
Suppress warning thrown during `ruff check .`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,13 +25,12 @@ dev = [
 
 [tool.ruff]
 line-length = 88
-ignore = ["N803", "N806"]
-target-version = "py310"  # Match your `>=3.10` requirement
-
-# Choose what to check for
-lint.select = ["E", "F", "B", "I", "UP", "N", "C4"]
-
+target-version = "py310"
 exclude = ["__pycache__", ".venv", "build", "dist", ".git"]
+
+[tool.ruff.lint]
+select = ["E", "F", "B", "I", "UP", "N", "C4"]
+ignore = ["N803", "N806"]
 
 [tool.ruff.format]
 quote-style = "double"


### PR DESCRIPTION
fixes #52 by adding a separate lint section called `[tool.ruff.lint]` for `select` and `ignore`.