### PR TITLE
[BUG] AptaTrans bug fixes: shapes mismatch in pretraining, add masking in encoders

### DIFF
--- a/pyaptamer/aptatrans/_model_lightning.py
+++ b/pyaptamer/aptatrans/_model_lightning.py
@@ -225,6 +225,6 @@ class AptaTransEncoderLightning(AptaTransLightning):
             x=(x_mlm, x_ssp), encoder_type=self.encoder_type
         )
 
-        loss_mlm = F.cross_entropy(y_mlm_hat, y_mlm.float())
-        loss_ssp = F.cross_entropy(y_ssp_hat, y_ssp.float())
+        loss_mlm = F.cross_entropy(y_mlm_hat.transpose(1, 2), y_mlm.long())
+        loss_ssp = F.cross_entropy(y_ssp_hat.transpose(1, 2), y_ssp.long())
         return self.weight_mlm * loss_mlm + self.weight_ssp * loss_ssp

--- a/pyaptamer/aptatrans/_pipeline.py
+++ b/pyaptamer/aptatrans/_pipeline.py
@@ -13,7 +13,7 @@ from pyaptamer.aptatrans import AptaTrans
 from pyaptamer.experiments import AptamerEvalAptaTrans
 from pyaptamer.mcts import MCTS
 from pyaptamer.utils import (
-    generate_all_aptamer_triplets,
+    generate_nplets,
 )
 from pyaptamer.utils._base import filter_words
 
@@ -37,9 +37,11 @@ class AptaTransPipeline:
         The device on which to run the model.
     model : AptaTrans
         An instance of the AptaTrans() class.
-    prot_words : dict[str, int]
-        A dictionary mapping protein words to their frequency. This should be computed
-        on the protein dataset used for pretraining the protein encoder.
+    prot_words : dict[str, float]
+        A dictionary mapping protein n-mer protein subsequences to a unique integer ID.
+        Used to encode protein sequences into their numerical representions. The
+        subsequences and their frequency should come from the same dataset used for
+        pretraining the protein encoder.
     depth : int, optional, default=20
         The depth of the tree in the Monte Carlo Tree Search (MCTS) algorithm.
     n_iterations : int, optional, default=1000
@@ -50,7 +52,7 @@ class AptaTransPipeline:
     apta_words, prot_words : dict[str, int]
         A dictionary mapping aptamer 3-mer subsequences to unique indices, and protein
         words to their frequency. In particular, `prot_words` now contains only protein
-        words with above-average frequency.
+        words with above-average frequency, mapped to unique integer IDs
 
     References
     ----------
@@ -104,8 +106,8 @@ class AptaTransPipeline:
         """Initialize aptamer and protein word vocabularies.
 
         For aptamers, creates a mapping between all possible 3-mer RNA subsequences and
-        integer indices. For proteins, load protein words mapped to their frequency and
-        filter out those with below-average frequency.
+        integer indices. For proteins, load protein words mapped to their frequency,
+        filter out those with below-average frequency, and assign unique integer IDs.
 
         Parameters
         ----------
@@ -119,9 +121,10 @@ class AptaTransPipeline:
             indices and protein words to their frequencies, respectively.
         """
         # generate all possible RNA triplets (5^3 -> 125 total)
-        apta_words = generate_all_aptamer_triplets(letters=["A", "C", "G", "U", "N"])
+        apta_words = generate_nplets(letters=["A", "C", "G", "U", "N"], repeat=3)
 
-        # filter out protein words with below average frequency
+        # filter out protein words with below average frequency and assign unique
+        # integer IDs
         prot_words = filter_words(prot_words)
 
         return (apta_words, prot_words)

--- a/pyaptamer/aptatrans/tests/test_aptatrans_lightning.py
+++ b/pyaptamer/aptatrans/tests/test_aptatrans_lightning.py
@@ -19,9 +19,13 @@ def mock_model():
             self.dummy_param = nn.Parameter(torch.zeros(1))
 
         def forward_encoder(self, x, encoder_type):
+            batch_size, seq_len = x[0].shape
+            vocab_size = 125
+            ss_classes = 8
+
             return (
-                torch.rand(x[0].shape[0], x[0].shape[1], 10),
-                torch.rand(x[1].shape[0], x[1].shape[1], 10),
+                torch.randn(batch_size, seq_len, vocab_size),
+                torch.randn(batch_size, seq_len, ss_classes),
             )
 
         def forward(self, x_apta, x_prot):
@@ -105,16 +109,18 @@ class TestAptaTransEncoderLightning:
     )
     def test_training_step(self, lightning_model, batch_size, seq_len):
         """Check training_step computes loss correctly."""
-        # create dummy batch
-        x_mlm = torch.randint(0, 125, (batch_size, seq_len, 10))
-        x_ss = torch.randint(0, 125, (batch_size, seq_len, 10))
-        y_mlm = torch.randint(0, 125, (batch_size, seq_len, 10))
-        y_ss = torch.randint(0, 8, (batch_size, seq_len, 10))
-        batch = (x_mlm, x_ss, y_mlm, y_ss)
+
+        # Create dummy input tensors with expected shapes
+        x_mlm = torch.randint(0, 125, (batch_size, seq_len))
+        x_ssp = torch.randint(0, 125, (batch_size, seq_len))
+        y_mlm = torch.randint(0, 125, (batch_size, seq_len))
+        y_ssp = torch.randint(0, 8, (batch_size, seq_len))
+
+        batch = (x_mlm, x_ssp, y_mlm, y_ssp)
 
         loss = lightning_model.training_step(batch, batch_idx=0)
 
-        # check that loss is a scalar tensor
+        # check that the output is a valid scalar loss
         assert isinstance(loss, torch.Tensor)
         assert loss.dim() == 0
         assert loss.item() >= 0

--- a/pyaptamer/experiments/_aptamer.py
+++ b/pyaptamer/experiments/_aptamer.py
@@ -67,9 +67,8 @@ class AptamerEvalAptaTrans(BaseAptamerEval):
     device : torch.device
         Device to run the model on.
     prot_words : dict[str, float]
-        A dictionary mapping protein 3-mer protein subsequences to their frequency in
-        the dataset using for training the model used in the experiment. Used to encode
-        protein sequences into their numerical representions.
+        A dictionary mapping protein n-mer protein subsequences to a unique integer ID.
+        Used to encode protein sequences into their numerical representions.
 
     Attributes
     ----------
@@ -84,9 +83,9 @@ class AptamerEvalAptaTrans(BaseAptamerEval):
     >>> apta_embedding = EncoderPredictorConfig(128, 16, max_len=128)
     >>> prot_embedding = EncoderPredictorConfig(128, 16, max_len=128)
     >>> model = AptaTrans(apta_embedding, prot_embedding)
-    >>> target = "DHRNE"
     >>> device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    >>> prot_words = {"AAA": 0.5, "AAC": 0.3, "AAG": 0.2}
+    >>> target = "DHRNE"
+    >>> prot_words = {"DHR": 1, "RNE": 2, "NE": 3}
     >>> experiment = AptamerEvalAptaTrans(target, model, device, prot_words)
     >>> aptamer_candidate = "AUGGC"
     >>> imap = experiment.evaluate(aptamer_candidate, return_interaction_map=True)

--- a/pyaptamer/mcts/_algorithm.py
+++ b/pyaptamer/mcts/_algorithm.py
@@ -60,8 +60,8 @@ class MCTS(BaseObject):
     >>> prot_embedding = EncoderPredictorConfig(128, 16, max_len=128)
     >>> model = AptaTrans(apta_embedding, prot_embedding)
     >>> device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    >>> target = "MCKY"
-    >>> prot_words = {"AAA": 0.5, "AAC": 0.3, "AAG": 0.2}
+    >>> target = "DHRNE"
+    >>> prot_words = {"DHR": 1, "RNE": 2, "NE": 3}
     >>> experiment = AptamerEvalAptaTrans(target, model, device, prot_words)
     >>> mcts = MCTS(depth=5, n_iterations=2, experiment=experiment)
     >>> candidate = mcts.run(verbose=False)

--- a/pyaptamer/utils/__init__.py
+++ b/pyaptamer/utils/__init__.py
@@ -4,7 +4,7 @@ __author__ = ["nennomp"]
 __all__ = [
     "dna2rna",
     "encode_rna",
-    "generate_all_aptamer_triplets",
+    "generate_nplets",
     "rna2vec",
     "pdb_to_struct",
     "struct_to_aaseq",
@@ -14,7 +14,7 @@ from pyaptamer.utils._pdb_to_struct import pdb_to_struct
 from pyaptamer.utils._rna import (
     dna2rna,
     encode_rna,
-    generate_all_aptamer_triplets,
+    generate_nplets,
     rna2vec,
 )
 from pyaptamer.utils._struct_to_aaseq import struct_to_aaseq

--- a/pyaptamer/utils/_aptatrans_utils.py
+++ b/pyaptamer/utils/_aptatrans_utils.py
@@ -5,7 +5,7 @@ __all__ = ["seq2vec"]
 
 import numpy as np
 
-from pyaptamer.utils import generate_all_aptamer_triplets
+from pyaptamer.utils import generate_nplets
 
 
 def seq2vec(
@@ -42,8 +42,9 @@ def seq2vec(
     -------
     tuple[np.ndarray, np.ndarray]
         A tuple of numpy arrays, containing the padded primary sequence indices array
-        and the padded secondary structure indices array, respectively. Both have shape
-        (n_sequences, seq_max_len).
+        and the padded secondary structure indices array, respectively. The former has
+        sequence length (n_sequences, seq_max_len), the latter (n_sequences, len
+        (`words_ss`) = 584).
 
     Examples
     --------
@@ -51,10 +52,10 @@ def seq2vec(
     >>> words = {"AA": 1, "AC": 2, "A": 3}
     >>> sequences = (["AAAC"], ["HHHC"])
     >>> seq2vec(sequences, words, seq_max_len=4)
-    (array([[1., 2., 0., 0.]]), array([[91.,  0.,  0.,  0.]]))
+    (array([[1., 2., 0., 0.]]), array([[9., 0., 0., 0.]]))
     """
-    words_ss = generate_all_aptamer_triplets(
-        letters=["", "H", "B", "E", "G", "I", "T", "S", "-"]
+    words_ss = generate_nplets(
+        letters=["H", "B", "E", "G", "I", "T", "S", "-"], repeat=range(1, 4)
     )
 
     outputs = []

--- a/pyaptamer/utils/_rna.py
+++ b/pyaptamer/utils/_rna.py
@@ -2,10 +2,11 @@ __author__ = ["nennomp"]
 __all__ = [
     "dna2rna",
     "encode_rna",
-    "generate_all_aptamer_triplets",
+    "generate_nplets",
     "rna2vec",
 ]
 
+from collections.abc import Iterable
 from itertools import product
 
 import numpy as np
@@ -39,26 +40,38 @@ def dna2rna(sequence: str) -> str:
     return result
 
 
-def generate_all_aptamer_triplets(letters: list[str]) -> dict[str, int]:
+def generate_nplets(letters: list[str], repeat: int | Iterable[int]) -> dict[str, int]:
     """
-    Generate a dictionary mapping all possible 3-mer RNA subsequences (triplets) to
-    unique indices.
+    Generate a dictionary containing all possible n-plets of given characters.
+
+    This method generates all possible n-plets, specified by the `repeat` parameter, of
+    characters contained in `letters`. Each n-plet is mapped to a unique integer ID.
 
     Parameters
     ----------
     letters : list[str]
-        List of characters to form triplets from.
+        List of characters to form n-plets from.
+    repeat : int or Iterable[int]
+        The length(s) of the sequences to generate. If an int is given, only that length
+        is generated (e.g., triplets). If a list or range is given, all lengths are
+        generated.
 
     Returns
     -------
     dict[str, int]
-        A dictionary mapping each triplet to a unique integer ID.
+        A dictionary mapping each n-plet to a unique integer ID (1-indexed).
     """
-    triplets = {}
-    for idx, triplet in enumerate(product(letters, repeat=3)):
-        triplets["".join(triplet)] = idx + 1
+    if isinstance(repeat, int):
+        repeat = [repeat]
 
-    return triplets
+    nplets = {}
+    idx = 1
+    for r in repeat:
+        for combo in product(letters, repeat=r):
+            nplets["".join(combo)] = idx
+            idx += 1
+
+    return nplets
 
 
 def rna2vec(
@@ -126,7 +139,7 @@ def rna2vec(
         # generate all ss triplets
         letters = ["S", "H", "M", "I", "B", "X", "E"]
 
-    triplets = generate_all_aptamer_triplets(letters=letters)
+    triplets = generate_nplets(letters=letters, repeat=3)
 
     result = []
     for sequence in sequence_list:

--- a/pyaptamer/utils/tests/test_rna.py
+++ b/pyaptamer/utils/tests/test_rna.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest
 import torch
 
-from pyaptamer.utils import dna2rna, encode_rna, generate_all_aptamer_triplets, rna2vec
+from pyaptamer.utils import dna2rna, encode_rna, generate_nplets, rna2vec
 
 
 @pytest.mark.parametrize(
@@ -36,20 +36,14 @@ def test_dna2rna_edge_cases():
     assert dna2rna("AcGt") == "ANGN"
 
 
-def test_generate_all_aptamer_triplets():
-    """Check generation of all possible 3-mer RNA subsequences (triplets)."""
+@pytest.mark.parametrize("repeat", [2, 3, 4])
+def test_generate_nplets(repeat):
+    """Check generation of all possible n-plets."""
     nucleotides = ["A", "C", "G", "U", "N"]
-    words = generate_all_aptamer_triplets(letters=nucleotides)
-    expected_count = len(nucleotides) ** 3  # 5^3 = 125 triplets
+    words = generate_nplets(letters=nucleotides, repeat=repeat)
 
     assert isinstance(words, dict)
-    assert len(words) == expected_count
-
-    # check that all combinations are present
-    for triplet in product(nucleotides, repeat=3):
-        triplet_str = "".join(triplet)
-        assert triplet_str in words
-        assert isinstance(words[triplet_str], int)
+    assert len(words) == len(nucleotides) ** repeat
 
 
 def test_rna2vec_rna_sequences():


### PR DESCRIPTION
This PR resolves #177.

It addressed (i) a bug related to a shape mismatches between predictions and ground-truth labels when pretraining the encoders. Also, (ii) added an attention mask to avoid attention looking at padded zeros (as in the original implementation). This avoid useless computations and potential degradation of performance.

Consequently, a few other methods in the utils and/or experiments had to be updated. Similarly, docstrings and tests have been updated.

In short, the changes are the following:
* In `pyaptamer.aptatrans._model_lightning`, specifically its `training_step(...)` method. This solves one of the shape mismatche with a simple `transpose`;
* In `pyaptamer.utils._rna` and `pyaptamer.utils._aptatrans_utils`. These changes are related to the update of the `generate_nplets(...)` method. The old method was mapping n-plets to incorrect unique token integers.
* In `pyaptamer.aptatrans._model`, specifically its `make_encoder(...)` method. This change adds the attention mask and passes it to the encoder;

After adding the attention mask the docstrings of `AptamerEvalAptaTrans` and `MCTS` classes were failing. I realized that `prot_words` was supposed to map n-plets to integer IDs rather than float: while `prot_words` indeed starts as a mapping between n-plets and float frequencies, the embeddings in the encoders expect them mapped to integers. I updated the docstrings accordingly. Changes in `pyaptamer.experiments._aptamer` and `pyaptamer.MCTS._algorithm` are related to this.