### PR TITLE
Add ValueError when AptaTransPipeline receives a too small depth value

### DIFF
--- a/examples/aptatrans_tutorial.ipynb
+++ b/examples/aptatrans_tutorial.ipynb
@@ -548,7 +548,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.11.13"
   }
  },
  "nbformat": 4,

--- a/pyaptamer/aptatrans/_pipeline.py
+++ b/pyaptamer/aptatrans/_pipeline.py
@@ -43,7 +43,10 @@ class AptaTransPipeline:
         subsequences and their frequency should come from the same dataset used for
         pretraining the protein encoder.
     depth : int, optional, default=20
-        The depth of the tree in the Monte Carlo Tree Search (MCTS) algorithm.
+        The depth of the tree in the Monte Carlo Tree Search (MCTS) algorithm. Also
+        defines the length of the generated aptamer candidates. Must be equal or
+        greater than 3 since preprocessing uses triplet encoding (3-mers), which
+        requires sequences of at least 3 nucleotides to extract overlapping triplets.
     n_iterations : int, optional, default=1000
         The number of iterations for the MCTS algorithm.
 
@@ -91,7 +94,17 @@ class AptaTransPipeline:
         depth: int = 20,
         n_iterations: int = 1000,
     ) -> None:
-        super().__init__()
+        """
+        Raises
+        ------
+        ValueError
+            If `depth` is less than 3.
+        """
+        if depth < 3:
+            raise ValueError(
+                f"Invalid depth value: {depth}. Must be grater or equal than 3."
+            )
+
         self.device = device
         self.model = model.to(device)
         self.depth = depth

--- a/pyaptamer/aptatrans/tests/test_aptatrans.py
+++ b/pyaptamer/aptatrans/tests/test_aptatrans.py
@@ -230,6 +230,20 @@ class TestAptaTransPipeline:
         expected_prot_count = sum(1 for freq in prot_words.values() if freq > mean_freq)
         assert len(pipeline.prot_words) == expected_prot_count
 
+    @pytest.mark.parametrize("depth", [-1, 0, 1, 2])
+    def test_initialization_with_small_depth(self, depth):
+        """Check ValueError is raised at initialization when depth is less than 3."""
+        model = MockAptaTransNeuralNet(torch.device("cpu"))
+        prot_words = {"AAA": 0.5, "AAC": 0.3, "AAG": 0.8}
+
+        with pytest.raises(ValueError):
+            AptaTransPipeline(
+                device=torch.device("cpu"),
+                model=model,
+                prot_words=prot_words,
+                depth=depth,
+            )
+
     @pytest.mark.parametrize(
         "device, target",
         [


### PR DESCRIPTION
This PR resolves #196.

Added a `raise ValueError(...)` when the `AptaTransPipeline` is initialized with `depth` smaller than 3. Therefore, changes are limited to `aptatrans.pipeline.AptaTransPipeline` and its corresponding tests, where I added a new test to check whether the exception is correctly raised.

See the issue updated description for more info about why the bug occurred. I believe the best option is to raise an exception because the triplet (3-mers) encoding used by AptaTrans will simply produce empty vectors when provides sequences with length less than 3. This encoding is used in the original representation.