### PR TITLE
[ENH] Clean AptaMCTS implementation and fix MCTS simulation

### DIFF
--- a/pyaptamer/aptamcts/__init__.py
+++ b/pyaptamer/aptamcts/__init__.py
@@ -1,0 +1,6 @@
+"""AptaMCTS pipeline for aptamer recommendation."""
+
+__author__ = ["nennomp", "codex"]
+__all__ = ["AptaMCTS"]
+
+from pyaptamer.aptamcts._pipeline import AptaMCTS

--- a/pyaptamer/aptamcts/_pipeline.py
+++ b/pyaptamer/aptamcts/_pipeline.py
@@ -1,0 +1,77 @@
+"""AptaMCTS pipeline for candidate aptamer recommendation."""
+
+__author__ = ["nennomp", "codex"]
+__all__ = ["AptaMCTS"]
+
+import numpy as np
+from skbase.base import BaseObject
+
+from pyaptamer.experiments import AptamerEvalAptaNet
+from pyaptamer.mcts import MCTS
+
+
+class AptaMCTS(BaseObject):
+    """AptaMCTS pipeline for aptamer recommendation using MCTS and AptaNet scoring.
+
+    The pipeline initializes an `AptamerEvalAptaNet` experiment for a given target
+    sequence and uses `MCTS` to recommend high-scoring aptamer candidates.
+
+    Parameters
+    ----------
+    pipeline : AptaNetPipeline
+        Fitted AptaNet pipeline used as scoring function.
+    depth : int, optional, default=20
+        Target length for generated candidates.
+    n_iterations : int, optional, default=1000
+        Number of MCTS iterations per round.
+
+    References
+    ----------
+    .. [1] Lee, Gwangho, et al. "Predicting aptamer sequences that interact with target
+       proteins using an aptamer-protein interaction classifier and a Monte Carlo tree
+       search approach." PLOS ONE 16.6 (2021): e0253760.
+    """
+
+    def __init__(self, pipeline, depth: int = 20, n_iterations: int = 1000) -> None:
+        super().__init__()
+        self.pipeline = pipeline
+        self.depth = depth
+        self.n_iterations = n_iterations
+
+    def _init_aptamer_experiment(self, target: str) -> AptamerEvalAptaNet:
+        """Initialize aptamer recommendation experiment for `target`."""
+        return AptamerEvalAptaNet(target=target, pipeline=self.pipeline)
+
+    def predict(self, candidate: str, target: str) -> np.float64:
+        """Score one aptamer candidate against a target protein sequence."""
+        experiment = self._init_aptamer_experiment(target=target)
+        return experiment.evaluate(candidate)
+
+    def recommend(
+        self,
+        target: str,
+        n_candidates: int = 10,
+        verbose: bool = True,
+    ) -> set[tuple[str, str, float]]:
+        """Recommend aptamer candidates for a target protein sequence."""
+        experiment = self._init_aptamer_experiment(target=target)
+        mcts = MCTS(
+            experiment=experiment,
+            depth=self.depth,
+            n_iterations=self.n_iterations,
+        )
+
+        candidates = set()
+        while len(candidates) < n_candidates:
+            candidate = mcts.run(verbose=verbose)
+            candidates.add(tuple(candidate.values()))
+
+        if verbose:
+            for candidate, sequence, score in candidates:
+                print(
+                    f"Candidate: {candidate}, "
+                    f"Sequence: {sequence}, "
+                    f"Score: {float(score):.4f}"
+                )
+
+        return candidates

--- a/pyaptamer/aptamcts/tests/__init__.py
+++ b/pyaptamer/aptamcts/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for AptaMCTS pipeline."""

--- a/pyaptamer/aptamcts/tests/test_aptamcts.py
+++ b/pyaptamer/aptamcts/tests/test_aptamcts.py
@@ -1,0 +1,62 @@
+"""Test suite for AptaMCTS pipeline."""
+
+__author__ = ["codex"]
+
+import numpy as np
+
+from pyaptamer.aptamcts import AptaMCTS
+
+
+class MockAptaNetPipeline:
+    """Mock AptaNet pipeline for deterministic score assignment."""
+
+    def __init__(self, fixed_score=0.7):
+        self.fixed_score = fixed_score
+
+    def predict_proba(self, X):
+        return np.array([[1 - self.fixed_score, self.fixed_score]] * len(X))
+
+
+def test_predict():
+    """Check `predict` returns scalar score from AptaNet experiment."""
+    pipeline = MockAptaNetPipeline(fixed_score=0.8)
+    aptamcts = AptaMCTS(pipeline=pipeline, depth=5, n_iterations=3)
+
+    score = aptamcts.predict(candidate="AUGCA", target="ACDEFGHIK")
+    assert isinstance(score, np.float64)
+    assert score == np.float64(0.8)
+
+
+def test_recommend(monkeypatch):
+    """Check `recommend` returns requested number of unique candidates."""
+    pipeline = MockAptaNetPipeline(fixed_score=0.6)
+    aptamcts = AptaMCTS(pipeline=pipeline, depth=5, n_iterations=3)
+
+    class MockMCTS:
+        def __init__(self, **kwargs):
+            self.counter = 0
+
+        def run(self, verbose: bool = False):
+            candidate_data = [
+                ("AAAAA", "A_A_A_A_A_", np.float64(0.91)),
+                ("CCCCC", "C_C_C_C_C_", np.float64(0.81)),
+                ("GGGGG", "G_G_G_G_G_", np.float64(0.71)),
+            ]
+            data = candidate_data[self.counter % len(candidate_data)]
+            self.counter += 1
+            return {
+                "candidate": data[0],
+                "sequence": data[1],
+                "score": data[2],
+            }
+
+    monkeypatch.setattr("pyaptamer.aptamcts._pipeline.MCTS", MockMCTS)
+
+    candidates = aptamcts.recommend(target="ACDEFGHIK", n_candidates=2, verbose=False)
+    assert isinstance(candidates, set)
+    assert len(candidates) == 2
+
+    for candidate, sequence, score in candidates:
+        assert isinstance(candidate, str)
+        assert isinstance(sequence, str)
+        assert isinstance(score, np.float64)

--- a/pyaptamer/mcts/_algorithm.py
+++ b/pyaptamer/mcts/_algorithm.py
@@ -154,6 +154,22 @@ class MCTS(BaseObject):
 
         return result
 
+    @staticmethod
+    def _to_scalar_score(score) -> float:
+        """Convert model output to a scalar float used for backpropagation."""
+        if hasattr(score, "item"):
+            return float(score.item())
+        return float(score)
+
+    @staticmethod
+    def _token_count(encoded_sequence: str) -> int:
+        """Return the number of encoded tokens in an underscore-form sequence."""
+        if len(encoded_sequence) % 2 != 0:
+            raise ValueError(
+                f"Encoded sequence must have even length, got {len(encoded_sequence)}."
+            )
+        return len(encoded_sequence) // 2
+
     def _selection(self, node: "TreeNode") -> "TreeNode":
         """Select a node for expansion.
 
@@ -237,12 +253,13 @@ class MCTS(BaseObject):
         sequence = self.base + sequence
 
         # fill the rest of the sequence with random possible values
-        remaining_length = (self.depth * 2) - len(sequence)
-        for _ in range(remaining_length):
+        remaining_tokens = self.depth - self._token_count(sequence)
+        for _ in range(max(0, remaining_tokens)):
             sequence += random.choice(self.states)
 
-        # evaluate the candidate sequence with the goal function
-        return self.experiment.evaluate(sequence)
+        # evaluate the reconstructed candidate sequence with the goal function
+        reconstructed_sequence = self._reconstruct(sequence)
+        return self._to_scalar_score(self.experiment.evaluate(reconstructed_sequence))
 
     def _find_best_subsequence(self) -> str:
         """Retrieve the best sequence found so far, according to the UCT scores.
@@ -256,7 +273,7 @@ class MCTS(BaseObject):
         subsequence = self.base
 
         # traverse the tree
-        max_steps = (self.depth * 2) - len(self.base)
+        max_steps = self.depth - self._token_count(self.base)
         for _ in range(max_steps):
             if not curr.children:
                 break
@@ -284,9 +301,9 @@ class MCTS(BaseObject):
         """
         self._reset()
 
-        # continue until we reach the target sequence length (i.e, depth * 2)
+        # continue until we reach the target sequence length
         round_count = 0
-        while len(self.base) < self.depth * 2:
+        while self._token_count(self.base) < self.depth:
             if verbose:
                 print(f"\n ----- Round: {round_count + 1} -----")
 
@@ -309,13 +326,15 @@ class MCTS(BaseObject):
             if verbose:
                 print("#" * 50)
                 print(f"Best subsequence: {self.base}")
-                print(f"Depth: {len(self.base) // 2}")
+                print(f"Depth: {self._token_count(self.base)}")
                 print("#" * 50)
 
             # reset for next iteration
             self.root = TreeNode(
                 n_states=len(self.states),
-                depth=len(self.base) // 2,  # adjust depth based on current base
+                depth=self._token_count(
+                    self.base
+                ),  # adjust depth based on current base
             )
 
             round_count += 1

--- a/pyaptamer/mcts/tests/test_mcts.py
+++ b/pyaptamer/mcts/tests/test_mcts.py
@@ -306,8 +306,35 @@ class TestMCTS:
     def test_simulation(self, mcts):
         """Check simulation step runs without errors."""
         node = mcts.root.create_child(val="A_")
-        _ = mcts._simulation(node=node)
-        assert True
+        score = mcts._simulation(node=node)
+        assert isinstance(score, float)
+
+    def test_simulation_uses_reconstructed_sequence(self):
+        """Check simulation evaluates underscore-free candidates with target length."""
+
+        class RecordingExperiment:
+            def __init__(self):
+                self.last_sequence = None
+
+            def evaluate(self, aptamer_candidate):
+                self.last_sequence = aptamer_candidate
+                return np.float64(len(aptamer_candidate))
+
+        experiment = RecordingExperiment()
+        mcts = MCTS(
+            experiment=experiment,
+            states=NUCLEOTIDES,
+            depth=5,
+            n_iterations=2,
+        )
+
+        node = mcts.root.create_child(val="A_")
+        score = mcts._simulation(node=node)
+
+        assert score == 5.0
+        assert experiment.last_sequence is not None
+        assert "_" not in experiment.last_sequence
+        assert len(experiment.last_sequence) == 5
 
     def test_find_best_subsequence(self, mcts):
         """Check whether the best subsequence is returned based on UCT scores."""


### PR DESCRIPTION
## Summary
This PR addresses issue #21 by adding a clean AptaMCTS implementation and fixing correctness issues in the underlying MCTS simulation logic.

### What changed
- Added a dedicated `AptaMCTS` pipeline:
  - `pyaptamer/aptamcts/__init__.py`
  - `pyaptamer/aptamcts/_pipeline.py`
  - `pyaptamer/aptamcts/tests/test_aptamcts.py`
- Fixed `MCTS` simulation correctness in `pyaptamer/mcts/_algorithm.py`:
  - token-based depth accounting (instead of raw string length)
  - simulation evaluates reconstructed aptamer sequence (consistent scoring format)
  - scalar score normalization for stable backpropagation
- Added regression coverage in `pyaptamer/mcts/tests/test_mcts.py` for reconstructed-sequence simulation and score type.

## Why
- Issue #21 requested a clean AptaMCTS implementation.
- Current MCTS simulation had a sequence-length/token mismatch and inconsistent scoring input format during simulation vs final candidate evaluation.

## Validation
- `pre-commit run --files <changed files>`
- `python -m pytest pyaptamer\\mcts\\tests\\test_mcts.py pyaptamer\\aptamcts\\tests\\test_aptamcts.py -p no:warnings`
- `python -m pytest pyaptamer\\aptatrans\\tests\\test_aptatrans.py pyaptamer\\experiments\\tests\\test_aptamer.py -p no:warnings`
- `python -m pytest pyaptamer -p no:warnings`

Closes #21.
