### PR TITLE
fix(utils): use os.path.basename for PDB structure ID

### DIFF
--- a/pyaptamer/utils/_pdb_to_struct.py
+++ b/pyaptamer/utils/_pdb_to_struct.py
@@ -1,6 +1,8 @@
 __author__ = "satvshr"
 __all__ = ["pdb_to_struct"]
 
+import os
+
 from Bio.PDB import PDBParser
 
 
@@ -19,6 +21,6 @@ def pdb_to_struct(pdb_file_path):
         Parsed Biopython structure object.
     """
     parser = PDBParser(QUIET=True)
-    structure_id = pdb_file_path.split("/")[-1].split("\\")[-1]
+    structure_id = os.path.basename(pdb_file_path)
     structure = parser.get_structure(structure_id, pdb_file_path)
     return structure


### PR DESCRIPTION
## Summary

Replaces manual path splitting with `os.path.basename()` when deriving the structure identifier in `pdb_to_struct`.

## Changes

**`_pdb_to_struct.py`**

The previous logic used `pdb_file_path.split("/")[-1].split("\\")[-1]` to get the filename for the Biopython structure ID. That:

- Assumes only `/` and `\\` as path separators
- Fails on mixed or non-standard separators
- Ignores `os.path` conventions for cross-platform paths

Switching to `os.path.basename(pdb_file_path)` uses the standard library and behaves correctly on all supported platforms.