### PR TITLE
[BUG] Fix output of MCTS and corresponding tests

### DIFF
--- a/pyaptamer/aptanet/_pipeline.py
+++ b/pyaptamer/aptanet/_pipeline.py
@@ -1,4 +1,4 @@
-__author__ = "satvshr"
+__author__ = ["nennomp", "satvshr"]
 __all__ = ["AptaNetPipeline"]
 __required__ = ["python>=3.9,<3.13"]
 
@@ -59,6 +59,7 @@ class AptaNetPipeline:
     >>> X_test_pairs = [(aptamer_seq, protein_seq) for _ in range(10)]
     >>> pipe.fit(X_train_pairs, y_train)  # doctest: +ELLIPSIS
     >>> preds = pipe.predict(X_test_pairs)
+    >>> proba = pipe.predict_proba(X_test_pairs)
     """
 
     def __init__(self, k=None, classifier=None):
@@ -77,6 +78,10 @@ class AptaNetPipeline:
     def fit(self, X, y):
         self.pipeline_ = self._build_pipeline()
         self.pipeline_.fit(X, y)
+
+    def predict_proba(self, X):
+        check_is_fitted(self)
+        return self.pipeline_.predict_proba(X)
 
     def predict(self, X):
         check_is_fitted(self)

--- a/pyaptamer/aptanet/tests/test_aptanet.py
+++ b/pyaptamer/aptanet/tests/test_aptanet.py
@@ -1,4 +1,5 @@
-__author__ = "satvshr"
+__author__ = ["nennomp", "satvshr"]
+
 
 import sys
 
@@ -41,6 +42,25 @@ def test_pipeline_fit_and_predict_classification(aptamer_seq, protein_seq):
     sys.version_info >= (3, 13), reason="skorch does not support Python 3.13"
 )
 @pytest.mark.parametrize("aptamer_seq, protein_seq", params)
+def test_pipeline_fit_and_predict_proba(aptamer_seq, protein_seq):
+    """
+    Test if Pipeline probability estimates predictions returns floats and shape matches
+    input.
+    """
+    pipe = AptaNetPipeline()
+
+    X_raw = [(aptamer_seq, protein_seq) for _ in range(40)]
+    y = np.array([0] * 20 + [1] * 20, dtype=np.float32)
+
+    pipe.fit(X_raw, y)
+    preds = pipe.predict_proba(X_raw)
+
+    assert preds.shape == (40, 2)
+    assert preds.dtype == np.float32
+    assert np.all((preds >= 0) & (preds <= 1))
+
+
+@pytest.mark.parametrize("aptamer_seq, protein_seq", params)
 def test_pipeline_fit_and_predict_regression(aptamer_seq, protein_seq):
     """
     Test if Pipeline predictions are valid floats and shape matches input
@@ -61,9 +81,25 @@ def test_pipeline_fit_and_predict_regression(aptamer_seq, protein_seq):
 @pytest.mark.skipif(
     sys.version_info >= (3, 13), reason="skorch does not support Python 3.13"
 )
-@parametrize_with_checks([AptaNetClassifier(), AptaNetRegressor()])
+@parametrize_with_checks(
+    estimators=[AptaNetClassifier(), AptaNetRegressor()],
+    # TODO: for some reason, despite including `check_pipeline_consistency` in the
+    # checks that are supposed to fail (via `expected_failed_checks` parameter), the
+    # check is still run and obviously fails. Currently, the if block is the only
+    # workaround that works, and skips the check completely. Note that,
+    # `check_pipeline_consistency` will never pass for non-deterministic estimators as
+    # in our case. If anyone has a better working solution, please suggest.
+    # expected_failed_checks={
+    #    "check_pipeline_consistency": "estimator is non-deterministic"
+    # },
+)
 def test_sklearn_compatible_estimator(estimator, check):
     """
-    Run scikit-learn's compatibility checks on the AptaPipeline.
+    Run scikit-learn's compatibility checks on the AptaNetClassifier.
     """
-    check(estimator)
+    expected_failed_checks = ["check_pipeline_consistency"]
+    if check.func.__name__ not in expected_failed_checks:
+        try:
+            check(estimator)
+        except Exception as e:
+            pytest.fail(f"Estimator check failed: {e}")

--- a/pyaptamer/aptatrans/_pipeline.py
+++ b/pyaptamer/aptatrans/_pipeline.py
@@ -11,7 +11,7 @@ import torch
 from torch import Tensor
 
 from pyaptamer.aptatrans import AptaTrans
-from pyaptamer.experiments import Aptamer
+from pyaptamer.experiments import AptamerEvalAptaTrans
 from pyaptamer.mcts import MCTS
 from pyaptamer.utils import (
     generate_all_aptamer_triplets,
@@ -127,10 +127,9 @@ class AptaTransPipeline:
 
         return (apta_words, prot_words)
 
-    def _init_aptamer_experiment(self, target: str) -> Aptamer:
-        """Initialize the aptamer experiment."""
-        # initialize the aptamer recommendation experiment
-        experiment = Aptamer(
+    def _init_aptamer_experiment(self, target: str) -> AptamerEvalAptaTrans:
+        """Initialize the aptamer recommendation experiment."""
+        experiment = AptamerEvalAptaTrans(
             target=target,
             model=self.model,
             device=self.device,

--- a/pyaptamer/aptatrans/tests/test_aptatrans.py
+++ b/pyaptamer/aptatrans/tests/test_aptatrans.py
@@ -253,7 +253,9 @@ class TestAptaTransPipeline:
             def __init__(self, **kwargs):
                 captured_args.update(kwargs)
 
-        monkeypatch.setattr("pyaptamer.aptatrans._pipeline.Aptamer", MockAptamer)
+        monkeypatch.setattr(
+            "pyaptamer.aptatrans._pipeline.AptamerEvalAptaTrans", MockAptamer
+        )
 
         # test experiment initialization
         experiment = pipeline._init_aptamer_experiment(target)
@@ -296,7 +298,9 @@ class TestAptaTransPipeline:
         def mock_aptamer(**kwargs):
             return MockExperiment()
 
-        monkeypatch.setattr("pyaptamer.aptatrans._pipeline.Aptamer", mock_aptamer)
+        monkeypatch.setattr(
+            "pyaptamer.aptatrans._pipeline.AptamerEvalAptaTrans", mock_aptamer
+        )
 
         # test prediction - note the typo fix: self.experiment -> experiment
         monkeypatch.setattr(
@@ -342,7 +346,9 @@ class TestAptaTransPipeline:
         def mock_aptamer(**kwargs):
             return MockExperiment()
 
-        monkeypatch.setattr("pyaptamer.aptatrans._pipeline.Aptamer", mock_aptamer)
+        monkeypatch.setattr(
+            "pyaptamer.aptatrans._pipeline.AptamerEvalAptaTrans", mock_aptamer
+        )
 
         # mock MCTS to return deterministic candidates
         class MockMCTS:

--- a/pyaptamer/experiments/__init__.py
+++ b/pyaptamer/experiments/__init__.py
@@ -1,5 +1,6 @@
 """Base classes for experiments."""
 
-__all__ = ["Aptamer"]
+__author__ = ["nennomp"]
+__all__ = ["AptamerEvalAptaNet", "AptamerEvalAptaTrans"]
 
-from pyaptamer.experiments._aptamer import Aptamer
+from pyaptamer.experiments._aptamer import AptamerEvalAptaNet, AptamerEvalAptaTrans

--- a/pyaptamer/experiments/_aptamer.py
+++ b/pyaptamer/experiments/_aptamer.py
@@ -1,6 +1,9 @@
 __author__ = ["nennomp"]
-__all__ = ["Aptamer"]
+__all__ = ["AptamerEvalAptaNet", "AptamerEvalAptaTrans"]
 
+from abc import ABC, abstractmethod
+
+import numpy as np
 import torch
 from skbase.base import BaseObject
 from torch import Tensor
@@ -8,94 +11,58 @@ from torch import Tensor
 from pyaptamer.utils import encode_rna, rna2vec
 
 
-class Aptamer(BaseObject):
-    """Candidate aptamer evaluation for a given target protein.
+class BaseAptamerEval(BaseObject, ABC):
+    """Abstract base class for candidate aptamer evaluation against target proteins.
+
+    This class defines the common interface and shared functionality for aptamer
+    evaluation using different models or pipelines.
 
     Parameters
     ----------
-    target : str, optional
-        Target sequence string.
-    model : torch.nn.Module
-        Model to use for assigning scores.
-    device : torch.device
-        Device to run the model on.
-    prot_words : dict[str, int]
-        A dictionary mapping protein 3-mer subsequences to integer token IDs.
-
-    Attributes
-    ----------
-    target_encoded : Tensor
-        Encoded target sequence tensor.
-
-    Examples
-    --------
-    >>> import torch
-    >>> from pyaptamer.aptatrans import AptaTrans, EncoderPredictorConfig
-    >>> from pyaptamer.experiments import Aptamer
-    >>> apta_embedding = EncoderPredictorConfig(128, 16, max_len=128)
-    >>> prot_embedding = EncoderPredictorConfig(128, 16, max_len=128)
-    >>> model = AptaTrans(apta_embedding, prot_embedding)
-    >>> target = "DHRNE"
-    >>> device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    >>> prot_words = {"AAA": 0.5, "AAC": 0.3, "AAG": 0.2}
-    >>> experiment = Aptamer(target, model, device, prot_words)
-    >>> aptamer_candidate = "AUGGC"
-    >>> imap = experiment.evaluate(aptamer_candidate, return_interaction_map=True)
-    >>> score = experiment.evaluate(aptamer_candidate)
+    target : str
+        Target sequence string consisting of amino acid letters and (possibly) unknown
+        characters. Interpreted as the amino-acid sequence of the binding target
+        protein.
     """
 
-    def __init__(
-        self,
-        target: str,
-        model: torch.nn.Module,
-        device: torch.device,
-        prot_words: dict[str, int],
-    ) -> None:
+    def __init__(self, target: str) -> None:
         self.target = target
-        self.model = model
-        self.device = device
-
-        self.target_encoded = encode_rna(
-            sequences=target,
-            words=prot_words,
-            max_len=model.prot_embedding.max_len,
-        ).to(device)
-
         super().__init__()
 
     def _inputnames(self) -> list[str]:
         """Return the inputs of the experiment."""
         return ["aptamer_candidate"]
 
-    def reconstruct(self, sequence: str = "") -> Tensor:
-        """Reconstruct the actual aptamer sequence from the encoded representation.
+    def reconstruct(self, sequence: str = "") -> str:
+        """Reconstruct the aptamer sequence.
 
-        The encoding uses pairs like 'A_' (add A to left) and '_A' (add A to right).
-        This method converts these pairs back to the actual sequence. Then, from its
-        RNA sequence representation it is converted to a vector.
+        The experiment expects aptamer candidates in a specific (encoded) format
+        involving pairs of nucleotide letters and direction markers (underscores). For
+        instance, 'A_' indicates adding 'A' to the left of the current sequence
+        (prepending), while '_A' indicates adding 'A' to the right (appending). As an
+        example, the input 'A_C__GU_' would be reconstructed to 'UCAG'.
 
         Parameters
         ----------
-        seq : str
+        sequence : str
             Encoded sequence with direction markers (underscores).
 
         Returns
         -------
-        tuple[str, torch.Tensor]
-            The reconstructed RNA sequence and its vector representation.
+        str
+            The reconstructed RNA sequence.
+
+        Examples
+        --------
+        >>> from pyaptamer.experiments import BaseAptamerEval
+        >>> experiment = BaseAptamerEval(target="DHRNE")
+        >>> reconstructed_seq = experiment.reconstruct("A_C__GU_")
+        >>> print(reconstructed_seq)
+        UCAG
         """
         # already reconstructed
         if "_" not in sequence:
-            return (
-                sequence,
-                torch.tensor(
-                    rna2vec(
-                        [sequence],
-                        max_sequence_length=self.model.apta_embedding.max_len,
-                    ),
-                    dtype=torch.int64,
-                ),
-            )
+            return sequence
 
         # if the sequence is not reconstructed yet, it should have an even length
         # because it should consist of pairs such as 'A_' and '_A' (i.e., nucleotide +
@@ -115,20 +82,114 @@ class Aptamer(BaseObject):
                     # prepend the current value
                     result = sequence[i] + result
 
-        return (
-            result,
-            torch.tensor(
-                rna2vec(
-                    [result], max_sequence_length=self.model.apta_embedding.max_len
-                ),
-                dtype=torch.int64,
+        return result
+
+    @abstractmethod
+    def evaluate(self, aptamer_candidate: str, **kwargs) -> np.float64:
+        """Evaluate the given aptamer candidate against the target protein.
+
+        Parameters
+        ----------
+        aptamer_candidate : str
+            The aptamer candidate to evaluate.
+        **kwargs
+            Additional keyword arguments specific to the implementation.
+
+        Returns
+        -------
+        np.float64
+            The score assigned to the aptamer candidate.
+        """
+        pass
+
+
+class AptamerEvalAptaTrans(BaseAptamerEval):
+    """Candidate aptamer evaluation for a given target protein using AptaTrans.
+
+    Parameters
+    ----------
+    target : str
+        Target sequence string consisting of amino acid letters and (possibly) unknown
+        characters. Interpreted as the amino-acid sequence of the binding target
+        protein.
+    model : torch.nn.Module
+        Model to use for assigning scores.
+    device : torch.device
+        Device to run the model on.
+    prot_words : dict[str, float]
+        A dictionary mapping protein 3-mer protein subsequences to their frequency in
+        the dataset using for training the model used in the experiment. Used to encode
+        protein sequences into their numerical representions.
+
+    Attributes
+    ----------
+    target_encoded : Tensor
+        Encoded target sequence tensor.
+
+    Examples
+    --------
+    >>> import torch
+    >>> from pyaptamer.aptatrans import AptaTrans, EncoderPredictorConfig
+    >>> from pyaptamer.experiments import AptamerEvalAptaTrans
+    >>> apta_embedding = EncoderPredictorConfig(128, 16, max_len=128)
+    >>> prot_embedding = EncoderPredictorConfig(128, 16, max_len=128)
+    >>> model = AptaTrans(apta_embedding, prot_embedding)
+    >>> target = "DHRNE"
+    >>> device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    >>> prot_words = {"AAA": 0.5, "AAC": 0.3, "AAG": 0.2}
+    >>> experiment = AptamerEvalAptaTrans(target, model, device, prot_words)
+    >>> aptamer_candidate = "AUGGC"
+    >>> imap = experiment.evaluate(aptamer_candidate, return_interaction_map=True)
+    >>> score = experiment.evaluate(aptamer_candidate)
+    """
+
+    def __init__(
+        self,
+        target: str,
+        model: torch.nn.Module,
+        device: torch.device,
+        prot_words: dict[str, int],
+    ) -> None:
+        super().__init__(target)
+        self.model = model
+        self.device = device
+
+        self.target_encoded = encode_rna(
+            sequences=target,
+            words=prot_words,
+            max_len=model.prot_embedding.max_len,
+        ).to(device)
+
+    def _get_numerical_repr(self, sequence: str) -> Tensor:
+        """
+        Convert the reconstructed sequence to its numerical representation.
+
+        The method expects an already reconstructed aptamer sequence (e.g., 'UCAG') and
+        then proceeds to convert it to its numerical representation using the `rna2vec`
+        function. Used to prepare the aptamer sequence for model input.
+
+        Parameters
+        ----------
+        sequence : str
+            Reconstructed sequence without direction markers (underscores).
+
+        Returns
+        -------
+        Tensor
+            A tensor containing the numerical representation of the aptamer sequence.
+        """
+        return torch.tensor(
+            rna2vec(
+                [sequence],
+                max_sequence_length=self.model.apta_embedding.max_len,
             ),
+            dtype=torch.int64,
         )
 
     @torch.no_grad()
     def evaluate(
         self, aptamer_candidate: str, return_interaction_map: bool = False
-    ) -> Tensor:
+    ) -> np.float64 | np.ndarray:
         """Evaluate the given aptamer candidate against the target protein.
 
         If `return_interaction_map` is set to `True`, the method returns the
@@ -147,21 +208,85 @@ class Aptamer(BaseObject):
 
         Returns
         -------
-        Tensor
+        np.float64 or np.ndarray
             The score assigned to the aptamer candidate if `return_interaction_map` is
             `False`. If `return_interaction_map` is `True`, the interaction map, of
             shape (batch_size, 1, seq_len_aptamer, seq_len_protein).
         """
-        aptamer_candidate = self.reconstruct(aptamer_candidate)[1]
+        aptamer_candidate = self.reconstruct(aptamer_candidate)
+        aptamer_candidate = self._get_numerical_repr(aptamer_candidate)
+
         self.model.eval()
 
         if return_interaction_map:
-            return self.model.forward_imap(
-                aptamer_candidate.to(self.device),
-                self.target_encoded,
+            return (
+                self.model.forward_imap(
+                    aptamer_candidate.to(self.device),
+                    self.target_encoded,
+                )
+                .cpu()
+                .detach()
+                .numpy()
             )
         else:
-            return self.model(
-                aptamer_candidate.to(self.device),
-                self.target_encoded,
+            return np.float64(
+                self.model(
+                    aptamer_candidate.to(self.device),
+                    self.target_encoded,
+                ).item()
             )
+
+
+class AptamerEvalAptaNet(BaseAptamerEval):
+    """Candidate aptamer evaluation for a given target protein using AptaNet.
+
+    Parameters
+    ----------
+    target : str
+        Target sequence string consisting of amino acid letters and (possibly) unknown
+        characters. Interpreted as the amino-acid sequence of the binding target
+        protein.
+    pipeline : AptaNetPipeline
+        Fitted AptaNetPipeline to use for assigning scores.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from pyaptamer.aptanet import AptaNetPipeline
+    >>> from pyaptamer.experiments import AptamerEvalAptaNet
+    >>> aptamer_seq = "AGCTTAGCGTACAGCTTAAAAGGGTTTCCCCTGCCCGCGTAC"
+    >>> protein_seq = "ACDEFGHIKLMNPQRSTVWYACDEFGHIKLMNPQRSTVWY"
+    >>> pairs = [(aptamer_seq, protein_seq) for _ in range(5)]
+    >>> labels = np.array([0] * 5, dtype=np.float32)
+    >>> pipeline = AptaNetPipeline()
+    >>> pipeline.fit(pairs, labels)
+    >>> target = "ACDEFACDEFACDEFACDEFACDEFACDEFACDEFACDEF"
+    >>> experiment = AptamerEvalAptaNet(target, pipeline)
+    >>> aptamer_candidate = "A_U_G_G_C_"
+    >>> score = experiment.evaluate(aptamer_candidate)
+    """
+
+    def __init__(self, target: str, pipeline) -> None:
+        super().__init__(target)
+        self.pipeline = pipeline
+
+    def evaluate(self, aptamer_candidate: str) -> np.float64:
+        """Evaluate the given aptamer candidate against the target protein.
+
+        Parameters
+        ----------
+        aptamer_candidate : str
+            The aptamer candidate to evaluate. It should be a string consisting of
+            letters representing nucleotides: 'A_', '_A', 'C_', '_C', 'G_', '_G', 'U_',
+            '_U'. Underscores indicate whether the nucleotides are supposed to be (e.
+            g., 'A_') prepended or appended (e.g., '_A') to the sequence.
+
+        Returns
+        -------
+        np.float64
+            The probability score assigned to the aptamer candidate.
+        """
+        aptamer_seq = self.reconstruct(aptamer_candidate)
+        score = self.pipeline.predict_proba(X=[(aptamer_seq, self.target)])
+
+        return np.float64(score[:, 1].item())  # return the positive class probability

--- a/pyaptamer/experiments/tests/test_aptamer.py
+++ b/pyaptamer/experiments/tests/test_aptamer.py
@@ -1,13 +1,13 @@
-"""Test suite for the Aptamer experiment class."""
+"""Test suite for the AptamerEval experiment classes."""
 
 __author__ = ["nennomp"]
 
+import numpy
 import pytest
 import torch
 import torch.nn as nn
-from torch import Tensor
 
-from pyaptamer.experiments import Aptamer
+from pyaptamer.experiments import AptamerEvalAptaNet, AptamerEvalAptaTrans
 
 
 class MockModel(nn.Module):
@@ -30,27 +30,25 @@ class MockModel(nn.Module):
         pass
 
 
-@pytest.fixture
-def experiment():
-    target = "DHRNE"
-    model = MockModel()
-    device = torch.device("cpu")
-    return Aptamer(
-        target=target,
-        model=model,
-        device=device,
-        prot_words={"AAA": 0.5, "AAC": 0.3, "AAG": 0.2},
-    )
+class MockAptaNetPipeline:
+    """Mock AptaNetPipeline for testing."""
 
+    def __init__(self, fixed_score=0.7):
+        self.fixed_score = fixed_score
+        self.is_fitted = True
 
-@pytest.fixture
-def target_encoded():
-    return torch.tensor([[1, 2, 3]])
+    def predict_proba(self, X):
+        """
+        Mock predict method that returns fixed scores for binary classification (no
+        binding, binding).
+        """
+        # return probability scores as a list
+        return numpy.array([[1 - self.fixed_score, self.fixed_score]] * len(X))
 
-
-@pytest.fixture
-def target():
-    return "ACGU"
+    def fit(self, X, y):
+        """Mock fit method."""
+        self.is_fitted = True
+        return self
 
 
 @pytest.fixture
@@ -59,74 +57,129 @@ def model():
 
 
 @pytest.fixture
-def default_device():
+def pipeline():
+    return MockAptaNetPipeline()
+
+
+@pytest.fixture
+def device():
+    """Default device for AptaTrans experiments."""
     return torch.device("cpu")
 
 
 @pytest.fixture
+def target():
+    return "ACDEFGHIKLMNPQRSTVWY"
+
+
+@pytest.fixture
 def prot_words():
+    """Protein words for AptaTrans experiments."""
     return {"AAA": 0.5, "AAC": 0.3, "AAG": 0.2, "AUG": 0.1, "CGA": 0.4}
 
 
-class TestAptamer:
-    """Test suite for the Aptamer() class."""
+class TestAptamerEvalConcrete:
+    """Test suite for concrete AptamerEval implementations (AptaTrans and AptaNet)."""
 
-    @pytest.mark.parametrize(
-        "device",
-        [
-            (torch.device("cpu")),
-            pytest.param(
-                torch.device("cuda"),
-                marks=pytest.mark.skipif(
-                    not torch.cuda.is_available(), reason="CUDA not available"
-                ),
-            ),
-        ],
-    )
-    def test_init(self, target, model, device, prot_words):
-        """Check correct initialization."""
-        experiment = Aptamer(
+    @pytest.fixture
+    def experiment(self, request, target, model, device, prot_words, pipeline):
+        """
+        Fixture that returns an initialized AptamerEval instance based on the parameter.
+        """
+        if request.param == "aptatrans":
+            return AptamerEvalAptaTrans(
+                target=target,
+                model=model,
+                device=device,
+                prot_words=prot_words,
+            )
+        elif request.param == "aptanet":
+            return AptamerEvalAptaNet(
+                target=target,
+                pipeline=pipeline,
+            )
+
+    @pytest.fixture
+    def aptatrans_experiment(self, target, model, device, prot_words):
+        """Fixture that returns an initialized AptamerEvalAptaTrans instance."""
+        return AptamerEvalAptaTrans(
             target=target,
             model=model,
             device=device,
             prot_words=prot_words,
         )
-        assert experiment.target_encoded.device.type == device.type
 
-    def test_inputnames(self, experiment):
-        """Check that the inputs of the experiment are correctly returned."""
-        inputs = experiment._inputnames()
-        assert inputs == ["aptamer_candidate"]
+    @pytest.fixture
+    def aptanet_experiment(self, target, pipeline):
+        """Fixture that returns an initialized AptamerEvalAptaNet instance."""
+        return AptamerEvalAptaNet(
+            target=target,
+            pipeline=pipeline,
+        )
 
-    def test_reconstruct(self, experiment):
-        """Check sequence reconstruction."""
-        # empty sequence
-        result_str, result_vector = experiment.reconstruct("")
+    @pytest.mark.parametrize("experiment", ["aptatrans", "aptanet"], indirect=True)
+    def test_evaluate(self, experiment):
+        """Check that the experiment's evaluation method works correctly."""
+        aptamer_candidate = "ACGU"
+        score = experiment.evaluate(aptamer_candidate)
+        assert isinstance(score, numpy.float64)
+
+    @pytest.mark.parametrize("experiment", ["aptatrans", "aptanet"], indirect=True)
+    def test_evaluate_empty_sequence(self, experiment):
+        """Check evaluation with empty sequence."""
+        score = experiment.evaluate("")
+        assert isinstance(score, numpy.float64)
+
+    @pytest.mark.parametrize("experiment", ["aptatrans", "aptanet"], indirect=True)
+    def test_evaluate_with_underscores(self, experiment):
+        """Check evaluation with sequences containing underscores."""
+        aptamer_candidate = "A_C_G_U_"
+        score = experiment.evaluate(aptamer_candidate)
+        assert isinstance(score, numpy.float64)
+
+    @pytest.mark.parametrize("experiment", ["aptatrans", "aptanet"], indirect=True)
+    def test_evaluate_already_reconstructed(self, experiment):
+        """Check evaluation with already reconstructed sequence."""
+        aptamer_candidate = "ACGU"  # no underscores
+        score = experiment.evaluate(aptamer_candidate)
+        assert isinstance(score, numpy.float64)
+
+    def test_reconstruct_aptanet(self, aptanet_experiment):
+        """Check sequence reconstruction in AptamerEvalAptaNet."""
+        result = aptanet_experiment.reconstruct("")
+        assert result == ""
+
+        result = aptanet_experiment.reconstruct("A_C_G_U_")
+        assert result == "UGCA"
+
+    def test_reconstruct_aptatrans(self, aptatrans_experiment):
+        """Check sequence reconstruction in AptamerEvalAptaTrans."""
+        result_str = aptatrans_experiment.reconstruct("")
         assert result_str == ""
-        assert torch.equal(result_vector, torch.tensor([]))
-        # prepend and append
-        result_str, result_vector = experiment.reconstruct("A_C__G_U")
+
+        result_str = aptatrans_experiment.reconstruct("A_C__G_U")
         assert result_str == "CAGU"
-        # 100 is the maximum length specified in our mock model
+
+    def test_get_numerical_repr(self, aptatrans_experiment):
+        """Check get numerical representation in AptamerEvalAptaTrans."""
+        result_vector = aptatrans_experiment._get_numerical_repr("")
+        assert torch.equal(result_vector, torch.tensor([]))
+
+        result_vector = aptatrans_experiment._get_numerical_repr("UCAG")
         assert result_vector.shape == (1, 100)
         assert result_vector[0, 0] != 0  # first triplet should not be 0
         assert result_vector[0, 1] != 0  # second triplet should not be 0
         assert torch.all(result_vector[0, 2:] == 0)  # rest should be padding
 
-    def test_evaluate(self, experiment):
-        """Check that the experiment's evaluation method works correctly."""
-        aptamer_candidate = "A_C_GU"
-        score = experiment.evaluate(aptamer_candidate)
-        assert isinstance(score, Tensor)
-        assert score.shape == (1,)
-
-    def test_evaluate_imap(self, experiment):
+    def test_evaluate_imap(self, aptatrans_experiment):
         """
         Check that the experiment's evaluation method works correctly when returning
         interaction map.
         """
         aptamer_candidate = "ACGU"
-        score = experiment.evaluate(aptamer_candidate, return_interaction_map=True)
-        assert isinstance(score, Tensor)
+        score = aptatrans_experiment.evaluate(
+            aptamer_candidate, return_interaction_map=True
+        )
+        assert isinstance(score, numpy.ndarray)
         # 100 is the maximum length specified in our mock model
-        assert score.shape == (1, 1, 100, experiment.target_encoded.shape[1])
+        assert score.shape == (1, 1, 100, aptatrans_experiment.target_encoded.shape[1])

--- a/pyaptamer/mcts/__init__.py
+++ b/pyaptamer/mcts/__init__.py
@@ -1,5 +1,6 @@
 """Monte Carlo Tree Search (MCTS) algorithm for string optimization."""
 
+__author__ = ["nennomp"]
 __all__ = ["MCTS"]
 
 from pyaptamer.mcts._algorithm import MCTS

--- a/pyaptamer/mcts/_algorithm.py
+++ b/pyaptamer/mcts/_algorithm.py
@@ -54,7 +54,7 @@ class MCTS(BaseObject):
     --------
     >>> import torch
     >>> from pyaptamer.aptatrans import AptaTrans, EncoderPredictorConfig
-    >>> from pyaptamer.experiments import Aptamer
+    >>> from pyaptamer.experiments import AptamerEvalAptaTrans
     >>> from pyaptamer.mcts import MCTS
     >>> apta_embedding = EncoderPredictorConfig(128, 16, max_len=128)
     >>> prot_embedding = EncoderPredictorConfig(128, 16, max_len=128)
@@ -62,7 +62,7 @@ class MCTS(BaseObject):
     >>> device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     >>> target = "MCKY"
     >>> prot_words = {"AAA": 0.5, "AAC": 0.3, "AAG": 0.2}
-    >>> experiment = Aptamer(target, model, device, prot_words)
+    >>> experiment = AptamerEvalAptaTrans(target, model, device, prot_words)
     >>> mcts = MCTS(depth=5, n_iterations=2, experiment=experiment)
     >>> candidate = mcts.run(verbose=False)
     """
@@ -236,8 +236,9 @@ class MCTS(BaseObject):
         Returns
         -------
         dict
-            Dictionary containing the final candidate sequence (`candidate`) and its
-            score (`score`).
+            Dictionary containing the final reconstructed candidate sequence
+            (`candidate`), the corresponding unreconstructed candidate sequence
+            (`sequence`), and its score (`score`).
         """
         self._reset()
 
@@ -279,7 +280,7 @@ class MCTS(BaseObject):
 
         self.candidate = self.base
         return {
-            "candidate": self.experiment.reconstruct(self.candidate)[0],
+            "candidate": self.experiment.reconstruct(self.candidate),
             "sequence": self.candidate,
             "score": self.experiment.evaluate(self.candidate),
         }

--- a/pyaptamer/mcts/tests/test_mcts.py
+++ b/pyaptamer/mcts/tests/test_mcts.py
@@ -1,499 +1,324 @@
-"""Monte Carlo Tree Search (MCTS) for string optimization."""
+"""Test suite for the Monte Carlo Tree Search (MCTS) algorithm."""
 
 __author__ = ["nennomp"]
-__all__ = ["MCTS"]
 
-import random
 
 import numpy as np
-from skbase.base import BaseObject
+import pytest
+import torch
 
+from pyaptamer.experiments import AptamerEvalAptaNet, AptamerEvalAptaTrans
+from pyaptamer.mcts import MCTS
+from pyaptamer.mcts._algorithm import TreeNode
 
-class MCTS(BaseObject):
-    """
-    MCTS algorithm implementation for string optimization, specifically for aptamr
-    generation as described in aptamer generation as described in [1]_, originally
-    introduced in [2]_.
+NUCLEOTIDES = ["A_", "_A", "C_", "_C", "G_", "_G", "U_", "_U"]
 
-    Adapted from:
 
-    - https://github.com/PNUMLB/AptaTrans/blob/master/mcts.py
-    - https://github.com/leekh7411/Apta-MCTS/blob/master/src/mcts.py
+@pytest.fixture
+def root():
+    return TreeNode()
 
-    Parameters
-    ----------
-    states : list[str]
-        Possible values for the nodes. Underscores indicate whether the values are
-        supposed to be prepended or appended to the sequence.
-    depth : int, optional
-        Maximum depth of the search tree, also the length of the generated sequences.
-    n_iterations : int, optional
-        Number of iterations per round for the MCTS algorithm.
-    experiment : BaseExperiment, optional, default=None
-        An instance of an experiment class definingthe goal function for the algorithm.
 
-    Attributes
-    ----------
-    base : str
-        Best sequence found so far.
-    candidate : str
-        Final candidate sequence.
-    root : TreeNode
-        Root node of the MCTS tree.
+@pytest.fixture
+def val():
+    return "A_"
 
-    References
-    ----------
-    .. [1] Shin, Incheol, et al. "AptaTrans: a deep neural network for predicting
-    aptamer-protein interaction using pretrained encoders." BMC bioinformatics 24.1
-    (2023): 447.
-    .. [2] Lee, Gwangho, et al. "Predicting aptamer sequences that interact with target
-    proteins using an aptamer-protein interaction classifier and a Monte Carlo tree
-    search approach." PloS one 16.6 (2021): e0253760.
 
-    Examples
-    --------
-    >>> import torch
-    >>> from pyaptamer.experiments import Aptamer
-    >>> from pyaptamer.mcts import MCTS
-    >>> device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    >>> target = "MCKY"
-    >>> target_encoded = torch.tensor([1, 0, 0, 1, 0, 1], dtype=torch.float32).to
-    ... (device)
-    >>> experiment = Aptamer(target_encoded, target, model, device)
-    >>> mcts = MCTS(depth=10, experiment=experiment)
-    >>> candidate = mcts.run()
-    >>> print((candidate["candidate"], len(candidate["candidate"])))
-    ('CUUUAUGUCA', 10)
-    >>> print((candidate["sequence"], len(candidate["sequence"])))
-    ('_GU_A__U_CU__AU_U_C_', 20)
-    >>> print(candidate["score"])
-    tensor([0.5000])
-    """
+@pytest.fixture
+def val_not_found():
+    return "X_"
 
-    def __init__(
-        self,
-        states: list[str] | None = None,
-        depth: int = 20,
-        n_iterations: int = 1000,
-        experiment=None,
-    ) -> None:
-        """
-        Parameters
-        ----------
-        experiment : Aptamer
-            An instance of the Aptamer() class specifying the goal function.
-        states : list[str], optional
-            A list containing possible values for the nodes. Underscores indicate
-            whether the values are supposed to be prepended or appended to the sequence.
-        depth : int, optional
-            Maximum depth of the search tree.
-        n_iterations : int, optional
-            Number of iterations per round for the MCTS algorithm.
-        """
-        self.experiment = experiment
-        self.depth = depth
-        self.n_iterations = n_iterations
 
-        super().__init__()
+@pytest.fixture
+def tree_with_children(tree_node):
+    """Provide a TreeNode with some children already added."""
+    for val in ["A_", "C_", "G_"]:
+        tree_node.create_child(val=val)
+    return tree_node
 
-        if states is None:
-            states = ["A_", "C_", "G_", "U_", "_A", "_C", "_G", "_U"]
-        self.states = states
 
-        self.root = TreeNode(
-            n_states=len(states),
-        )
-        self.base = ""
-        self.candidate = ""
+class TestTreeNode:
+    """Tests for the TreeNode() class."""
 
-    def _reset(self) -> None:
-        """Reset the MCTS algorithm to its initial state."""
-        self.root = TreeNode(
-            n_states=len(self.states),
-        )
-        self.base = ""
-        self.candidate = ""
-
-    def _selection(self, node: "TreeNode") -> "TreeNode":
-        """Select a node for expansion.
-
-        The tree is traversed recursively based on the more promising nodes according
-        to their UCT scores. When a node is fully expanded, the best child is selected
-        and the search continues down that path. The expansion stops when a node that
-        has not been fully expanded is found, or when a terminal node is reached.
-
-        Parameters
-        ----------
-        node : TreeNode
-            Starting node for selection.
-
-        Returns
-        -------
-        TreeNode
-            The node selected for expansion.
-        """
-        while not node.is_terminal:
-            if node.is_fully_expanded():  # fully expanded, select best one and continue
-                node = node.get_best_child()
-            else:  # expand
-                return node
-        return node
-
-    def _expansion(self, node: "TreeNode") -> "TreeNode":
-        """Expand the selected node.
-
-        The selected node is expanded by creating a new child to which a randomly
-        selected value is assigned. The value is randomly chosen from the set of
-        unexpanded states (those that have not been added to the node's children yet).
-
-        Parameters
-        ----------
-        node : TreeNode
-            Node to expand from.
-
-        Returns
-        -------
-        TreeNode
-            The newly created child node from the expansion.
-        """
-        is_terminal = node.depth == self.depth - 1
-
-        # find all unexpanded values for this node
-        unexpanded = list(set(self.states) - set(node.children.keys()))
-
-        # randomly selected one value from unexpanded ones
-        val = random.choice(unexpanded)
-
-        return node.create_child(val=val, is_terminal=is_terminal)
-
-    def _simulation(self, node: "TreeNode") -> float:
-        """
-        Simulate a random playout for the node/path and generate a candidate sequence.
-
-        Starting from the given node, a random walk is performed: random values are
-        added to the sequence until the desired length (depth) is reached. The sequence
-        is then evaluated leveraging the goal function defined by `self.experiment`.
-
-        Parameters
-        ----------
-        node : TreeNode
-            Node to start simulation from.
-
-        Returns
-        -------
-        float
-            The score for the simulate sequence, assigned according to the goal
-            function defined by `self.experiment`.
-        """
-        curr = node
-        sequence = ""
-
-        # build the current sequence from node to root
-        while not curr.is_root:
-            sequence = curr.val + sequence
-            curr = curr.parent
-
-        # prepend the `self.base` sequence
-        sequence = self.base + sequence
-
-        # fill the rest of the sequence with random possible values
-        remaining_length = (self.depth * 2) - len(sequence)
-        for _ in range(remaining_length):
-            sequence += random.choice(self.states)
-
-        # evaluate the candidate sequence with the goal function
-        return self.experiment.evaluate(sequence)
-
-    def _find_best_subsequence(self) -> str:
-        """Retrieve the best sequence found so far, according to the UCT scores.
-
-        Returns
-        -------
-        str
-            The best subsequence found in the current tree.
-        """
-        curr = self.root
-        subsequence = self.base
-
-        # traverse the tree
-        max_steps = (self.depth * 2) - len(self.base)
-        for _ in range(max_steps):
-            if not curr.children:
-                break
-
-            curr = curr.get_best_child()
-            subsequence += curr.val
-
-        return subsequence
-
-    def run(self, verbose: bool = True) -> dict:
-        """
-        Perform a full recommendation run consisting of `self.n_iterations` rounds of
-        (selection -> expansion -> simulation -> backpropagation)
-
-        Parameters
-        ----------
-        verbose : bool
-            Whether to print progress information.
-
-        Returns
-        -------
-        dict
-            Dictionary containing the final candidate sequence (`candidate`) and its
-            score (`score`).
-        """
-        self._reset()
-
-        # continue until we reach the target sequence length (i.e, depth * 2)
-        round_count = 0
-        while len(self.base) < self.depth * 2:
-            if verbose:
-                print(f"\n ----- Round: {round_count + 1} -----")
-
-            for _ in range(self.n_iterations):
-                # selection
-                node = self._selection(node=self.root)
-
-                # expansion
-                if not node.is_terminal:
-                    node = self._expansion(node=node)
-
-                # simulation
-                score = self._simulation(node=node)
-
-                # backpropagation
-                node.backpropagate(score)
-
-            self.base = self._find_best_subsequence()
-
-            if verbose:
-                print("#" * 50)
-                print(f"Best subsequence: {self.base}")
-                print(f"Depth: {len(self.base) // 2}")
-                print("#" * 50)
-
-            # reset for next iteration
-            self.root = TreeNode(
-                n_states=len(self.states),
-                depth=len(self.base) // 2,  # adjust depth based on current base
-            )
-
-            round_count += 1
-
-        self.candidate = self.base
-        return {
-            "candidate": self.experiment.reconstruct(self.candidate)[0],
-            "sequence": self.candidate,
-            "score": self.experiment.evaluate(self.candidate),
-        }
-
-
-class TreeNode:
-    """Node of the MCTS tree.
-
-    Adapted from:
-    - https://github.com/PNUMLB/AptaTrans/blob/master/mcts.py
-
-    Parameters
-    ----------
-    val : str, optional
-        Value for this node.
-    parent : TreeNode, optional
-        Reference to the parent node.
-    depth : int, optional
-        Depth of the node in the tree.
-    states : int, optional
-        Number of possible children states.
-    is_root : bool, optional
-        Whether this node is the root of the tree.
-    is_terminal : bool, optional
-        Whether this node is the last one in the path.
-    exploitation_score : float, optional
-        Accumulated exploitation score from simulations.
-
-    Attributes
-    ----------
-    visits : int
-        Counter tracking the umber of visits to this node.
-    children : dict[str, TreeNode]
-        Dictionary of child nodes indexed by value.
-
-    Examples
-    --------
-    >>> from pyaptamer.mcts.algorithm import TreeNode
-    >>> node = TreeNode(val="A")
-    >>> child = node.create_child(val="C", is_terminal=True)
-    >>> child.backpropagate(score=0.5)
-    >>> print(node.uct_score())
-    inf
-    >>> print(child.uct_score())
-    np.float64(0.6663)
-    """
-
-    def __init__(
-        self,
-        val: str = "",
-        parent=None,
-        depth: int = 0,
-        n_states: int = 8,
-        is_root: bool = True,
-        is_terminal: bool = False,
-        exploitation_score: float = 0.0,
-    ) -> None:
-        """
-        Parameters
-        ----------
-        val : str, optional
-            Value for this node.
-        parent : TreeNode, optional
-            Reference to the parent node.
-        depth : int, optional
-            Depth of the node in the tree.
-        n_states : int, optional
-            Number of possible children states.
-        is_root : bool, optional
-            Whether this node is the root of the tree.
-        is_terminal : bool, optional
-            Whether this node is the last one in the path.
-        exploitation_score : float, optional
-            Accumulated exploitation score from simulations.
-        """
-        self.val = val
-        self.parent = parent
-        self.depth = depth
-        self.n_states = n_states
-        self.is_root = is_root
-        self.is_terminal = is_terminal
-        self.exploitation_score = exploitation_score
-
-        self.n_visits = 1
-        self.children = {}
-
-    def is_fully_expanded(self) -> bool:
-        """
-        Check if all possible children of this node have been created (i.e., whether
-        the node is fully-expanded).
-
-        Returns
-        -------
-        bool
-            True if the node is fully-expanded, False otherwise.
-        """
-        return len(self.children) == self.n_states
-
-    def uct_score(self) -> float:
-        """Compute upper confidence bound applied to trees (UCT) score.
-
-        UCT balances the trade-off between exploration (visting new paths) and
-        exploitation (visting known paths).
-        See:
-        - https://en.wikipedia.org/wiki/Monte_Carlo_tree_search
-
-        Returns
-        -------
-        float
-            The UCT score for this node.
-        """
-        if self.parent is None:
-            return float("inf")
-
-        # exploration term
-        exploration = np.sqrt(np.log(self.parent.n_visits) / (2 * self.n_visits))
-        # exploitation term
-        exploitation = self.exploitation_score / self.n_visits
-
-        return exploitation + exploration
-
-    def get_child(self, val: str):
-        """Retrieve the child node of the current node by value.
-
-        Parameters
-        ----------
-        val : str, optional
-            Value used to find the child node.
-
-        Returns
-        -------
-        TreeNode
-            The child node corresponding to the given value, if it exists.
-
-        Raises
-        ------
-        KeyError
-            If the child with the given value does not exist.
-        """
-        if val in self.children:
-            return self.children[val]
-        else:
-            raise KeyError(f"Child with value {val} does not exist for this node")
-
-    def get_best_child(self):
-        """Select the best child based on UCT scores.
-
-        If multiple children have the same UCT score, one of them is randomly selected.
-
-        Returns
-        -------
-        TreeNode
-            The child node with the highest UCT score.
-        """
-        best_children = []
-        best_uct_score = float("-inf")
-        for _, child in self.children.items():
-            uct_score = child.uct_score()
-            if uct_score > best_uct_score:
-                best_uct_score = uct_score
-                best_children = [child]
-            elif uct_score == best_uct_score:
-                best_children.append(child)
-
-        # break ties randomly
-        return random.choice(best_children)
-
-    def create_child(self, val: str, is_terminal: bool = False):
-        """
-        Create a new child node with the given value. If the child already
-        exists, it will return it.
-
-        Parameters
-        ----------
-        val : str
-            Value to assign to the newly created node.
-        is_terminal : bool, optional
-            Whether this child node is the last one in the path.
-
-        Returns
-        -------
-        TreeNode
-            The newly created (or existing) child node.
-        """
-        if val in self.children:
-            return self.children[val]
-
-        node = TreeNode(
+    def test_init(self, root, val):
+        """Check correct initialization."""
+        # check node initialization (passing parameters)
+        node2 = TreeNode(
             val=val,
-            parent=self,
-            depth=self.depth + 1,
-            n_states=self.n_states,
+            parent=root,
+            depth=1,
             is_root=False,
-            is_terminal=is_terminal,
+            is_terminal=True,
+            exploitation_score=0.1,
         )
-        self.children[val] = node
-        return node
+        assert node2.val == val
+        assert node2.parent == root
+        assert node2.depth == 1
+        assert node2.n_states == 8
+        assert node2.is_root is False
+        assert node2.is_terminal is True
+        assert node2.exploitation_score == 0.1
+        assert node2.n_visits == 1
+        assert len(node2.children) == 0
 
-    def backpropagate(self, score: float) -> None:
-        """Backpropagate the score up the tree to all ancestors of the current node.
+    def test_is_fully_expanded(self, root):
+        """Check that (not) fully-expended nodes are properly tracked."""
+        assert not root.is_fully_expanded()
 
-        The visit count and exploitation score is updated as we traverse up the tree.
+        # add all possible children
+        for val in NUCLEOTIDES:
+            root.create_child(val=val)
+        assert root.is_fully_expanded()
 
-        Parameters
-        ----------
-        score : float
-            Score to backpropagate.
+    def test_uct_score(self, root, val):
+        """Test UCT score calculation."""
+        child = root.create_child(val=val, is_terminal=True)
+
+        # check whether the correct value is returned
+        child.backpropagate(score=0.5)
+        new_uct_score = child.uct_score()
+        assert new_uct_score == pytest.approx(0.6663, rel=1e-4)
+
+    def test_uct_score_parent_none(self, root):
+        """Test UCT score calculation when parent is None, should return inf."""
+        uct = root.uct_score()
+        assert uct == float("inf")
+
+    def test_get_child(self, root, val):
+        """Check whether a child node is properly retrieved."""
+        child = root.create_child(val=val, is_terminal=True)
+        assert child == root.get_child(val)
+
+    def test_get_child_fail(self, root, val_not_found):
         """
-        curr = self
-        while curr is not None:
-            curr.n_visits += 1
-            if not curr.is_root:
-                curr.exploitation_score += score
-            curr = curr.parent
+        Check whether a KeyError exception is raised when trying to retrieve a child
+        that does not exist.
+        """
+        with pytest.raises(KeyError) as exc_info:
+            root.get_child(val_not_found)
+
+        assert val_not_found in str(exc_info.value)
+
+    def test_get_best_child(self, root):
+        """Check retrieving best child based on UCT."""
+        child1 = root.create_child(val="A_", is_terminal=True)
+        child2 = root.create_child(val="C_", is_terminal=True)
+
+        child1.backpropagate(20.0)
+        child2.backpropagate(5.0)
+
+        # best child should be the one with higher score
+        best_child = max([child1, child2], key=lambda root: root.uct_score())
+        assert root.get_best_child() == best_child
+
+    def test_get_best_child_ties(self, root):
+        """Check retrieving best child based on UCT in presence of ties."""
+        child1 = root.create_child(val="A_", is_terminal=True)
+        child2 = root.create_child(val="C_", is_terminal=True)
+        child3 = root.create_child(val="_C", is_terminal=True)
+
+        # give the same score to two children
+        child1.backpropagate(20.0)
+        child2.backpropagate(5.0)
+        child3.backpropagate(20.0)
+
+        # best child should be randomly selected among those with highest score
+        assert root.get_best_child() in [child1, child3]
+
+    @pytest.mark.parametrize("val", NUCLEOTIDES)
+    def test_create_child_all_nucleotides(self, root, val):
+        """Test child creation works for all nucleotide types."""
+        child = root.create_child(val=val)
+        assert child.val == val
+        assert child.parent == root
+
+    def test_create_child(self, root, val):
+        """Check successful child creation."""
+        child = root.create_child(val=val, is_terminal=True)
+        assert child is not None
+        assert child.val == val
+        assert child.parent == root
+        assert val in root.children
+        assert root.children[val] == child
+
+    def test_create_child_already_exists(self, root, val):
+        """Check that attempting to create a child that already exists returns it."""
+        child1 = root.create_child(val=val, is_terminal=True)
+        child2 = root.create_child(val=val, is_terminal=True)
+        # should be the same object
+        assert child1 == child2
+
+    def test_backpropagate(self, root):
+        """Check (exploitation) score backpropagation."""
+        child1 = root.create_child(val="A_")
+        child2 = child1.create_child(val="_C", is_terminal=True)
+
+        # backpropagate from leaf
+        child2.backpropagate(score=10.0)
+
+        # check that visits are updated
+        assert root.n_visits == 2
+        assert child1.n_visits == 2
+        assert child2.n_visits == 2
+        # check that (exploitation) scores are updated
+        assert root.exploitation_score == 0.0
+        assert child1.exploitation_score == 10.0
+        assert child2.exploitation_score == 10.0
+
+
+class MockModel:
+    def __init__(self):
+        self.apta_embedding = type("obj", (object,), {"max_len": 128})
+        self.prot_embedding = type("obj", (object,), {"max_len": 128})
+
+    def eval(self):
+        pass
+
+    def __call__(self, *args, **kwargs):
+        return torch.tensor([0.5])
+
+
+class MockPipeline:
+    def predict_proba(self, X):
+        return np.array([[0.5, 0.5]])
+
+
+class MockExperimentAptaTrans(AptamerEvalAptaTrans):
+    def __init__(
+        self,
+        target,
+        model,
+        device,
+        prot_words,
+        fixed_score=0.5,
+    ):
+        super().__init__(target, model, device, prot_words)
+        self.fixed_score = fixed_score
+
+    def evaluate(self, aptamer_candidate):
+        # return a fixed score for deterministic testing
+        return torch.tensor([self.fixed_score])
+
+
+class MockExperimentAptaNet(AptamerEvalAptaNet):
+    def __init__(
+        self,
+        target,
+        pipeline,
+        fixed_score=0.5,
+    ):
+        super().__init__(target, pipeline)
+        self.fixed_score = fixed_score
+
+    def evaluate(self, aptamer_candidate):
+        # return a fixed score for deterministic testing
+        return np.float64(self.fixed_score)
+
+
+@pytest.fixture(params=["aptatrans", "aptanet"])
+def mcts(request):
+    if request.param == "aptatrans":
+        mock_model = MockModel()
+        device = torch.device("cpu")
+        prot_words = {"AAA": 0.5, "AAC": 0.3, "AAG": 0.2}
+
+        experiment = MockExperimentAptaTrans(
+            target="ACGU", model=mock_model, device=device, prot_words=prot_words
+        )
+    else:  # aptanet
+        mock_pipeline = MockPipeline()
+        experiment = MockExperimentAptaNet(target="ACGU", pipeline=mock_pipeline)
+
+    mcts = MCTS(
+        experiment=experiment,
+        states=NUCLEOTIDES,
+        depth=5,
+        n_iterations=10,
+    )
+    return mcts
+
+
+class TestMCTS:
+    """Tests for the MCTS() class."""
+
+    def test_reset(self, mcts):
+        """Check correct reset of the inner state."""
+        # modify its inner state
+        mcts.base = "ACGU"
+        mcts.candidate = "AUGCC"
+        mcts.root.create_child(val="A_")
+
+        # check that reset works
+        mcts._reset()
+        assert mcts.base == ""
+        assert mcts.candidate == ""
+        assert len(mcts.root.children) == 0
+
+    def test_selection_not_fully_expanded(self, mcts):
+        """Check selection step when the node is not fully expanded."""
+        # from root with no childrem, should return the root itself
+        selected = mcts._selection(node=mcts.root)
+        assert selected == mcts.root
+
+        child1 = mcts.root.create_child(val="A_", is_terminal=True)
+
+        # should expand `child1` since it's not fully expanded
+        selected = mcts._selection(node=child1)
+        assert selected == child1
+
+    def test_selection_fully_expanded(self, mcts):
+        """Check selection step when the node is fully expanded."""
+        for val in NUCLEOTIDES:
+            child = mcts.root.create_child(val=val)
+            child.backpropagate(np.random.rand())
+
+        expected = max(
+            [mcts.root.children[val] for val in NUCLEOTIDES],
+            key=lambda node: node.uct_score(),
+        )
+        selected = mcts._selection(node=mcts.root)
+        assert expected == selected
+
+    def test_expansion(self, mcts):
+        """Check expansion step."""
+        # Test expansion creates a new child
+        expanded = mcts._expansion(node=mcts.root)
+
+        assert expanded is not None
+        assert expanded.parent == mcts.root
+        assert expanded.val in NUCLEOTIDES
+
+    def test_simulation(self, mcts):
+        """Check simulation step runs without errors."""
+        node = mcts.root.create_child(val="A_")
+        _ = mcts._simulation(node=node)
+        assert True
+
+    def test_find_best_subsequence(self, mcts):
+        """Check whether the best subsequence is returned based on UCT scores."""
+        node = mcts.root.create_child(val="A_")
+        # create two paths
+        child1 = node.create_child(val="C_", is_terminal=True)
+        child11 = child1.create_child(val="G_", is_terminal=True)
+        child2 = node.create_child(val="U_", is_terminal=True)
+        child21 = child2.create_child(val="C_", is_terminal=True)
+
+        # backpropagate scores
+        child11.backpropagate(20.0)
+        child21.backpropagate(5.0)
+
+        # highest score path should be 'A_C_G_'
+        best = mcts._find_best_subsequence()
+        assert best == "A_C_G_"
+
+    def test_run_verbose(self, mcts):
+        """Check that a run (with verbose enabled) completes without errors."""
+        candidate = mcts.run(verbose=True)
+        assert isinstance(candidate, dict)
+        assert "candidate" in candidate
+        assert "sequence" in candidate
+        assert "score" in candidate
+        assert len(candidate["candidate"]) == 5
+        # length of sequence should be 2 * 5 (i.e., 2 * 5) as it still contains
+        # the underscores
+        assert len(candidate["sequence"]) == 10


### PR DESCRIPTION
This PR resolves #161. It is stacked on #121 and should be merged after it.

Now `MCTS` correctly returns the reconstructed aptamer sequence in method `run(...)`, independently of the experiment being used. Before, it was working for the experiment with AptaTrans (since it returned a tuple,  `reconstruct(...)[0]` worked as intended). However, it was not working for the experiment with AptaNet (since it returned just one element, taking `reconstruct(...)[0]` resulted in the first letter of the reconstructed sequence).

I have also added and/or modified tests in the experiments and MCTS accordingly. In particular, I had to rewrite the tests for MCTS which I had overwritten in a previous PR by mistake. That's why this bug was not picked up.


Not taking into account tests and ignoring changes due to stacking on #121, the main changes are:
1. In `pyaptamer.experiments._aptamer.py`.
2. In `pyaptamer.mcts._algorithm.py`;

In (1.) I modified the `reconstruct(...)` method of `AptametEvalAptaTrans` so that it behaves like the other classes, returning only the recosntructed sequence. Then, since AptaTrans also needs the numerical representation of such sequence, I simply added a private method that does exactly this, `_get_numerical_repr(...)`. In (2.), I modified the return statement in method `run(...)` to take into account the changes from (1.).