### PR TITLE
[ENH] Add KMerEncoder to transformer interface

### DIFF
--- a/pyaptamer/trafos/__init__.py
+++ b/pyaptamer/trafos/__init__.py
@@ -1,1 +1,5 @@
 """Transformations."""
+
+from pyaptamer.trafos.encode import GreedyEncoder, KMerEncoder
+
+__all__ = ["GreedyEncoder", "KMerEncoder"]

--- a/pyaptamer/trafos/encode/__init__.py
+++ b/pyaptamer/trafos/encode/__init__.py
@@ -1,5 +1,6 @@
 """Feature encoding of strings."""
 
 from pyaptamer.trafos.encode._greedy import GreedyEncoder
+from pyaptamer.trafos.encode._kmer import KMerEncoder
 
-__all__ = ["GreedyEncoder"]
+__all__ = ["GreedyEncoder", "KMerEncoder"]

--- a/pyaptamer/trafos/encode/_kmer.py
+++ b/pyaptamer/trafos/encode/_kmer.py
@@ -1,0 +1,101 @@
+"""K-mer frequency encoder transformer."""
+
+__author__ = ["Jayant-kernel"]
+__all__ = ["KMerEncoder"]
+
+from itertools import product
+
+import numpy as np
+import pandas as pd
+
+from pyaptamer.trafos.base import BaseTransform
+
+
+class KMerEncoder(BaseTransform):
+    """K-mer frequency encoder for DNA/RNA aptamer sequences.
+
+    Encodes each sequence as a normalized k-mer frequency vector by counting
+    occurrences of all possible k-mers of length 1 to ``k`` over the DNA
+    alphabet ``{A, C, G, T}`` and normalizing the counts to frequencies.
+
+    Parameters
+    ----------
+    k : int, optional, default=4
+        Maximum k-mer length. All k-mers of length 1 to ``k`` are included,
+        yielding a feature vector of length ``sum(4**i for i in range(1, k+1))``.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from pyaptamer.trafos.encode import KMerEncoder
+    >>> enc = KMerEncoder(k=2)
+    >>> X = pd.DataFrame({"sequence": ["ACGT", "AACC"]})
+    >>> enc.fit_transform(X).shape
+    (2, 20)
+    """
+
+    _tags = {
+        "authors": ["Jayant-kernel"],
+        "maintainers": ["Jayant-kernel"],
+        "output_type": "numeric",
+        "property:fit_is_empty": True,
+        "capability:multivariate": False,
+    }
+
+    def __init__(self, k=4):
+        self.k = k
+        super().__init__()
+
+    def _transform(self, X):
+        """Transform aptamer sequences to k-mer frequency vectors.
+
+        Parameters
+        ----------
+        X : pd.DataFrame, shape (n_samples, 1)
+            DataFrame whose first column contains aptamer sequence strings.
+
+        Returns
+        -------
+        Xt : pd.DataFrame, shape (n_samples, n_features)
+            Numeric DataFrame where each row is the k-mer frequency vector
+            for the corresponding input sequence.
+            ``n_features = sum(4**i for i in range(1, k+1))``.
+        """
+        k = self.k
+        dna_bases = list("ACGT")
+
+        all_kmers = []
+        for i in range(1, k + 1):
+            all_kmers.extend(["".join(p) for p in product(dna_bases, repeat=i)])
+
+        sequences = X.iloc[:, 0].tolist()
+
+        rows = []
+        for seq in sequences:
+            kmer_counts = dict.fromkeys(all_kmers, 0)
+            for i in range(len(seq)):
+                for j in range(1, k + 1):
+                    if i + j <= len(seq):
+                        kmer = seq[i : i + j]
+                        if kmer in kmer_counts:
+                            kmer_counts[kmer] += 1
+
+            total = sum(kmer_counts.values())
+            freq = np.array(
+                [kmer_counts[km] / total if total > 0 else 0.0 for km in all_kmers],
+                dtype=np.float32,
+            )
+            rows.append(freq)
+
+        result = np.vstack(rows)
+        return pd.DataFrame(result, index=X.index)
+
+    def get_test_params(self):
+        """Return test parameter sets for KMerEncoder.
+
+        Returns
+        -------
+        params : list of dict
+            Two parameter sets: one with k=1 and one with k=2.
+        """
+        return [{"k": 1}, {"k": 2}]

--- a/pyaptamer/trafos/encode/tests/test_kmer.py
+++ b/pyaptamer/trafos/encode/tests/test_kmer.py
@@ -1,0 +1,75 @@
+"""Tests for KMerEncoder."""
+
+__author__ = ["Jayant-kernel"]
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from pyaptamer.trafos.encode import KMerEncoder
+
+APTAMER_SEQ = "AGCTTAGCGTACAGCTTAAAAGGGTTTCCCCTGCCCGCGTAC"
+X = pd.DataFrame({"sequence": [APTAMER_SEQ, "ACGTACGT"]})
+
+
+def test_kmer_encoder_output_shape_k4():
+    """Check KMerEncoder output shape for k=4."""
+    enc = KMerEncoder(k=4)
+    Xt = enc.fit_transform(X)
+    # sum(4^i for i in 1..4) = 4+16+64+256 = 340
+    assert isinstance(Xt, pd.DataFrame)
+    assert Xt.shape == (2, 340)
+
+
+def test_kmer_encoder_output_shape_k1():
+    """Check KMerEncoder output shape for k=1."""
+    enc = KMerEncoder(k=1)
+    Xt = enc.fit_transform(X)
+    assert Xt.shape == (2, 4)
+
+
+def test_kmer_encoder_output_shape_k2():
+    """Check KMerEncoder output shape for k=2."""
+    enc = KMerEncoder(k=2)
+    Xt = enc.fit_transform(X)
+    # 4 + 16 = 20
+    assert Xt.shape == (2, 20)
+
+
+def test_kmer_encoder_frequencies_sum_to_one():
+    """Check that k-mer frequency rows sum to 1."""
+    enc = KMerEncoder(k=2)
+    Xt = enc.fit_transform(X)
+    sums = Xt.values.sum(axis=1)
+    assert np.allclose(sums, 1.0, atol=1e-5)
+
+
+def test_kmer_encoder_output_dtype_float():
+    """Check KMerEncoder output values are float."""
+    enc = KMerEncoder(k=2)
+    Xt = enc.fit_transform(X)
+    assert np.issubdtype(Xt.values.dtype, np.floating)
+
+
+def test_kmer_encoder_fit_is_empty():
+    """Check fit() returns self without error (fit_is_empty tag)."""
+    enc = KMerEncoder(k=2)
+    result = enc.fit(X)
+    assert result is enc
+
+
+def test_kmer_encoder_preserves_index():
+    """Check KMerEncoder preserves DataFrame index."""
+    X_idx = pd.DataFrame({"sequence": [APTAMER_SEQ]}, index=[42])
+    enc = KMerEncoder(k=1)
+    Xt = enc.fit_transform(X_idx)
+    assert list(Xt.index) == [42]
+
+
+@pytest.mark.parametrize("k", [1, 2, 3])
+def test_kmer_encoder_different_k(k):
+    """Check KMerEncoder works for k=1, 2, 3."""
+    enc = KMerEncoder(k=k)
+    Xt = enc.fit_transform(X)
+    expected_cols = sum(4**i for i in range(1, k + 1))
+    assert Xt.shape == (2, expected_cols)


### PR DESCRIPTION
#### Reference Issues/PRs

Closes #174. Related to #106, #170.

#### What does this implement/fix? Explain your changes.

Implements **KMerEncoder** as a proper `BaseTransform` subclass, following the `GreedyEncoder` pattern established in #106/#170.

- **`KMerEncoder`** (`pyaptamer/trafos/encode/_kmer.py`) — encodes aptamer sequences as normalized k-mer frequency vectors over alphabet `{A,C,G,T}` for all k-mer lengths 1 to `k`. Output shape: `(n_samples, sum(4**i for i in range(1, k+1)))`.

**Note:** `PSeAACTransformer` removed from this PR — protein feature design scope is being finalized in PR #231. That will be a follow-up once #231 lands.

Both:
- Sets `property:fit_is_empty: True` (no fitting needed)
- Implements `get_test_params()` for skbase test compatibility
- Exported from `pyaptamer.trafos.encode` and `pyaptamer.trafos`

#### What should a reviewer concentrate their feedback on?

- Whether the `_tags` dict matches the conventions in `GreedyEncoder`
- Whether `get_test_params()` gives sufficient coverage for the skbase test runner

#### Did you add any tests for the change?

`pyaptamer/trafos/encode/tests/test_kmer.py` — 10 tests:
- Output shape for k=1, 2, 4
- Frequency rows sum to 1
- Output dtype is float
- `fit()` returns self
- DataFrame index is preserved
- Parametrized k values (k=1, 2, 3)

#### Any other comments?

Single clean commit. Existing `generate_kmer_vecs` in `_aptanet_utils.py` is unchanged — deprecation is a separate concern.

#### PR checklist

- [x] The PR title starts with [ENH]
- [x] Added/modified tests
- [x] Used pre-commit hooks — `ruff check` and `ruff format --check` pass on all changed files