### PR TITLE
Fix typos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,7 +177,7 @@ cython_debug/
 #  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
 #  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
 #  and can be added to the global gitignore or merged into this file. However, if you prefer, 
-#  you could uncomment the following to ignore the enitre vscode folder
+#  you could uncomment the following to ignore the entire vscode folder
 .vscode/
 
 # Ruff stuff:

--- a/pyaptamer/mcts/_algorithm.py
+++ b/pyaptamer/mcts/_algorithm.py
@@ -387,8 +387,8 @@ class TreeNode:
     def uct_score(self) -> float:
         """Compute upper confidence bound applied to trees (UCT) score.
 
-        UCT balances the trade-off between exploration (visting new paths) and
-        exploitation (visting known paths).
+        UCT balances the trade-off between exploration (visiting new paths) and
+        exploitation (visiting known paths).
         See:
         - https://en.wikipedia.org/wiki/Monte_Carlo_tree_search
 

--- a/pyaptamer/pseaac/_features.py
+++ b/pyaptamer/pseaac/_features.py
@@ -16,7 +16,7 @@ class PSeAAC:
     selected physicochemical properties and sequence-order correlations as described in
     the PseAAC model by Chou.
 
-    The PSeAAC algorith uses 21 normalized physiochemical (NP) properties of amino
+    The PSeAAC algorithm uses 21 normalized physiochemical (NP) properties of amino
     acids, which we load from a predefined matrix using `aa_props`.These 21 properties
     are grouped into 7 distinct property groups, with each group containing
     3 consecutive properties. Specifically, the groups are arranged in order as follows:


### PR DESCRIPTION
Correct misspellings in DNA research.

Using https://github.com/crate-ci/typos