### PR TITLE
[ENH] Add test step and metrics' logs in AptaTrans lightning wrappers

### DIFF
--- a/pyaptamer/aptatrans/_model_lightning.py
+++ b/pyaptamer/aptatrans/_model_lightning.py
@@ -97,6 +97,45 @@ class AptaTransLightning(L.LightningModule):
         x_apta, x_prot, y = batch
         y_hat = self.model(x_apta, x_prot)
         loss = F.binary_cross_entropy(y_hat.squeeze(0), y.float())
+
+        # compute accuracy
+        y_pred = (y_hat.squeeze(0) > 0.5).float()
+        accuracy = (y_pred == y.float()).float().mean()
+
+        self.log("train_loss", loss, on_epoch=True, on_step=False, prog_bar=True)
+        self.log(
+            "train_accuracy", accuracy, on_epoch=True, on_step=False, prog_bar=True
+        )
+
+        return loss
+
+    def test_step(self, batch: tuple[Tensor, Tensor, Tensor], batch_idx: int) -> Tensor:
+        """Defines a single (mini-batch) step in the test loop.
+
+        Parameters
+        ----------
+        batch: tuple[Tensor, Tensor, Tensor]
+            A batch of data containing aptamer sequences, protein sequences, and labels.
+        batch_idx: int
+            Index of the batch.
+
+        Returns
+        -------
+        Tensor
+            The computed loss for the batch.
+        """
+        # (input aptamers, input proteins, ground-truth targets)
+        x_apta, x_prot, y = batch
+        y_hat = self.model(x_apta, x_prot)
+        loss = F.binary_cross_entropy(y_hat.squeeze(0), y.float())
+
+        # compute accuracy
+        y_pred = (y_hat.squeeze(0) > 0.5).float()
+        accuracy = (y_pred == y.float()).float().mean()
+
+        self.log("test_loss", loss, on_epoch=True, on_step=False, prog_bar=True)
+        self.log("test_accuracy", accuracy, on_epoch=True, on_step=False, prog_bar=True)
+
         return loss
 
     def configure_optimizers(self) -> torch.optim.Optimizer:
@@ -227,4 +266,8 @@ class AptaTransEncoderLightning(AptaTransLightning):
 
         loss_mlm = F.cross_entropy(y_mlm_hat.transpose(1, 2), y_mlm.long())
         loss_ssp = F.cross_entropy(y_ssp_hat.transpose(1, 2), y_ssp.long())
-        return self.weight_mlm * loss_mlm + self.weight_ssp * loss_ssp
+        loss = self.weight_mlm * loss_mlm + self.weight_ssp * loss_ssp
+
+        self.log("train_loss", loss, on_epoch=True, on_step=False, prog_bar=True)
+
+        return loss

--- a/pyaptamer/aptatrans/tests/test_aptatrans_lightning.py
+++ b/pyaptamer/aptatrans/tests/test_aptatrans_lightning.py
@@ -70,15 +70,19 @@ class TestAptaTransLightning:
         "batch_size, seq_len",
         [(4, 50), (8, 100), (2, 75)],
     )
-    def test_training_step(self, lightning_model, batch_size, seq_len):
-        """Check training_step computes loss correctly."""
+    @pytest.mark.parametrize(
+        "step_method",
+        ["training_step", "test_step"],
+    )
+    def test_step(self, lightning_model, batch_size, seq_len, step_method):
+        """Check training_step and test_step compute loss correctly."""
         # create dummy batch
         x_apta = torch.randint(0, 4, (batch_size, seq_len))
         x_prot = torch.randint(0, 20, (batch_size, seq_len))
         y = torch.randint(0, 2, (batch_size, 1)).float()
         batch = (x_apta, x_prot, y)
 
-        loss = lightning_model.training_step(batch, batch_idx=0)
+        loss = getattr(lightning_model, step_method)(batch, batch_idx=0)
 
         # check that loss is a scalar tensor
         assert isinstance(loss, torch.Tensor)


### PR DESCRIPTION
This PR resolves #182.

All changes are in `pyaptamer.aptatrans._model_lightning.py` classes and corresponding tests.

Changes include:
* Added metrics' logs (loss, classification accuracy) to the AptaTrans lightning wrappers;
* Added a `test_step(...)` method so that, along with training, infered may be done under-the-hood in `lightning`.