### PR TITLE
[ENH] Replace seq_id with chain_id in MoleculeLoader

### DIFF
--- a/pyaptamer/data/loader.py
+++ b/pyaptamer/data/loader.py
@@ -102,8 +102,9 @@ class MoleculeLoader:
             seqres_records = list(SeqIO.parse(handle, "pdb-seqres"))
 
         return [
-            (record.id.split(":")[1] if ":" in record.id else record.id, str(record.seq))
+            (
+                record.id.split(":")[1] if ":" in record.id else record.id,
+                str(record.seq),
+            )
             for record in seqres_records
         ]
-
-

--- a/pyaptamer/data/loader.py
+++ b/pyaptamer/data/loader.py
@@ -63,9 +63,9 @@ class MoleculeLoader:
 
         for path in paths:
             seqs = self._load_dispatch(path, "seq")
-            for chain_id, seq in seqs:
-                index_tuples.append((path, chain_id))
-                sequences.append(seq)
+            for _, row in seqs.iterrows():
+                index_tuples.append((path, row["chain_id"]))
+                sequences.append(row["sequence"])
 
         index = pd.MultiIndex.from_tuples(index_tuples, names=["path", "chain_id"])
 
@@ -95,16 +95,17 @@ class MoleculeLoader:
 
         Returns
         --------
-        list of tuple
-            List of ``(chain_id, sequence)`` tuples, one per chain.
+        pandas.DataFrame
+            DataFrame with columns ``["chain_id", "sequence"]``.
         """
         with open(path) as handle:
             seqres_records = list(SeqIO.parse(handle, "pdb-seqres"))
 
-        return [
-            (
-                record.id.split(":")[1] if ":" in record.id else record.id,
-                str(record.seq),
-            )
+        records = [
+            {
+                "chain_id": record.id.split(":")[1] if ":" in record.id else record.id,
+                "sequence": str(record.seq),
+            }
             for record in seqres_records
         ]
+        return pd.DataFrame.from_records(records, columns=["chain_id", "sequence"])

--- a/pyaptamer/data/loader.py
+++ b/pyaptamer/data/loader.py
@@ -46,13 +46,13 @@ class MoleculeLoader:
             self._path = [Path(p) if isinstance(p, str) else p for p in path]
 
     def to_df_seq(self):
-        """Return a pd.DataFrame of sequences with MultiIndex (path, seq_id).
+        """Return a pd.DataFrame of sequences with MultiIndex (path, chain_id).
 
         Returns
         --------
         pd.DataFrame
             sequences in self in a pd.DataFrame;
-            index is a MultiIndex (path, seq_id);
+            index is a MultiIndex (path, chain_id);
             has single column "sequence";
             each row contains one primary amino-acid sequence
         """
@@ -63,11 +63,11 @@ class MoleculeLoader:
 
         for path in paths:
             seqs = self._load_dispatch(path, "seq")
-            for i, seq in enumerate(seqs):
-                index_tuples.append((path, i))
+            for chain_id, seq in seqs:
+                index_tuples.append((path, chain_id))
                 sequences.append(seq)
 
-        index = pd.MultiIndex.from_tuples(index_tuples, names=["path", "seq_id"])
+        index = pd.MultiIndex.from_tuples(index_tuples, names=["path", "chain_id"])
 
         columns = ["sequence"] if self.columns is None else self.columns
 
@@ -95,15 +95,15 @@ class MoleculeLoader:
 
         Returns
         --------
-        pandas.DataFrame
-            DataFrame with columns ``['chain', 'sequence']``
+        list of tuple
+            List of ``(chain_id, sequence)`` tuples, one per chain.
         """
         with open(path) as handle:
             seqres_records = list(SeqIO.parse(handle, "pdb-seqres"))
 
-            records = [
-                {"chain": getattr(record, "id", None), "sequence": str(record.seq)}
-                for record in seqres_records
-            ]
-        df = pd.DataFrame.from_records(records, columns=["chain", "sequence"])
-        return df["sequence"].tolist()
+        return [
+            (record.id.split(":")[1] if ":" in record.id else record.id, str(record.seq))
+            for record in seqres_records
+        ]
+
+

--- a/pyaptamer/data/tests/test_loader.py
+++ b/pyaptamer/data/tests/test_loader.py
@@ -24,7 +24,7 @@ def test_string_path():
 
     # MultiIndex contract
     assert df.index.nlevels == 2
-    assert df.index.names == ["path", "seq_id"]
+    assert df.index.names == ["path", "chain_id"]
 
     # all sequences are strings
     assert df["sequence"].map(type).eq(str).all()
@@ -43,6 +43,6 @@ def test_pathlib_path():
 
     assert list(df.columns) == ["sequence"]
     assert df.index.nlevels == 2
-    assert df.index.names == ["path", "seq_id"]
+    assert df.index.names == ["path", "chain_id"]
     assert df["sequence"].map(type).eq(str).all()
     assert any(seq.startswith("QTDMSRK") for seq in df["sequence"])


### PR DESCRIPTION
This PR replaces `seq_id` with `chain_id` in `MoleculeLoader`, so sequences are now indexed using actual PDB chain IDs instead of numbers. Also updates `_load_pdb_seq` to extract and clean the chain IDs.
Fixes:  #255

output: 
```
path                                               chain_id                                                   
/home/kajal/pyaptamer/pyaptamer/datasets/data/1... A         QTDMSRKAFVFPKESDTSYVSLKAPLTKPLKAFTVCLHFYTELSST...
                                                   B         QTDMSRKAFVFPKESDTSYVSLKAPLTKPLKAFTVCLHFYTELSST...
                                                   C         QTDMSRKAFVFPKESDTSYVSLKAPLTKPLKAFTVCLHFYTELSST...
                                                   D         QTDMSRKAFVFPKESDTSYVSLKAPLTKPLKAFTVCLHFYTELSST...
                                                   E         QTDMSRKAFVFPKESDTSYVSLKAPLTKPLKAFTVCLHFYTELSST...
                                                   F         QTDMSRKAFVFPKESDTSYVSLKAPLTKPLKAFTVCLHFYTELSST...
                                                   G         QTDMSRKAFVFPKESDTSYVSLKAPLTKPLKAFTVCLHFYTELSST...
                                                   H         QTDMSRKAFVFPKESDTSYVSLKAPLTKPLKAFTVCLHFYTELSST...
                                                   I         QTDMSRKAFVFPKESDTSYVSLKAPLTKPLKAFTVCLHFYTELSST...
                                                   J         QTDMSRKAFVFPKESDTSYVSLKAPLTKPLKAFTVCLHFYTELSST...
/home/kajal/pyaptamer/pyaptamer/datasets/data/5... A         ERDCRVSSFRVKENFDKARFSGTWYAMAKKDPEGLFLQDNIVAEFS...
```
