### PR TITLE
Optimize CI workflow and enable caching (#260)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,19 +27,18 @@ jobs:
     steps:
       - name: repository checkout step
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: python environment step
         uses: actions/setup-python@v6
         with:
           python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: "pyproject.toml"
 
       - name: install pre-commit
         run: python3 -m pip install pre-commit
-
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Get changed files
         id: changed-files
@@ -104,6 +103,8 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: "pyproject.toml"
 
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
@@ -146,6 +147,8 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+          cache: "pip"
+          cache-dependency-path: "pyproject.toml"
 
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"


### PR DESCRIPTION
**Problem:** 

The CI pipeline was inefficient due to redundant repository checkout steps and the lack of package caching, leading to unnecessarily long build times.

**Solution:**

**Streamlined Checkout:** Removed a duplicate actions/checkout@v6 step in the code-quality job and consolidated it with required fetch-depth settings.

**Dependency Caching:** Added cache: "pip" and cache-dependency-path: "pyproject.toml" to all setup-python jobs. This allows GitHub Actions to reuse installed packages across different runs.

**Impact:**

Significantly reduces runtime for CI checks by skipping the download phase for unchanged dependencies.
Reduces resource consumption on CI runners.