### PR TITLE
fix(aptanet): check pipeline consistency for non deterministic estimators 

### DIFF
--- a/pyaptamer/aptanet/_feature_classifier.py
+++ b/pyaptamer/aptanet/_feature_classifier.py
@@ -337,4 +337,5 @@ class AptaNetRegressor(RegressorMixin, BaseEstimator):
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
         tags.regressor_tags.poor_score = True
+        tags.non_deterministic = True
         return tags

--- a/pyaptamer/aptanet/tests/test_aptanet.py
+++ b/pyaptamer/aptanet/tests/test_aptanet.py
@@ -84,7 +84,9 @@ def test_pipeline_fit_and_predict_regression(aptamer_seq, protein_seq):
 
 @parametrize_with_checks(
     estimators=[AptaNetClassifier(), AptaNetRegressor()],
-    expected_failed_checks=_expected_failed_checks_for_non_deterministic_estimators,
+    expected_failed_checks={
+        "check_pipeline_consistency": "estimator is non-deterministic"
+        },
 )
 def test_sklearn_compatible_estimator(estimator, check):
     """
@@ -93,22 +95,3 @@ def test_sklearn_compatible_estimator(estimator, check):
     check(estimator)
 
 
-def test_expected_failed_checks_marks_non_deterministic_estimators_only():
-    """
-    Test if pipeline consistency is marked as xfail only for non-deterministic
-    estimators.
-    """
-    expected_failure = {"check_pipeline_consistency": "estimator is non-deterministic"}
-
-    assert (
-        _expected_failed_checks_for_non_deterministic_estimators(AptaNetClassifier())
-        == expected_failure
-    )
-    assert (
-        _expected_failed_checks_for_non_deterministic_estimators(AptaNetRegressor())
-        == expected_failure
-    )
-    assert (
-        _expected_failed_checks_for_non_deterministic_estimators(LinearRegression())
-        == {}
-    )

--- a/pyaptamer/aptanet/tests/test_aptanet.py
+++ b/pyaptamer/aptanet/tests/test_aptanet.py
@@ -3,7 +3,6 @@ __author__ = ["nennomp", "satvshr"]
 
 import numpy as np
 import pytest
-from sklearn.linear_model import LinearRegression
 from sklearn.utils.estimator_checks import parametrize_with_checks
 
 from pyaptamer.aptanet import AptaNetClassifier, AptaNetPipeline, AptaNetRegressor
@@ -86,12 +85,10 @@ def test_pipeline_fit_and_predict_regression(aptamer_seq, protein_seq):
     estimators=[AptaNetClassifier(), AptaNetRegressor()],
     expected_failed_checks={
         "check_pipeline_consistency": "estimator is non-deterministic"
-        },
+    },
 )
 def test_sklearn_compatible_estimator(estimator, check):
     """
     Run scikit-learn's compatibility checks on the AptaNetClassifier.
     """
     check(estimator)
-
-

--- a/pyaptamer/aptanet/tests/test_aptanet.py
+++ b/pyaptamer/aptanet/tests/test_aptanet.py
@@ -15,17 +15,6 @@ params = [
 ]
 
 
-def _expected_failed_checks_for_non_deterministic_estimators(estimator):
-    """
-    Mark pipeline consistency check is expected to fail only for non-deterministic
-    estimators.
-    """
-    sklearn_tags = estimator.__sklearn_tags__()
-    if sklearn_tags.non_deterministic:
-        return {"check_pipeline_consistency": "estimator is non-deterministic"}
-    return {}
-
-
 @pytest.mark.parametrize("aptamer_seq, protein_seq", params)
 def test_pipeline_fit_and_predict_classification(aptamer_seq, protein_seq):
     """

--- a/pyaptamer/aptanet/tests/test_aptanet.py
+++ b/pyaptamer/aptanet/tests/test_aptanet.py
@@ -3,6 +3,7 @@ __author__ = ["nennomp", "satvshr"]
 
 import numpy as np
 import pytest
+from sklearn.linear_model import LinearRegression
 from sklearn.utils.estimator_checks import parametrize_with_checks
 
 from pyaptamer.aptanet import AptaNetClassifier, AptaNetPipeline, AptaNetRegressor
@@ -13,6 +14,17 @@ params = [
         "ACDEFGHIKLMNPQRSTVWYACDEFGHIKLMNPQRSTVWY",
     )
 ]
+
+
+def _expected_failed_checks_for_non_deterministic_estimators(estimator):
+    """
+    Mark pipeline consistency check is expected to fail only for non-deterministic
+    estimators.
+    """
+    sklearn_tags = estimator.__sklearn_tags__()
+    if sklearn_tags.non_deterministic:
+        return {"check_pipeline_consistency": "estimator is non-deterministic"}
+    return {}
 
 
 @pytest.mark.parametrize("aptamer_seq, protein_seq", params)
@@ -72,23 +84,31 @@ def test_pipeline_fit_and_predict_regression(aptamer_seq, protein_seq):
 
 @parametrize_with_checks(
     estimators=[AptaNetClassifier(), AptaNetRegressor()],
-    # TODO: for some reason, despite including `check_pipeline_consistency` in the
-    # checks that are supposed to fail (via `expected_failed_checks` parameter), the
-    # check is still run and obviously fails. Currently, the if block is the only
-    # workaround that works, and skips the check completely. Note that,
-    # `check_pipeline_consistency` will never pass for non-deterministic estimators as
-    # in our case. If anyone has a better working solution, please suggest.
-    # expected_failed_checks={
-    #    "check_pipeline_consistency": "estimator is non-deterministic"
-    # },
+    expected_failed_checks=_expected_failed_checks_for_non_deterministic_estimators,
 )
 def test_sklearn_compatible_estimator(estimator, check):
     """
     Run scikit-learn's compatibility checks on the AptaNetClassifier.
     """
-    expected_failed_checks = ["check_pipeline_consistency"]
-    if check.func.__name__ not in expected_failed_checks:
-        try:
-            check(estimator)
-        except Exception as e:
-            pytest.fail(f"Estimator check failed: {e}")
+    check(estimator)
+
+
+def test_expected_failed_checks_marks_non_deterministic_estimators_only():
+    """
+    Test if pipeline consistency is marked as xfail only for non-deterministic
+    estimators.
+    """
+    expected_failure = {"check_pipeline_consistency": "estimator is non-deterministic"}
+
+    assert (
+        _expected_failed_checks_for_non_deterministic_estimators(AptaNetClassifier())
+        == expected_failure
+    )
+    assert (
+        _expected_failed_checks_for_non_deterministic_estimators(AptaNetRegressor())
+        == expected_failure
+    )
+    assert (
+        _expected_failed_checks_for_non_deterministic_estimators(LinearRegression())
+        == {}
+    )


### PR DESCRIPTION
 Resolves #250.

### **Description**

The `parametrize_with_checks` is used to validate the compatibility of `AptaNetClassifier` and `AptaNetRegressor`. But, the `check_pipeline_consistency` test fails for these estimators because they are non-deterministic.

### **Changes**
- **In test_aptanet.py file** 
   - Added a function to mark the `check_pipeline_consistency` test as expected to fail for non-deterministic estimators.
  - Updated `parametrize_with_checks` by replacing manual `if` block workaround with the `expected_failed_checks` .
  - Added `test_expected_failed_checks_marks_non_deterministic_estimators_only` to verify that only non-deterministic estimators are marked as `xfail` for `check_pipeline_consistency`.
- **In  _feature_classifier.py**
   - Added `tags.non_deterministic = True`  to mark the regressor as non-deterministic.

### **How to Test**
- Run this command in the project root: 
     python -m pytest pyaptamer/aptanet/tests/test_aptanet.py -v

### **Output**
- All the checks passed and the non-deterministic ones were skipped 
 
<img width="1847" height="126" alt="image" src="https://github.com/user-attachments/assets/8f863315-8b35-4866-a431-994b5569ff25" />
<img width="1856" height="596" alt="image" src="https://github.com/user-attachments/assets/3dea3eff-aa54-4ae4-88b1-3ec22214f6e2" />

