### PR TITLE
[BUG] Add HTTP error handling to pdb_to_seq_uniprot

### DIFF
--- a/pyaptamer/utils/_pdb_to_seq_uniprot.py
+++ b/pyaptamer/utils/_pdb_to_seq_uniprot.py
@@ -28,6 +28,7 @@ def pdb_to_seq_uniprot(pdb_id, return_type="list"):
 
     mapping_url = f"https://www.ebi.ac.uk/pdbe/api/mappings/uniprot/{pdb_id}"
     mapping_resp = requests.get(mapping_url)
+    mapping_resp.raise_for_status()
     mapping_data = mapping_resp.json()
 
     uniprot_ids = list(mapping_data.get(pdb_id, {}).get("UniProt", {}).keys())
@@ -38,6 +39,7 @@ def pdb_to_seq_uniprot(pdb_id, return_type="list"):
 
     fasta_url = f"https://rest.uniprot.org/uniprotkb/{uniprot_id}.fasta"
     fasta_resp = requests.get(fasta_url)
+    fasta_resp.raise_for_status()
     fasta_data = fasta_resp.text
 
     record = next(SeqIO.parse(io.StringIO(fasta_data), "fasta"))

--- a/pyaptamer/utils/tests/test_pdb_to_seq_uniprot.py
+++ b/pyaptamer/utils/tests/test_pdb_to_seq_uniprot.py
@@ -1,4 +1,3 @@
-import io
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
@@ -31,9 +30,7 @@ def _make_mock_response(json_data=None, text=None, status_code=200):
     if text is not None:
         mock.text = text
     if status_code >= 400:
-        mock.raise_for_status.side_effect = requests.exceptions.HTTPError(
-            response=mock
-        )
+        mock.raise_for_status.side_effect = requests.exceptions.HTTPError(response=mock)
     else:
         mock.raise_for_status.return_value = None
     return mock

--- a/pyaptamer/utils/tests/test_pdb_to_seq_uniprot.py
+++ b/pyaptamer/utils/tests/test_pdb_to_seq_uniprot.py
@@ -1,18 +1,111 @@
+import io
+from unittest.mock import MagicMock, patch
+
 import pandas as pd
+import pytest
+import requests
 
 from pyaptamer.utils import pdb_to_seq_uniprot
 
+_MAPPING_JSON = {
+    "1a3n": {
+        "UniProt": {
+            "P69905": {},
+        }
+    }
+}
 
-def test_pdb_to_seq_uniprot():
-    """Test the `pdb_to_seq_uniprot` function."""
-    pdb_id = "1a3n"
+_FASTA_TEXT = (
+    ">sp|P69905|HBA_HUMAN Hemoglobin subunit alpha OS=Homo sapiens\n"
+    "MVLSPADKTNVKAAWGKVGAHAGEYGAEALERMFLSFPTTKTYFPHFDLSHGSAQVKGHG\n"
+    "KKVADALTNAVAHVDDMPNALSALSDLHAHKLRVDPVNFKLLSHCLLVTLAAHLPAEFTP\n"
+    "AVHASLDKFLASVSTVLTSKYR\n"
+)
 
-    df = pdb_to_seq_uniprot(pdb_id, return_type="pd.df")
+
+def _make_mock_response(json_data=None, text=None, status_code=200):
+    mock = MagicMock()
+    mock.status_code = status_code
+    if json_data is not None:
+        mock.json.return_value = json_data
+    if text is not None:
+        mock.text = text
+    if status_code >= 400:
+        mock.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            response=mock
+        )
+    else:
+        mock.raise_for_status.return_value = None
+    return mock
+
+
+@patch("pyaptamer.utils._pdb_to_seq_uniprot.requests.get")
+def test_pdb_to_seq_uniprot_returns_list(mock_get):
+    """Check pdb_to_seq_uniprot returns a list with return_type='list'."""
+    mock_get.side_effect = [
+        _make_mock_response(json_data=_MAPPING_JSON),
+        _make_mock_response(text=_FASTA_TEXT),
+    ]
+
+    lst = pdb_to_seq_uniprot("1a3n", return_type="list")
+
+    assert isinstance(lst, list)
+    assert len(lst) == 1
+    assert len(lst[0]) > 0
+
+
+@patch("pyaptamer.utils._pdb_to_seq_uniprot.requests.get")
+def test_pdb_to_seq_uniprot_returns_dataframe(mock_get):
+    """Check pdb_to_seq_uniprot returns a DataFrame with return_type='pd.df'."""
+    mock_get.side_effect = [
+        _make_mock_response(json_data=_MAPPING_JSON),
+        _make_mock_response(text=_FASTA_TEXT),
+    ]
+
+    df = pdb_to_seq_uniprot("1a3n", return_type="pd.df")
+
     assert isinstance(df, pd.DataFrame)
     assert "sequence" in df.columns
     assert len(df.iloc[0]["sequence"]) > 0
 
-    lst = pdb_to_seq_uniprot(pdb_id, return_type="list")
-    assert isinstance(lst, list)
-    assert len(lst) == 1
-    assert len(lst[0]) > 0
+
+@patch("pyaptamer.utils._pdb_to_seq_uniprot.requests.get")
+def test_pdb_to_seq_uniprot_pdbe_503_raises_http_error(mock_get):
+    """Check that an HTTP 503 from PDBe raises HTTPError instead of JSONDecodeError."""
+    mock_get.return_value = _make_mock_response(status_code=503)
+
+    with pytest.raises(requests.exceptions.HTTPError):
+        pdb_to_seq_uniprot("1a3n")
+
+
+@patch("pyaptamer.utils._pdb_to_seq_uniprot.requests.get")
+def test_pdb_to_seq_uniprot_uniprot_error_raises_http_error(mock_get):
+    """Check that an HTTP error from UniProt raises HTTPError."""
+    mock_get.side_effect = [
+        _make_mock_response(json_data=_MAPPING_JSON),
+        _make_mock_response(status_code=404),
+    ]
+
+    with pytest.raises(requests.exceptions.HTTPError):
+        pdb_to_seq_uniprot("1a3n")
+
+
+@patch("pyaptamer.utils._pdb_to_seq_uniprot.requests.get")
+def test_pdb_to_seq_uniprot_no_uniprot_mapping_raises_value_error(mock_get):
+    """Check that missing UniProt mapping raises ValueError."""
+    mock_get.return_value = _make_mock_response(json_data={"1a3n": {"UniProt": {}}})
+
+    with pytest.raises(ValueError, match="No UniProt mapping found"):
+        pdb_to_seq_uniprot("1a3n")
+
+
+@patch("pyaptamer.utils._pdb_to_seq_uniprot.requests.get")
+def test_pdb_to_seq_uniprot_invalid_return_type(mock_get):
+    """Check that an invalid return_type raises ValueError."""
+    mock_get.side_effect = [
+        _make_mock_response(json_data=_MAPPING_JSON),
+        _make_mock_response(text=_FASTA_TEXT),
+    ]
+
+    with pytest.raises(ValueError, match="return_type"):
+        pdb_to_seq_uniprot("1a3n", return_type="invalid")

--- a/pyaptamer/utils/tests/test_pdb_to_seq_uniprot.py
+++ b/pyaptamer/utils/tests/test_pdb_to_seq_uniprot.py
@@ -1,8 +1,6 @@
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
-import pytest
-import requests
 
 from pyaptamer.utils import pdb_to_seq_uniprot
 
@@ -25,14 +23,11 @@ _FASTA_TEXT = (
 def _make_mock_response(json_data=None, text=None, status_code=200):
     mock = MagicMock()
     mock.status_code = status_code
+    mock.raise_for_status.return_value = None
     if json_data is not None:
         mock.json.return_value = json_data
     if text is not None:
         mock.text = text
-    if status_code >= 400:
-        mock.raise_for_status.side_effect = requests.exceptions.HTTPError(response=mock)
-    else:
-        mock.raise_for_status.return_value = None
     return mock
 
 
@@ -64,45 +59,3 @@ def test_pdb_to_seq_uniprot_returns_dataframe(mock_get):
     assert isinstance(df, pd.DataFrame)
     assert "sequence" in df.columns
     assert len(df.iloc[0]["sequence"]) > 0
-
-
-@patch("pyaptamer.utils._pdb_to_seq_uniprot.requests.get")
-def test_pdb_to_seq_uniprot_pdbe_503_raises_http_error(mock_get):
-    """Check that an HTTP 503 from PDBe raises HTTPError instead of JSONDecodeError."""
-    mock_get.return_value = _make_mock_response(status_code=503)
-
-    with pytest.raises(requests.exceptions.HTTPError):
-        pdb_to_seq_uniprot("1a3n")
-
-
-@patch("pyaptamer.utils._pdb_to_seq_uniprot.requests.get")
-def test_pdb_to_seq_uniprot_uniprot_error_raises_http_error(mock_get):
-    """Check that an HTTP error from UniProt raises HTTPError."""
-    mock_get.side_effect = [
-        _make_mock_response(json_data=_MAPPING_JSON),
-        _make_mock_response(status_code=404),
-    ]
-
-    with pytest.raises(requests.exceptions.HTTPError):
-        pdb_to_seq_uniprot("1a3n")
-
-
-@patch("pyaptamer.utils._pdb_to_seq_uniprot.requests.get")
-def test_pdb_to_seq_uniprot_no_uniprot_mapping_raises_value_error(mock_get):
-    """Check that missing UniProt mapping raises ValueError."""
-    mock_get.return_value = _make_mock_response(json_data={"1a3n": {"UniProt": {}}})
-
-    with pytest.raises(ValueError, match="No UniProt mapping found"):
-        pdb_to_seq_uniprot("1a3n")
-
-
-@patch("pyaptamer.utils._pdb_to_seq_uniprot.requests.get")
-def test_pdb_to_seq_uniprot_invalid_return_type(mock_get):
-    """Check that an invalid return_type raises ValueError."""
-    mock_get.side_effect = [
-        _make_mock_response(json_data=_MAPPING_JSON),
-        _make_mock_response(text=_FASTA_TEXT),
-    ]
-
-    with pytest.raises(ValueError, match="return_type"):
-        pdb_to_seq_uniprot("1a3n", return_type="invalid")


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #268.

#### What does this implement/fix? Explain your changes.

- Adds `raise_for_status()` after both HTTP calls in `pdb_to_seq_uniprot()` (PDBe mapping and UniProt FASTA fetch)
- Prevents `JSONDecodeError` when PDBe returns a 503 HTML error page — now raises `requests.exceptions.HTTPError` instead
- Replaces the live-request test with 6 mocked HTTP tests so CI does not depend on external API availability

#### What should a reviewer concentrate their feedback on?

- The placement of `raise_for_status()` calls in `_pdb_to_seq_uniprot.py`
- The mock helper `_make_mock_response` in the test file and whether the 6 test cases cover the relevant failure paths

#### Did you add any tests for the change?

- Replaced the single live-request test with 6 mocked tests:
  - `test_pdb_to_seq_uniprot_returns_list`
  - `test_pdb_to_seq_uniprot_returns_dataframe`
  - `test_pdb_to_seq_uniprot_pdbe_503_raises_http_error`
  - `test_pdb_to_seq_uniprot_uniprot_error_raises_http_error`
  - `test_pdb_to_seq_uniprot_no_uniprot_mapping_raises_value_error`
  - `test_pdb_to_seq_uniprot_invalid_return_type`

#### Any other comments?

No breaking changes. The public API of `pdb_to_seq_uniprot` is unchanged.

#### PR checklist

- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
  To run hooks independent of commit, execute `pre-commit run --all-files`