### PR TITLE
fix: add proper HTTP error handling in pdb_to_seq_uniprot

### DIFF
--- a/pyaptamer/utils/_pdb_to_seq_uniprot.py
+++ b/pyaptamer/utils/_pdb_to_seq_uniprot.py
@@ -28,6 +28,7 @@ def pdb_to_seq_uniprot(pdb_id, return_type="list"):
 
     mapping_url = f"https://www.ebi.ac.uk/pdbe/api/mappings/uniprot/{pdb_id}"
     mapping_resp = requests.get(mapping_url)
+    mapping_resp.raise_for_status()
     mapping_data = mapping_resp.json()
 
     uniprot_ids = list(mapping_data.get(pdb_id, {}).get("UniProt", {}).keys())
@@ -38,6 +39,7 @@ def pdb_to_seq_uniprot(pdb_id, return_type="list"):
 
     fasta_url = f"https://rest.uniprot.org/uniprotkb/{uniprot_id}.fasta"
     fasta_resp = requests.get(fasta_url)
+    fasta_resp.raise_for_status()
     fasta_data = fasta_resp.text
 
     record = next(SeqIO.parse(io.StringIO(fasta_data), "fasta"))

--- a/pyaptamer/utils/tests/test_pdb_to_seq_uniprot.py
+++ b/pyaptamer/utils/tests/test_pdb_to_seq_uniprot.py
@@ -1,4 +1,10 @@
+import io
+from unittest.mock import patch
+
 import pandas as pd
+import pytest
+import requests
+from Bio import SeqIO
 
 from pyaptamer.utils import pdb_to_seq_uniprot
 
@@ -16,3 +22,118 @@ def test_pdb_to_seq_uniprot():
     assert isinstance(lst, list)
     assert len(lst) == 1
     assert len(lst[0]) > 0
+
+
+@patch("pyaptamer.utils._pdb_to_seq_uniprot.requests.get")
+def test_pdb_to_seq_uniprot_pdbe_http_error(mock_get):
+    """Test that PDBe API HTTP errors raise requests.HTTPError, not JSONDecodeError."""
+    # Mock the first call (PDBe mapping) to return 503 with HTML body
+    mock_response_503 = requests.Response()
+    mock_response_503.status_code = 503
+    mock_response_503._content = b"<html><body>Service Temporarily Unavailable</body></html>"
+    mock_response_503.reason = "Service Unavailable"
+
+    # Configure mock to return 503 for PDBe URL
+    mock_get.return_value = mock_response_503
+
+    with pytest.raises(requests.HTTPError) as excinfo:
+        pdb_to_seq_uniprot("1a3n")
+
+    assert "503" in str(excinfo.value)
+
+
+@patch("pyaptamer.utils._pdb_to_seq_uniprot.requests.get")
+def test_pdb_to_seq_uniprot_pdbe_404(mock_get):
+    """Test that PDBe API 404 raises HTTPError."""
+    mock_response_404 = requests.Response()
+    mock_response_404.status_code = 404
+    mock_response_404._content = b"<html><body>Not Found</body></html>"
+    mock_response_404.reason = "Not Found"
+
+    mock_get.return_value = mock_response_404
+
+    with pytest.raises(requests.HTTPError) as excinfo:
+        pdb_to_seq_uniprot("nonexistent")
+
+    assert "404" in str(excinfo.value)
+
+
+@patch("pyaptamer.utils._pdb_to_seq_uniprot.requests.get")
+def test_pdb_to_seq_uniprot_uniprot_http_error(mock_get):
+    """Test that UniProt API HTTP errors raise requests.HTTPError."""
+    # First call (PDBe) returns valid mapping
+    pdbe_response = requests.Response()
+    pdbe_response.status_code = 200
+    pdbe_response._content = b'{"1a3n": {"UniProt": {"P12345": {}}}}'
+
+    # Second call (UniProt) returns 503
+    uniprot_response = requests.Response()
+    uniprot_response.status_code = 503
+    uniprot_response._content = b"<html><body>Service Unavailable</body></html>"
+    uniprot_response.reason = "Service Unavailable"
+
+    mock_get.side_effect = [pdbe_response, uniprot_response]
+
+    with pytest.raises(requests.HTTPError) as excinfo:
+        pdb_to_seq_uniprot("1a3n")
+
+    assert "503" in str(excinfo.value)
+
+
+@patch("pyaptamer.utils._pdb_to_seq_uniprot.requests.get")
+def test_pdb_to_seq_uniprot_uniprot_404(mock_get):
+    """Test that UniProt API 404 raises HTTPError."""
+    pdbe_response = requests.Response()
+    pdbe_response.status_code = 200
+    pdbe_response._content = b'{"1a3n": {"UniProt": {"P12345": {}}}}'
+
+    uniprot_response = requests.Response()
+    uniprot_response.status_code = 404
+    uniprot_response._content = b"<html><body>Not Found</body></html>"
+    uniprot_response.reason = "Not Found"
+
+    mock_get.side_effect = [pdbe_response, uniprot_response]
+
+    with pytest.raises(requests.HTTPError) as excinfo:
+        pdb_to_seq_uniprot("1a3n")
+
+    assert "404" in str(excinfo.value)
+
+
+@patch("pyaptamer.utils._pdb_to_seq_uniprot.requests.get")
+def test_pdb_to_seq_uniprot_success_list(mock_get):
+    """Test successful retrieval with mocked responses, returning list."""
+    pdbe_response = requests.Response()
+    pdbe_response.status_code = 200
+    pdbe_response._content = b'{"1a3n": {"UniProt": {"P12345": {"mappings": []}}}}'
+
+    fasta_content = b">sp|P12345|Test protein\nMKTIIALSYIFCLVFADYKDDDKG"
+    uniprot_response = requests.Response()
+    uniprot_response.status_code = 200
+    uniprot_response._content = fasta_content
+
+    mock_get.side_effect = [pdbe_response, uniprot_response]
+
+    result = pdb_to_seq_uniprot("1a3n", return_type="list")
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0] == "MKTIIALSYIFCLVFADYKDDDKG"
+
+
+@patch("pyaptamer.utils._pdb_to_seq_uniprot.requests.get")
+def test_pdb_to_seq_uniprot_success_df(mock_get):
+    """Test successful retrieval with mocked responses, returning DataFrame."""
+    pdbe_response = requests.Response()
+    pdbe_response.status_code = 200
+    pdbe_response._content = b'{"1a3n": {"UniProt": {"P12345": {"mappings": []}}}}'
+
+    fasta_content = b">sp|P12345|Test protein\nMKTIIALSYIFCLVFADYKDDDKG"
+    uniprot_response = requests.Response()
+    uniprot_response.status_code = 200
+    uniprot_response._content = fasta_content
+
+    mock_get.side_effect = [pdbe_response, uniprot_response]
+
+    df = pdb_to_seq_uniprot("1a3n", return_type="pd.df")
+    assert isinstance(df, pd.DataFrame)
+    assert df["sequence"].iloc[0] == "MKTIIALSYIFCLVFADYKDDDKG"


### PR DESCRIPTION
## Summary

Fixed bug in `pdb_to_seq_uniprot()` where HTTP errors from PDBe or UniProt APIs would cause confusing `JSONDecodeError` instead of clear HTTP error exceptions.

## Problem

When the PDBe endpoint returned 503 Service Temporarily Unavailable, the code attempted to call `.json()` on an HTML error page, raising `requests.exceptions.JSONDecodeError` instead of a more helpful HTTP error.

## Solution

Added `.raise_for_status()` calls to both API requests:
- PDBe mapping API response (line 31)
- UniProt FASTA API response (line 42)

This ensures that any 4xx or 5xx responses raise `requests.HTTPError` with a clear message including the status code and URL.

## Changes

- `pyaptamer/utils/_pdb_to_seq_uniprot.py`: Added `raise_for_status()` calls
- `pyaptamer/utils/tests/test_pdb_to_seq_uniprot.py`: Added comprehensive test coverage for HTTP errors (503, 404) on both APIs, plus mocked success tests

## Test plan

All 7 tests pass:
- ✅ test_pdb_to_seq_uniprot (live API integration test)
- ✅ test_pdb_to_seq_uniprot_pdbe_http_error (503 handling)
- ✅ test_pdb_to_seq_uniprot_pdbe_404
- ✅ test_pdb_to_seq_uniprot_uniprot_http_error (503 handling)
- ✅ test_pdb_to_seq_uniprot_uniprot_404
- ✅ test_pdb_to_seq_uniprot_success_list
- ✅ test_pdb_to_seq_uniprot_success_df

Fixes: https://github.com/gc-os-ai/pyaptamer/issues