### PR TITLE
[ENH] Move reconstruction from experiments to MCTS and fix MCTS' tests

### DIFF
--- a/pyaptamer/experiments/_aptamer.py
+++ b/pyaptamer/experiments/_aptamer.py
@@ -6,7 +6,6 @@ from abc import ABC, abstractmethod
 import numpy as np
 import torch
 from skbase.base import BaseObject
-from torch import Tensor
 
 from pyaptamer.utils import encode_rna, rna2vec
 
@@ -33,57 +32,6 @@ class BaseAptamerEval(BaseObject, ABC):
         """Return the inputs of the experiment."""
         return ["aptamer_candidate"]
 
-    def reconstruct(self, sequence: str = "") -> str:
-        """Reconstruct the aptamer sequence.
-
-        The experiment expects aptamer candidates in a specific (encoded) format
-        involving pairs of nucleotide letters and direction markers (underscores). For
-        instance, 'A_' indicates adding 'A' to the left of the current sequence
-        (prepending), while '_A' indicates adding 'A' to the right (appending). As an
-        example, the input 'A_C__GU_' would be reconstructed to 'UCAG'.
-
-        Parameters
-        ----------
-        sequence : str
-            Encoded sequence with direction markers (underscores).
-
-        Returns
-        -------
-        str
-            The reconstructed RNA sequence.
-
-        Examples
-        --------
-        >>> from pyaptamer.experiments import BaseAptamerEval
-        >>> experiment = BaseAptamerEval(target="DHRNE")
-        >>> reconstructed_seq = experiment.reconstruct("A_C__GU_")
-        >>> print(reconstructed_seq)
-        UCAG
-        """
-        # already reconstructed
-        if "_" not in sequence:
-            return sequence
-
-        # if the sequence is not reconstructed yet, it should have an even length
-        # because it should consist of pairs such as 'A_' and '_A' (i.e., nucleotide +
-        # direction marker).
-        assert len(sequence) % 2 == 0, (
-            f"Encoded sequence must have even length, got {len(sequence)}."
-        )
-
-        # reconstruct
-        result = ""
-        for i in range(0, len(sequence), 2):
-            match sequence[i]:
-                case "_":
-                    # append the next values
-                    result = result + sequence[i + 1]
-                case _:
-                    # prepend the current value
-                    result = sequence[i] + result
-
-        return result
-
     @abstractmethod
     def evaluate(self, aptamer_candidate: str, **kwargs) -> np.float64:
         """Evaluate the given aptamer candidate against the target protein.
@@ -91,7 +39,8 @@ class BaseAptamerEval(BaseObject, ABC):
         Parameters
         ----------
         aptamer_candidate : str
-            The aptamer candidate to evaluate.
+            The aptamer candidate to evaluate. It should be a string consisting of
+            letters representing nucleotides: 'A', 'C', 'G', and 'U'.
         **kwargs
             Additional keyword arguments specific to the implementation.
 
@@ -160,43 +109,6 @@ class AptamerEvalAptaTrans(BaseAptamerEval):
             max_len=model.prot_embedding.max_len,
         ).to(device)
 
-    def reconstruct(self, sequence: str = "") -> tuple[str, Tensor]:
-        """
-        Reconstruct the aptamer sequence and convert it to a numerical representation.
-
-        The experiment expects aptamer candidates in a specific (encoded) format
-        involving pairs of nucleotide letters and direction markers (underscores). For
-        instance, 'A_' indicates adding 'A' to the left of the current sequence
-        (prepending), while '_A' indicates adding 'A' to the right (appending). As an
-        example, the input 'A_C__GU_' would be reconstructed to 'UCAG'. Then, the
-        reconstructed sequence is converted to a numerical representation using the
-        `rna2vec` function.
-
-        Parameters
-        ----------
-        sequence : str
-            Encoded sequence with direction markers (underscores).
-
-        Returns
-        -------
-        tuple[str, Tensor]
-            A tuple containing the reconstructed RNA sequence and its numerical
-            representation, respectively.
-        """
-        # get the base reconstructed sequence
-        reconstructed_seq = super().reconstruct(sequence)
-
-        return (
-            reconstructed_seq,
-            torch.tensor(
-                rna2vec(
-                    [reconstructed_seq],
-                    max_sequence_length=self.model.apta_embedding.max_len,
-                ),
-                dtype=torch.int64,
-            ),
-        )
-
     @torch.no_grad()
     def evaluate(
         self, aptamer_candidate: str, return_interaction_map: bool = False
@@ -211,9 +123,7 @@ class AptamerEvalAptaTrans(BaseAptamerEval):
         ----------
         aptamer_candidate : str
             The aptamer candidate to evaluate. It should be a string consisting of
-            letters representing nucleotides: 'A_', '_A', 'C_', '_C', 'G_', '_G', 'U_',
-            '_U'. Underscores indicate whether the nucleotides are supposed to be (e.
-            g., 'A_') prepended or appended (e.g., '_A)'to the sequence.
+            letters representing nucleotides: 'A', 'C', 'G', and 'U'.
         return_interaction_map : bool, optional, default=False
             Whether to return the interaction map or not.
 
@@ -224,8 +134,16 @@ class AptamerEvalAptaTrans(BaseAptamerEval):
             `False`. If `return_interaction_map` is `True`, the interaction map, of
             shape (batch_size, 1, seq_len_aptamer, seq_len_protein).
         """
-        aptamer_candidate = self.reconstruct(aptamer_candidate)[1]
         self.model.eval()
+
+        # convert the aptamer candidate to its numerical representation
+        aptamer_candidate = torch.tensor(
+            rna2vec(
+                [aptamer_candidate],
+                max_sequence_length=self.model.apta_embedding.max_len,
+            ),
+            dtype=torch.int64,
+        )
 
         if return_interaction_map:
             return (
@@ -271,7 +189,7 @@ class AptamerEvalAptaNet(BaseAptamerEval):
     >>> pipeline.fit(pairs, labels)
     >>> target = "ACDEFACDEFACDEFACDEFACDEFACDEFACDEFACDEF"
     >>> experiment = AptamerEvalAptaNet(target, pipeline)
-    >>> aptamer_candidate = "A_U_G_G_C_"
+    >>> aptamer_candidate = "AUGGC"
     >>> score = experiment.evaluate(aptamer_candidate)
     """
 
@@ -286,16 +204,13 @@ class AptamerEvalAptaNet(BaseAptamerEval):
         ----------
         aptamer_candidate : str
             The aptamer candidate to evaluate. It should be a string consisting of
-            letters representing nucleotides: 'A_', '_A', 'C_', '_C', 'G_', '_G', 'U_',
-            '_U'. Underscores indicate whether the nucleotides are supposed to be (e.
-            g., 'A_') prepended or appended (e.g., '_A') to the sequence.
+            letters representing nucleotides: 'A', 'C', 'G', and 'U'.
 
         Returns
         -------
         np.float64
             The probability score assigned to the aptamer candidate.
         """
-        aptamer_seq = self.reconstruct(aptamer_candidate)
-        score = self.pipeline.predict_proba(X=[(aptamer_seq, self.target)])
+        score = self.pipeline.predict_proba(X=[(aptamer_candidate, self.target)])
 
         return np.float64(score[:, 1].item())  # return the positive class probability

--- a/pyaptamer/experiments/_aptamer.py
+++ b/pyaptamer/experiments/_aptamer.py
@@ -40,7 +40,8 @@ class BaseAptamerEval(BaseObject, ABC):
         ----------
         aptamer_candidate : str
             The aptamer candidate to evaluate. It should be a string consisting of
-            letters representing nucleotides: 'A', 'C', 'G', and 'U'.
+            letters representing nucleotides: 'A', 'C', 'G', and 'U' (for RNA) or 'T'
+            (for DNA).
         **kwargs
             Additional keyword arguments specific to the implementation.
 
@@ -123,7 +124,8 @@ class AptamerEvalAptaTrans(BaseAptamerEval):
         ----------
         aptamer_candidate : str
             The aptamer candidate to evaluate. It should be a string consisting of
-            letters representing nucleotides: 'A', 'C', 'G', and 'U'.
+            letters representing nucleotides: 'A', 'C', 'G', and 'U' (for RNA) or 'T'
+            (for DNA).
         return_interaction_map : bool, optional, default=False
             Whether to return the interaction map or not.
 
@@ -204,7 +206,8 @@ class AptamerEvalAptaNet(BaseAptamerEval):
         ----------
         aptamer_candidate : str
             The aptamer candidate to evaluate. It should be a string consisting of
-            letters representing nucleotides: 'A', 'C', 'G', and 'U'.
+            letters representing nucleotides: 'A', 'C', 'G', and 'U' (for RNA) or 'T'
+            (for DNA).
 
         Returns
         -------

--- a/pyaptamer/experiments/tests/test_aptamer.py
+++ b/pyaptamer/experiments/tests/test_aptamer.py
@@ -133,38 +133,9 @@ class TestAptamerEvalConcrete:
     @pytest.mark.parametrize("experiment", ["aptatrans", "aptanet"], indirect=True)
     def test_evaluate_with_underscores(self, experiment):
         """Check evaluation with sequences containing underscores."""
-        aptamer_candidate = "A_C_G_U_"
+        aptamer_candidate = "ACGU"
         score = experiment.evaluate(aptamer_candidate)
         assert isinstance(score, numpy.float64)
-
-    @pytest.mark.parametrize("experiment", ["aptatrans", "aptanet"], indirect=True)
-    def test_evaluate_already_reconstructed(self, experiment):
-        """Check evaluation with already reconstructed sequence."""
-        aptamer_candidate = "ACGU"  # no underscores
-        score = experiment.evaluate(aptamer_candidate)
-        assert isinstance(score, numpy.float64)
-
-    def test_reconstruct_aptanet(self, aptanet_experiment):
-        """Check sequence reconstruction in AptamerEvalAptaNet."""
-        result = aptanet_experiment.reconstruct("")
-        assert result == ""
-
-        result = aptanet_experiment.reconstruct("A_C_G_U_")
-        assert result == "UGCA"
-
-    def test_reconstruct_aptatrans(self, aptatrans_experiment):
-        """Check sequence reconstruction in AptamerEvalAptaTrans."""
-        result_str, result_vector = aptatrans_experiment.reconstruct("")
-        assert result_str == ""
-        assert torch.equal(result_vector, torch.tensor([]))
-
-        result_str, result_vector = aptatrans_experiment.reconstruct("A_C__G_U")
-        assert result_str == "CAGU"
-        # 100 is the maximum length specified in our mock model
-        assert result_vector.shape == (1, 100)
-        assert result_vector[0, 0] != 0  # first triplet should not be 0
-        assert result_vector[0, 1] != 0  # second triplet should not be 0
-        assert torch.all(result_vector[0, 2:] == 0)  # rest should be padding
 
     def test_evaluate_imap(self, aptatrans_experiment):
         """

--- a/pyaptamer/mcts/_algorithm.py
+++ b/pyaptamer/mcts/_algorithm.py
@@ -128,7 +128,7 @@ class MCTS(BaseObject):
         Returns
         -------
         str
-            The reconstructed RNA sequence.
+            The reconstructed sequence.
         """
         # already reconstructed
         if "_" not in sequence:

--- a/pyaptamer/mcts/_algorithm.py
+++ b/pyaptamer/mcts/_algorithm.py
@@ -111,6 +111,49 @@ class MCTS(BaseObject):
         self.base = ""
         self.candidate = ""
 
+    def _reconstruct(self, sequence: str) -> str:
+        """Reconstruct the aptamer sequence.
+
+        The algorithms produces expects aptamer candidates in a specific format
+        involving pairs of nucleotide letters and direction markers (underscores). For
+        instance, 'A_' indicates adding 'A' to the left of the current sequence
+        (prepending), while '_A' indicates adding 'A' to the right (appending). As an
+        example, the input 'A_C__GU_' would be reconstructed to 'UCAG'.
+
+        Parameters
+        ----------
+        sequence : str
+            Encoded sequence with direction markers (underscores).
+
+        Returns
+        -------
+        str
+            The reconstructed RNA sequence.
+        """
+        # already reconstructed
+        if "_" not in sequence:
+            return sequence
+
+        # if the sequence is not reconstructed yet, it should have an even length
+        # because it should consist of pairs such as 'A_' and '_A' (i.e., nucleotide +
+        # direction marker).
+        assert len(sequence) % 2 == 0, (
+            f"Encoded sequence must have even length, got {len(sequence)}."
+        )
+
+        # reconstruct
+        result = ""
+        for i in range(0, len(sequence), 2):
+            match sequence[i]:
+                case "_":
+                    # append the next values
+                    result = result + sequence[i + 1]
+                case _:
+                    # prepend the current value
+                    result = sequence[i] + result
+
+        return result
+
     def _selection(self, node: "TreeNode") -> "TreeNode":
         """Select a node for expansion.
 
@@ -278,10 +321,11 @@ class MCTS(BaseObject):
             round_count += 1
 
         self.candidate = self.base
+        reconstructed_candidate = self._reconstruct(self.candidate)
         return {
-            "candidate": self.experiment.reconstruct(self.candidate)[0],
+            "candidate": reconstructed_candidate,
             "sequence": self.candidate,
-            "score": self.experiment.evaluate(self.candidate),
+            "score": self.experiment.evaluate(reconstructed_candidate),
         }
 
 

--- a/pyaptamer/mcts/tests/test_mcts.py
+++ b/pyaptamer/mcts/tests/test_mcts.py
@@ -1,499 +1,339 @@
-"""Monte Carlo Tree Search (MCTS) for string optimization."""
+"""Test suite for the Monte Carlo Tree Search (MCTS) algorithm"""
 
 __author__ = ["nennomp"]
-__all__ = ["MCTS"]
 
-import random
 
 import numpy as np
-from skbase.base import BaseObject
+import pytest
+import torch
 
+from pyaptamer.experiments import AptamerEvalAptaNet, AptamerEvalAptaTrans
+from pyaptamer.mcts import MCTS
+from pyaptamer.mcts._algorithm import TreeNode
 
-class MCTS(BaseObject):
-    """
-    MCTS algorithm implementation for string optimization, specifically for aptamr
-    generation as described in aptamer generation as described in [1]_, originally
-    introduced in [2]_.
+NUCLEOTIDES = ["A_", "_A", "C_", "_C", "G_", "_G", "U_", "_U"]
 
-    Adapted from:
 
-    - https://github.com/PNUMLB/AptaTrans/blob/master/mcts.py
-    - https://github.com/leekh7411/Apta-MCTS/blob/master/src/mcts.py
+@pytest.fixture
+def root():
+    return TreeNode()
 
-    Parameters
-    ----------
-    states : list[str]
-        Possible values for the nodes. Underscores indicate whether the values are
-        supposed to be prepended or appended to the sequence.
-    depth : int, optional
-        Maximum depth of the search tree, also the length of the generated sequences.
-    n_iterations : int, optional
-        Number of iterations per round for the MCTS algorithm.
-    experiment : BaseExperiment, optional, default=None
-        An instance of an experiment class definingthe goal function for the algorithm.
 
-    Attributes
-    ----------
-    base : str
-        Best sequence found so far.
-    candidate : str
-        Final candidate sequence.
-    root : TreeNode
-        Root node of the MCTS tree.
+@pytest.fixture
+def val():
+    return "A_"
 
-    References
-    ----------
-    .. [1] Shin, Incheol, et al. "AptaTrans: a deep neural network for predicting
-    aptamer-protein interaction using pretrained encoders." BMC bioinformatics 24.1
-    (2023): 447.
-    .. [2] Lee, Gwangho, et al. "Predicting aptamer sequences that interact with target
-    proteins using an aptamer-protein interaction classifier and a Monte Carlo tree
-    search approach." PloS one 16.6 (2021): e0253760.
 
-    Examples
-    --------
-    >>> import torch
-    >>> from pyaptamer.experiments import Aptamer
-    >>> from pyaptamer.mcts import MCTS
-    >>> device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    >>> target = "MCKY"
-    >>> target_encoded = torch.tensor([1, 0, 0, 1, 0, 1], dtype=torch.float32).to
-    ... (device)
-    >>> experiment = Aptamer(target_encoded, target, model, device)
-    >>> mcts = MCTS(depth=10, experiment=experiment)
-    >>> candidate = mcts.run()
-    >>> print((candidate["candidate"], len(candidate["candidate"])))
-    ('CUUUAUGUCA', 10)
-    >>> print((candidate["sequence"], len(candidate["sequence"])))
-    ('_GU_A__U_CU__AU_U_C_', 20)
-    >>> print(candidate["score"])
-    tensor([0.5000])
-    """
+@pytest.fixture
+def val_not_found():
+    return "X_"
 
-    def __init__(
-        self,
-        states: list[str] | None = None,
-        depth: int = 20,
-        n_iterations: int = 1000,
-        experiment=None,
-    ) -> None:
-        """
-        Parameters
-        ----------
-        experiment : Aptamer
-            An instance of the Aptamer() class specifying the goal function.
-        states : list[str], optional
-            A list containing possible values for the nodes. Underscores indicate
-            whether the values are supposed to be prepended or appended to the sequence.
-        depth : int, optional
-            Maximum depth of the search tree.
-        n_iterations : int, optional
-            Number of iterations per round for the MCTS algorithm.
-        """
-        self.experiment = experiment
-        self.depth = depth
-        self.n_iterations = n_iterations
 
-        super().__init__()
+@pytest.fixture
+def tree_with_children(tree_node):
+    """Provide a TreeNode with some children already added."""
+    for val in ["A_", "C_", "G_"]:
+        tree_node.create_child(val=val)
+    return tree_node
 
-        if states is None:
-            states = ["A_", "C_", "G_", "U_", "_A", "_C", "_G", "_U"]
-        self.states = states
 
-        self.root = TreeNode(
-            n_states=len(states),
-        )
-        self.base = ""
-        self.candidate = ""
+class TestTreeNode:
+    """Tests for the TreeNode() class."""
 
-    def _reset(self) -> None:
-        """Reset the MCTS algorithm to its initial state."""
-        self.root = TreeNode(
-            n_states=len(self.states),
-        )
-        self.base = ""
-        self.candidate = ""
-
-    def _selection(self, node: "TreeNode") -> "TreeNode":
-        """Select a node for expansion.
-
-        The tree is traversed recursively based on the more promising nodes according
-        to their UCT scores. When a node is fully expanded, the best child is selected
-        and the search continues down that path. The expansion stops when a node that
-        has not been fully expanded is found, or when a terminal node is reached.
-
-        Parameters
-        ----------
-        node : TreeNode
-            Starting node for selection.
-
-        Returns
-        -------
-        TreeNode
-            The node selected for expansion.
-        """
-        while not node.is_terminal:
-            if node.is_fully_expanded():  # fully expanded, select best one and continue
-                node = node.get_best_child()
-            else:  # expand
-                return node
-        return node
-
-    def _expansion(self, node: "TreeNode") -> "TreeNode":
-        """Expand the selected node.
-
-        The selected node is expanded by creating a new child to which a randomly
-        selected value is assigned. The value is randomly chosen from the set of
-        unexpanded states (those that have not been added to the node's children yet).
-
-        Parameters
-        ----------
-        node : TreeNode
-            Node to expand from.
-
-        Returns
-        -------
-        TreeNode
-            The newly created child node from the expansion.
-        """
-        is_terminal = node.depth == self.depth - 1
-
-        # find all unexpanded values for this node
-        unexpanded = list(set(self.states) - set(node.children.keys()))
-
-        # randomly selected one value from unexpanded ones
-        val = random.choice(unexpanded)
-
-        return node.create_child(val=val, is_terminal=is_terminal)
-
-    def _simulation(self, node: "TreeNode") -> float:
-        """
-        Simulate a random playout for the node/path and generate a candidate sequence.
-
-        Starting from the given node, a random walk is performed: random values are
-        added to the sequence until the desired length (depth) is reached. The sequence
-        is then evaluated leveraging the goal function defined by `self.experiment`.
-
-        Parameters
-        ----------
-        node : TreeNode
-            Node to start simulation from.
-
-        Returns
-        -------
-        float
-            The score for the simulate sequence, assigned according to the goal
-            function defined by `self.experiment`.
-        """
-        curr = node
-        sequence = ""
-
-        # build the current sequence from node to root
-        while not curr.is_root:
-            sequence = curr.val + sequence
-            curr = curr.parent
-
-        # prepend the `self.base` sequence
-        sequence = self.base + sequence
-
-        # fill the rest of the sequence with random possible values
-        remaining_length = (self.depth * 2) - len(sequence)
-        for _ in range(remaining_length):
-            sequence += random.choice(self.states)
-
-        # evaluate the candidate sequence with the goal function
-        return self.experiment.evaluate(sequence)
-
-    def _find_best_subsequence(self) -> str:
-        """Retrieve the best sequence found so far, according to the UCT scores.
-
-        Returns
-        -------
-        str
-            The best subsequence found in the current tree.
-        """
-        curr = self.root
-        subsequence = self.base
-
-        # traverse the tree
-        max_steps = (self.depth * 2) - len(self.base)
-        for _ in range(max_steps):
-            if not curr.children:
-                break
-
-            curr = curr.get_best_child()
-            subsequence += curr.val
-
-        return subsequence
-
-    def run(self, verbose: bool = True) -> dict:
-        """
-        Perform a full recommendation run consisting of `self.n_iterations` rounds of
-        (selection -> expansion -> simulation -> backpropagation)
-
-        Parameters
-        ----------
-        verbose : bool
-            Whether to print progress information.
-
-        Returns
-        -------
-        dict
-            Dictionary containing the final candidate sequence (`candidate`) and its
-            score (`score`).
-        """
-        self._reset()
-
-        # continue until we reach the target sequence length (i.e, depth * 2)
-        round_count = 0
-        while len(self.base) < self.depth * 2:
-            if verbose:
-                print(f"\n ----- Round: {round_count + 1} -----")
-
-            for _ in range(self.n_iterations):
-                # selection
-                node = self._selection(node=self.root)
-
-                # expansion
-                if not node.is_terminal:
-                    node = self._expansion(node=node)
-
-                # simulation
-                score = self._simulation(node=node)
-
-                # backpropagation
-                node.backpropagate(score)
-
-            self.base = self._find_best_subsequence()
-
-            if verbose:
-                print("#" * 50)
-                print(f"Best subsequence: {self.base}")
-                print(f"Depth: {len(self.base) // 2}")
-                print("#" * 50)
-
-            # reset for next iteration
-            self.root = TreeNode(
-                n_states=len(self.states),
-                depth=len(self.base) // 2,  # adjust depth based on current base
-            )
-
-            round_count += 1
-
-        self.candidate = self.base
-        return {
-            "candidate": self.experiment.reconstruct(self.candidate)[0],
-            "sequence": self.candidate,
-            "score": self.experiment.evaluate(self.candidate),
-        }
-
-
-class TreeNode:
-    """Node of the MCTS tree.
-
-    Adapted from:
-    - https://github.com/PNUMLB/AptaTrans/blob/master/mcts.py
-
-    Parameters
-    ----------
-    val : str, optional
-        Value for this node.
-    parent : TreeNode, optional
-        Reference to the parent node.
-    depth : int, optional
-        Depth of the node in the tree.
-    states : int, optional
-        Number of possible children states.
-    is_root : bool, optional
-        Whether this node is the root of the tree.
-    is_terminal : bool, optional
-        Whether this node is the last one in the path.
-    exploitation_score : float, optional
-        Accumulated exploitation score from simulations.
-
-    Attributes
-    ----------
-    visits : int
-        Counter tracking the umber of visits to this node.
-    children : dict[str, TreeNode]
-        Dictionary of child nodes indexed by value.
-
-    Examples
-    --------
-    >>> from pyaptamer.mcts.algorithm import TreeNode
-    >>> node = TreeNode(val="A")
-    >>> child = node.create_child(val="C", is_terminal=True)
-    >>> child.backpropagate(score=0.5)
-    >>> print(node.uct_score())
-    inf
-    >>> print(child.uct_score())
-    np.float64(0.6663)
-    """
-
-    def __init__(
-        self,
-        val: str = "",
-        parent=None,
-        depth: int = 0,
-        n_states: int = 8,
-        is_root: bool = True,
-        is_terminal: bool = False,
-        exploitation_score: float = 0.0,
-    ) -> None:
-        """
-        Parameters
-        ----------
-        val : str, optional
-            Value for this node.
-        parent : TreeNode, optional
-            Reference to the parent node.
-        depth : int, optional
-            Depth of the node in the tree.
-        n_states : int, optional
-            Number of possible children states.
-        is_root : bool, optional
-            Whether this node is the root of the tree.
-        is_terminal : bool, optional
-            Whether this node is the last one in the path.
-        exploitation_score : float, optional
-            Accumulated exploitation score from simulations.
-        """
-        self.val = val
-        self.parent = parent
-        self.depth = depth
-        self.n_states = n_states
-        self.is_root = is_root
-        self.is_terminal = is_terminal
-        self.exploitation_score = exploitation_score
-
-        self.n_visits = 1
-        self.children = {}
-
-    def is_fully_expanded(self) -> bool:
-        """
-        Check if all possible children of this node have been created (i.e., whether
-        the node is fully-expanded).
-
-        Returns
-        -------
-        bool
-            True if the node is fully-expanded, False otherwise.
-        """
-        return len(self.children) == self.n_states
-
-    def uct_score(self) -> float:
-        """Compute upper confidence bound applied to trees (UCT) score.
-
-        UCT balances the trade-off between exploration (visting new paths) and
-        exploitation (visting known paths).
-        See:
-        - https://en.wikipedia.org/wiki/Monte_Carlo_tree_search
-
-        Returns
-        -------
-        float
-            The UCT score for this node.
-        """
-        if self.parent is None:
-            return float("inf")
-
-        # exploration term
-        exploration = np.sqrt(np.log(self.parent.n_visits) / (2 * self.n_visits))
-        # exploitation term
-        exploitation = self.exploitation_score / self.n_visits
-
-        return exploitation + exploration
-
-    def get_child(self, val: str):
-        """Retrieve the child node of the current node by value.
-
-        Parameters
-        ----------
-        val : str, optional
-            Value used to find the child node.
-
-        Returns
-        -------
-        TreeNode
-            The child node corresponding to the given value, if it exists.
-
-        Raises
-        ------
-        KeyError
-            If the child with the given value does not exist.
-        """
-        if val in self.children:
-            return self.children[val]
-        else:
-            raise KeyError(f"Child with value {val} does not exist for this node")
-
-    def get_best_child(self):
-        """Select the best child based on UCT scores.
-
-        If multiple children have the same UCT score, one of them is randomly selected.
-
-        Returns
-        -------
-        TreeNode
-            The child node with the highest UCT score.
-        """
-        best_children = []
-        best_uct_score = float("-inf")
-        for _, child in self.children.items():
-            uct_score = child.uct_score()
-            if uct_score > best_uct_score:
-                best_uct_score = uct_score
-                best_children = [child]
-            elif uct_score == best_uct_score:
-                best_children.append(child)
-
-        # break ties randomly
-        return random.choice(best_children)
-
-    def create_child(self, val: str, is_terminal: bool = False):
-        """
-        Create a new child node with the given value. If the child already
-        exists, it will return it.
-
-        Parameters
-        ----------
-        val : str
-            Value to assign to the newly created node.
-        is_terminal : bool, optional
-            Whether this child node is the last one in the path.
-
-        Returns
-        -------
-        TreeNode
-            The newly created (or existing) child node.
-        """
-        if val in self.children:
-            return self.children[val]
-
-        node = TreeNode(
+    def test_init(self, root, val):
+        """Check correct initialization."""
+        # check node initialization (passing parameters)
+        node2 = TreeNode(
             val=val,
-            parent=self,
-            depth=self.depth + 1,
-            n_states=self.n_states,
+            parent=root,
+            depth=1,
             is_root=False,
-            is_terminal=is_terminal,
+            is_terminal=True,
+            exploitation_score=0.1,
         )
-        self.children[val] = node
-        return node
+        assert node2.val == val
+        assert node2.parent == root
+        assert node2.depth == 1
+        assert node2.n_states == 8
+        assert node2.is_root is False
+        assert node2.is_terminal is True
+        assert node2.exploitation_score == 0.1
+        assert node2.n_visits == 1
+        assert len(node2.children) == 0
 
-    def backpropagate(self, score: float) -> None:
-        """Backpropagate the score up the tree to all ancestors of the current node.
+    def test_is_fully_expanded(self, root):
+        """Check that (not) fully-expended nodes are properly tracked."""
+        assert not root.is_fully_expanded()
 
-        The visit count and exploitation score is updated as we traverse up the tree.
+        # add all possible children
+        for val in NUCLEOTIDES:
+            root.create_child(val=val)
+        assert root.is_fully_expanded()
 
-        Parameters
-        ----------
-        score : float
-            Score to backpropagate.
+    def test_uct_score(self, root, val):
+        """Test UCT score calculation."""
+        child = root.create_child(val=val, is_terminal=True)
+
+        # check whether the correct value is returned
+        child.backpropagate(score=0.5)
+        new_uct_score = child.uct_score()
+        assert new_uct_score == pytest.approx(0.6663, rel=1e-4)
+
+    def test_uct_score_parent_none(self, root):
+        """Test UCT score calculation when parent is None, should return inf."""
+        uct = root.uct_score()
+        assert uct == float("inf")
+
+    def test_get_child(self, root, val):
+        """Check whether a child node is properly retrieved."""
+        child = root.create_child(val=val, is_terminal=True)
+        assert child == root.get_child(val)
+
+    def test_get_child_fail(self, root, val_not_found):
         """
-        curr = self
-        while curr is not None:
-            curr.n_visits += 1
-            if not curr.is_root:
-                curr.exploitation_score += score
-            curr = curr.parent
+        Check whether a KeyError exception is raised when trying to retrieve a child
+        that does not exist.
+        """
+        with pytest.raises(KeyError) as exc_info:
+            root.get_child(val_not_found)
+
+        assert val_not_found in str(exc_info.value)
+
+    def test_get_best_child(self, root):
+        """Check retrieving best child based on UCT."""
+        child1 = root.create_child(val="A_", is_terminal=True)
+        child2 = root.create_child(val="C_", is_terminal=True)
+
+        child1.backpropagate(20.0)
+        child2.backpropagate(5.0)
+
+        # best child should be the one with higher score
+        best_child = max([child1, child2], key=lambda root: root.uct_score())
+        assert root.get_best_child() == best_child
+
+    def test_get_best_child_ties(self, root):
+        """Check retrieving best child based on UCT in presence of ties."""
+        child1 = root.create_child(val="A_", is_terminal=True)
+        child2 = root.create_child(val="C_", is_terminal=True)
+        child3 = root.create_child(val="_C", is_terminal=True)
+
+        # give the same score to two children
+        child1.backpropagate(20.0)
+        child2.backpropagate(5.0)
+        child3.backpropagate(20.0)
+
+        # best child should be randomly selected among those with highest score
+        assert root.get_best_child() in [child1, child3]
+
+    @pytest.mark.parametrize("val", NUCLEOTIDES)
+    def test_create_child_all_nucleotides(self, root, val):
+        """Test child creation works for all nucleotide types."""
+        child = root.create_child(val=val)
+        assert child.val == val
+        assert child.parent == root
+
+    def test_create_child(self, root, val):
+        """Check successful child creation."""
+        child = root.create_child(val=val, is_terminal=True)
+        assert child is not None
+        assert child.val == val
+        assert child.parent == root
+        assert val in root.children
+        assert root.children[val] == child
+
+    def test_create_child_already_exists(self, root, val):
+        """Check that attempting to create a child that already exists returns it."""
+        child1 = root.create_child(val=val, is_terminal=True)
+        child2 = root.create_child(val=val, is_terminal=True)
+        # should be the same object
+        assert child1 == child2
+
+    def test_backpropagate(self, root):
+        """Check (exploitation) score backpropagation."""
+        child1 = root.create_child(val="A_")
+        child2 = child1.create_child(val="_C", is_terminal=True)
+
+        # backpropagate from leaf
+        child2.backpropagate(score=10.0)
+
+        # check that visits are updated
+        assert root.n_visits == 2
+        assert child1.n_visits == 2
+        assert child2.n_visits == 2
+        # check that (exploitation) scores are updated
+        assert root.exploitation_score == 0.0
+        assert child1.exploitation_score == 10.0
+        assert child2.exploitation_score == 10.0
+
+
+class MockModel:
+    def __init__(self):
+        self.apta_embedding = type("obj", (object,), {"max_len": 128})
+        self.prot_embedding = type("obj", (object,), {"max_len": 128})
+
+    def eval(self):
+        pass
+
+    def __call__(self, *args, **kwargs):
+        return torch.tensor([0.5])
+
+
+class MockPipeline:
+    def predict_proba(self, X):
+        return np.array([[0.5, 0.5]])
+
+
+class MockExperimentAptaTrans(AptamerEvalAptaTrans):
+    def __init__(
+        self,
+        target,
+        model,
+        device,
+        prot_words,
+        fixed_score=0.5,
+    ):
+        super().__init__(target, model, device, prot_words)
+        self.fixed_score = fixed_score
+
+    def evaluate(self, aptamer_candidate):
+        # return a fixed score for deterministic testing
+        return torch.tensor([self.fixed_score])
+
+
+class MockExperimentAptaNet(AptamerEvalAptaNet):
+    def __init__(
+        self,
+        target,
+        pipeline,
+        fixed_score=0.5,
+    ):
+        super().__init__(target, pipeline)
+        self.fixed_score = fixed_score
+
+    def evaluate(self, aptamer_candidate):
+        # return a fixed score for deterministic testing
+        return np.float64(self.fixed_score)
+
+
+@pytest.fixture(params=["aptatrans", "aptanet"])
+def mcts(request):
+    if request.param == "aptatrans":
+        mock_model = MockModel()
+        device = torch.device("cpu")
+        prot_words = {"AAA": 0.5, "AAC": 0.3, "AAG": 0.2}
+
+        experiment = MockExperimentAptaTrans(
+            target="ACGU", model=mock_model, device=device, prot_words=prot_words
+        )
+    else:  # aptanet
+        mock_pipeline = MockPipeline()
+        experiment = MockExperimentAptaNet(target="ACGU", pipeline=mock_pipeline)
+
+    mcts = MCTS(
+        experiment=experiment,
+        states=NUCLEOTIDES,
+        depth=5,
+        n_iterations=10,
+    )
+    return mcts
+
+
+class TestMCTS:
+    """Tests for the MCTS() class."""
+
+    def test_reset(self, mcts):
+        """Check correct reset of the inner state."""
+        # modify its inner state
+        mcts.base = "ACGU"
+        mcts.candidate = "AUGCC"
+        mcts.root.create_child(val="A_")
+
+        # check that reset works
+        mcts._reset()
+        assert mcts.base == ""
+        assert mcts.candidate == ""
+        assert len(mcts.root.children) == 0
+
+    def test_reconstruct(self, mcts):
+        """Check reconstruction of aptamer candidates."""
+
+        # empty sequence
+        assert mcts._reconstruct("") == ""
+
+        # already reconstructed (no underscores)
+        assert mcts._reconstruct("ACGU") == "ACGU"
+
+        # simple prepends
+        assert mcts._reconstruct("A_C_G_U_") == "UGCA"
+
+        # mixed prepend/append
+        assert mcts._reconstruct("A_C__GU_") == "UCAG"
+
+    def test_selection_not_fully_expanded(self, mcts):
+        """Check selection step when the node is not fully expanded."""
+        # from root with no childrem, should return the root itself
+        selected = mcts._selection(node=mcts.root)
+        assert selected == mcts.root
+
+        child1 = mcts.root.create_child(val="A_", is_terminal=True)
+
+        # should expand `child1` since it's not fully expanded
+        selected = mcts._selection(node=child1)
+        assert selected == child1
+
+    def test_selection_fully_expanded(self, mcts):
+        """Check selection step when the node is fully expanded."""
+        for val in NUCLEOTIDES:
+            child = mcts.root.create_child(val=val)
+            child.backpropagate(np.random.rand())
+
+        expected = max(
+            [mcts.root.children[val] for val in NUCLEOTIDES],
+            key=lambda node: node.uct_score(),
+        )
+        selected = mcts._selection(node=mcts.root)
+        assert expected == selected
+
+    def test_expansion(self, mcts):
+        """Check expansion step."""
+        # Test expansion creates a new child
+        expanded = mcts._expansion(node=mcts.root)
+
+        assert expanded is not None
+        assert expanded.parent == mcts.root
+        assert expanded.val in NUCLEOTIDES
+
+    def test_simulation(self, mcts):
+        """Check simulation step runs without errors."""
+        node = mcts.root.create_child(val="A_")
+        _ = mcts._simulation(node=node)
+        assert True
+
+    def test_find_best_subsequence(self, mcts):
+        """Check whether the best subsequence is returned based on UCT scores."""
+        node = mcts.root.create_child(val="A_")
+        # create two paths
+        child1 = node.create_child(val="C_", is_terminal=True)
+        child11 = child1.create_child(val="G_", is_terminal=True)
+        child2 = node.create_child(val="U_", is_terminal=True)
+        child21 = child2.create_child(val="C_", is_terminal=True)
+
+        # backpropagate scores
+        child11.backpropagate(20.0)
+        child21.backpropagate(5.0)
+
+        # highest score path should be 'A_C_G_'
+        best = mcts._find_best_subsequence()
+        assert best == "A_C_G_"
+
+    def test_run_verbose(self, mcts):
+        """Check that a run (with verbose enabled) completes without errors."""
+        candidate = mcts.run(verbose=True)
+        assert isinstance(candidate, dict)
+        assert "candidate" in candidate
+        assert "sequence" in candidate
+        assert "score" in candidate
+        assert len(candidate["candidate"]) == 5
+        # length of sequence should be 2 * 5 (i.e., 2 * 5) as it still contains
+        # the underscores
+        assert len(candidate["sequence"]) == 10


### PR DESCRIPTION
This PR resolves #167 and #161.

Now the reconstruction of aptamer sequences happens inside `MCTS` rather than in the experiments. Docstrings and tests have been updated accordingly for both.

Additionally, a bug related to the tests of MCTS has been fixed. By mistakes, the tests in `pyaptamer.mcts.tests.test_mcts.py` were overwritten in a previous PR and thus were not testing the algorithm.

Changes to look at (excluding tests) are:
* In `pyaptamer.experiments._aptamer.py` (removed the reconstruct method, updated docstrings accordingly);
* In `pyaptamer.mcts._algorithm.py` (added the reconstruct method, updated docstrings accordingly).