### PR TITLE
[BUG} Solves `ruff` errors for non-UNIX systems.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ ignore = ["N803", "N806"]
 
 [tool.ruff.format]
 quote-style = "double"
-line-ending = "lf"
 indent-style = "space"
 docstring-code-format = true
 

--- a/x.py
+++ b/x.py
@@ -1,8 +1,0 @@
-print("hello there")
-
-
-def a():
-    print("a")
-
-
-print(a)


### PR DESCRIPTION
solves #95
I removed the ruff end of line check and replaced it with the pre-commit hook sktime uses, as it checks EOL for ALL files staged.