### PR TITLE
[BUG]: Fixes AMP finetuning crash by using BCEWithLogitsLoss

### DIFF
--- a/pyaptamer/aptatrans/_model.py
+++ b/pyaptamer/aptatrans/_model.py
@@ -162,7 +162,6 @@ class AptaTrans(nn.Module):
                     ("linear1", nn.Linear(self.inplanes, self.inplanes // 2)),
                     ("activation1", nn.GELU()),
                     ("linear2", nn.Linear(self.inplanes // 2, 1)),
-                    ("activation2", nn.Sigmoid()),
                 ]
             )
         )
@@ -378,5 +377,27 @@ class AptaTrans(nn.Module):
         out = self.avgpool(out)
         out = torch.flatten(out, 1)
         out = self.fc(out)
+
+        return out
+
+    def predict_proba(self, x_apta: Tensor, x_prot: Tensor) -> Tensor:
+        """Predict interaction probabilities.
+
+        This method applies a sigmoid activation to the raw logits produced by
+        the forward pass to return probabilities in the range [0, 1].
+
+        Parameters
+        ----------
+        x_apta, x_prot : Tensor
+            Input tensors for aptamers and proteins, respectively. Shapes are
+            (batch_size, seq_len (s1)) and (batch_size, seq_len (s2)), respectively.
+
+        Returns
+        -------
+        Tensor
+            Output tensor of shape (batch_size, 1) containing interaction probabilities.
+        """
+        out = self.forward(x_apta=x_apta, x_prot=x_prot)
+        out = torch.sigmoid(out)
 
         return out

--- a/pyaptamer/aptatrans/_model_lightning.py
+++ b/pyaptamer/aptatrans/_model_lightning.py
@@ -102,10 +102,10 @@ class AptaTransLightning(L.LightningModule):
         # (input aptamers, input proteins, ground-truth targets)
         x_apta, x_prot, y = batch
         y_hat = torch.flatten(self.model(x_apta, x_prot))
-        loss = F.binary_cross_entropy(y_hat, y.float())
+        loss = F.binary_cross_entropy_with_logits(y_hat, y.float())
 
         # compute accuracy
-        y_pred = (y_hat > 0.5).float()
+        y_pred = (y_hat > 0.0).float()
         accuracy = (y_pred == y.float()).float().mean()
 
         self._log_metric(f"{stage}_loss", loss)

--- a/pyaptamer/aptatrans/tests/test_aptatrans.py
+++ b/pyaptamer/aptatrans/tests/test_aptatrans.py
@@ -128,7 +128,7 @@ class TestAptaTransModel:
         in_dim: int,
         seq_len: int,
     ) -> None:
-        """Check forward pass on specified device."""
+        """Check forward pass outputs raw logits on specified device."""
         aptatrans = AptaTrans(
             apta_embedding=embeddings[0],
             prot_embedding=embeddings[1],
@@ -153,6 +153,60 @@ class TestAptaTransModel:
 
         # forward pass
         output = aptatrans(x_apta, x_prot)
+
+        # output should be raw logits
+        assert output.shape == (batch_size, 1)
+        assert not torch.allclose(output[0], output[1], atol=1e-5)
+
+    @pytest.mark.parametrize(
+        "device, batch_size, in_dim, seq_len",
+        [
+            (torch.device("cpu"), 4, 32, 10),
+            pytest.param(
+                torch.device("cuda"),
+                4,
+                32,
+                10,
+                marks=pytest.mark.skipif(
+                    not torch.cuda.is_available(), reason="CUDA not available"
+                ),
+            ),
+        ],
+    )
+    @torch.no_grad()
+    def test_predict_proba(
+        self,
+        embeddings: tuple[EncoderPredictorConfig, EncoderPredictorConfig],
+        device: torch.device,
+        batch_size: int,
+        in_dim: int,
+        seq_len: int,
+    ) -> None:
+        """Check predict_proba returns probabilities in [0, 1] on specified device."""
+        aptatrans = AptaTrans(
+            apta_embedding=embeddings[0],
+            prot_embedding=embeddings[1],
+            in_dim=in_dim,
+            n_encoder_layers=2,
+            n_heads=4,
+            conv_layers=[2, 2, 2],
+            dropout=0.1,
+        ).to(device)
+
+        # dummy input tensors
+        x_apta = torch.randint(
+            high=embeddings[0].num_embeddings,
+            size=(batch_size, seq_len),
+            dtype=torch.long,
+        ).to(device)
+        x_prot = torch.randint(
+            high=embeddings[1].num_embeddings,
+            size=(batch_size, seq_len),
+            dtype=torch.long,
+        ).to(device)
+
+        # forward pass
+        output = aptatrans.predict_proba(x_apta, x_prot)
 
         assert output.shape == (batch_size, 1)
         # output should be in [0, 1] (sigmoid activation)


### PR DESCRIPTION
#### Reference Issues/PRs
fixes #230 

#### What does this implement/fix? Explain your changes.
This PR resolves the AMP crash that occurs during fine-tuning.

- Removes the sigmoid activation from `AptaTrans.forward()` so it natively outputs raw logits.
- Adds `predict_proba()` method to allow users to extract `[0, 1]` probabilities when needed.
- Updates the fine-tuning step to use `F.binary_cross_entropy_with_logits`. Updates the accuracy threshold as well.
- Updates existing `test_forward` and adds new test for `predic_proba`.

#### Did you add any tests for the change?
Yes

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
  To run hooks independent of commit, execute `pre-commit run --all-files`