### PR TITLE
Fix AMP training stability by switching to BCEWithLogitsLoss (#230)

### DIFF
--- a/pyaptamer/aptatrans/_model.py
+++ b/pyaptamer/aptatrans/_model.py
@@ -162,7 +162,6 @@ class AptaTrans(nn.Module):
                     ("linear1", nn.Linear(self.inplanes, self.inplanes // 2)),
                     ("activation1", nn.GELU()),
                     ("linear2", nn.Linear(self.inplanes // 2, 1)),
-                    ("activation2", nn.Sigmoid()),
                 ]
             )
         )

--- a/pyaptamer/aptatrans/_model_lightning.py
+++ b/pyaptamer/aptatrans/_model_lightning.py
@@ -102,10 +102,11 @@ class AptaTransLightning(L.LightningModule):
         # (input aptamers, input proteins, ground-truth targets)
         x_apta, x_prot, y = batch
         y_hat = torch.flatten(self.model(x_apta, x_prot))
-        loss = F.binary_cross_entropy(y_hat, y.float())
+        loss = F.binary_cross_entropy_with_logits(y_hat, y.float())
 
         # compute accuracy
-        y_pred = (y_hat > 0.5).float()
+        y_prob = torch.sigmoid(y_hat)
+        y_pred = (y_prob > 0.5).float()
         accuracy = (y_pred == y.float()).float().mean()
 
         self._log_metric(f"{stage}_loss", loss)

--- a/pyaptamer/aptatrans/tests/test_aptatrans.py
+++ b/pyaptamer/aptatrans/tests/test_aptatrans.py
@@ -155,9 +155,10 @@ class TestAptaTransModel:
         output = aptatrans(x_apta, x_prot)
 
         assert output.shape == (batch_size, 1)
-        # output should be in [0, 1] (sigmoid activation)
-        assert torch.all(output >= 0.0) and torch.all(output <= 1.0)
-        assert not torch.allclose(output[0], output[1], atol=1e-5)
+        # probabilities (after sigmoid) should be in [0, 1]
+        probs = torch.sigmoid(output)
+        assert torch.all(probs >= 0.0) and torch.all(probs <= 1.0)
+        assert not torch.allclose(probs[0], probs[1], atol=1e-5)
 
 
 class MockAptaTransNeuralNet(nn.Module):

--- a/pyaptamer/experiments/_aptamer_aptatrans.py
+++ b/pyaptamer/experiments/_aptamer_aptatrans.py
@@ -112,8 +112,10 @@ class AptamerEvalAptaTrans(BaseAptamerEval):
             )
         else:
             return np.float64(
-                self.model(
-                    aptamer_candidate.to(self.device),
-                    self.target_encoded,
+                torch.sigmoid(
+                    self.model(
+                        aptamer_candidate.to(self.device),
+                        self.target_encoded,
+                    )
                 ).item()
             )


### PR DESCRIPTION
**Problem:** Training currently crashes when using Automatic Mixed Precision (AMP) because F.binary_cross_entropy is unsafe to autocast and requires inputs to be strictly in the range [0, 1].

**Solution:**

Model Refactor: Removed nn.Sigmoid from the AptaTrans model's final head. Outputting raw logits is the standard practice for modern deep learning.
Loss Stability: Switched to F.binary_cross_entropy_with_logits in the Lightning module. This is numerically more stable and explicitly supports AMP/autocast.
Backward Compatibility: Updated AptamerEvalAptaTrans.evaluate to explicitly apply a Sigmoid activation, ensuring that affinity scores returned to users remain as probabilities (0 to 1).
Accuracy Update: Updated accuracy logic to handle logits before thresholding.

**Testing:**

Updated test_aptatrans.py to account for the model change.
Verified that all 34 core unit tests and 7 experimental tests pass successfully.