### PR TITLE
[ENH] Add test coverage for AptaTrans pretrained weights local loading

### DIFF
--- a/pyaptamer/aptatrans/tests/test_aptatrans.py
+++ b/pyaptamer/aptatrans/tests/test_aptatrans.py
@@ -2,6 +2,9 @@
 
 __author__ = ["nennomp"]
 
+import os
+import tempfile
+
 import pytest
 import torch
 import torch.nn as nn
@@ -40,6 +43,56 @@ class TestAptaTransModel:
                 in_dim=128,
                 n_heads=3,
             )
+
+    def test_load_pretrained_weights_from_local_file(
+        self,
+        embeddings: tuple[EncoderPredictorConfig, EncoderPredictorConfig],
+    ):
+        """Check load_pretrained_weights() loads weights from a local file."""
+        model = AptaTrans(
+            apta_embedding=embeddings[0],
+            prot_embedding=embeddings[1],
+            in_dim=32,
+            n_encoder_layers=2,
+            n_heads=4,
+            conv_layers=[1, 1, 1],
+        )
+
+        # save the model's own state_dict as a stand-in for pretrained weights
+        state_dict = model.state_dict()
+
+        weights_dir = os.path.join(
+            os.path.dirname(
+                os.path.abspath(
+                    __import__("pyaptamer.aptatrans._model", fromlist=["_model"]).__file__
+                )
+            ),
+            "weights",
+        )
+        os.makedirs(weights_dir, exist_ok=True)
+        weights_path = os.path.join(weights_dir, "pretrained.pt")
+
+        with tempfile.NamedTemporaryFile(
+            dir=weights_dir, suffix=".pt", delete=False
+        ) as tmp:
+            tmp_path = tmp.name
+
+        try:
+            torch.save(state_dict, tmp_path)
+            os.replace(tmp_path, weights_path)
+
+            # load weights from the local file
+            model.load_pretrained_weights()
+
+            # verify weights are identical after loading
+            loaded_state_dict = model.state_dict()
+            for key in state_dict:
+                assert torch.equal(
+                    state_dict[key], loaded_state_dict[key]
+                ), f"Mismatch in parameter: {key}"
+        finally:
+            if os.path.exists(weights_path):
+                os.remove(weights_path)
 
     @pytest.mark.parametrize(
         "batch_size, seq_len_apta, seq_len_prot, in_dim",

--- a/pyaptamer/aptatrans/tests/test_aptatrans.py
+++ b/pyaptamer/aptatrans/tests/test_aptatrans.py
@@ -64,7 +64,9 @@ class TestAptaTransModel:
         weights_dir = os.path.join(
             os.path.dirname(
                 os.path.abspath(
-                    __import__("pyaptamer.aptatrans._model", fromlist=["_model"]).__file__
+                    __import__(
+                        "pyaptamer.aptatrans._model", fromlist=["_model"]
+                    ).__file__
                 )
             ),
             "weights",
@@ -87,9 +89,9 @@ class TestAptaTransModel:
             # verify weights are identical after loading
             loaded_state_dict = model.state_dict()
             for key in state_dict:
-                assert torch.equal(
-                    state_dict[key], loaded_state_dict[key]
-                ), f"Mismatch in parameter: {key}"
+                assert torch.equal(state_dict[key], loaded_state_dict[key]), (
+                    f"Mismatch in parameter: {key}"
+                )
         finally:
             if os.path.exists(weights_path):
                 os.remove(weights_path)


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #180.

#### What does this implement/fix? Explain your changes.

- Adds `test_load_pretrained_weights_from_local_file` to `TestAptaTransModel` in `pyaptamer/aptatrans/tests/test_aptatrans.py`
- Covers the previously untested `if os.path.exists(path):` branch in `AptaTrans.load_pretrained_weights()` (`_model.py` was at 85% coverage)
- Uses a small random model whose own `state_dict` is saved to a temp file at the expected `weights/pretrained.pt` path, then verifies all parameters are correctly restored after loading
- Cleans up the temp weights file in a `finally` block

#### What should a reviewer concentrate their feedback on?

- The test logic in `test_load_pretrained_weights_from_local_file`: whether the temp file setup and cleanup is correct
- Whether the path construction using `__import__` to locate the `weights/` directory is acceptable

#### Did you add any tests for the change?

- Added `test_load_pretrained_weights_from_local_file` to `TestAptaTransModel`
- Only `test_aptatrans.py` is modified; no new files added

#### Any other comments?

No changes to production code. Pure test coverage improvement for the local weights loading branch.

#### PR checklist

- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
  To run hooks independent of commit, execute `pre-commit run --all-files`