### PR TITLE
[ENH] Increase AptaTrans test coverage

### DIFF
--- a/pyaptamer/aptatrans/layers/tests/test_all_aptatrans_layers.py
+++ b/pyaptamer/aptatrans/layers/tests/test_all_aptatrans_layers.py
@@ -208,3 +208,14 @@ def test_interaction_map_mismatch_input_features(x_apta, x_prot):
         match="The number of features of `x_apta` and `x_prot` must match",
     ):
         interaction_map(x_apta, x_prot)
+
+
+def test_positional_encoding_exceeds_max_len():
+    """Check PositionalEncoding raises AssertionError when seq_len > max_len."""
+    max_len = 10
+    d_model = 64
+    pe = PositionalEncoding(d_model=d_model, max_len=max_len)
+
+    x = torch.randn(2, max_len + 5, d_model)
+    with pytest.raises(AssertionError, match="exceeds maximum length"):
+        pe(x)

--- a/pyaptamer/aptatrans/tests/test_aptatrans.py
+++ b/pyaptamer/aptatrans/tests/test_aptatrans.py
@@ -262,21 +262,15 @@ class TestAptaTransModel:
             in_dim=32,
             n_heads=4,
         )
-        weights_dir = tmp_path / "weights"
-        weights_dir.mkdir()
-        weights_path = weights_dir / "pretrained.pt"
+        weights_path = tmp_path / "pretrained.pt"
         torch.save(model.state_dict(), weights_path)
 
-        state_dict = model.state_dict()
         monkeypatch.setattr(
             "pyaptamer.aptatrans._model.os.path.relpath",
             lambda *a, **kw: str(weights_path),
         )
         monkeypatch.setattr(
             "pyaptamer.aptatrans._model.os.path.exists", lambda *a, **kw: True
-        )
-        monkeypatch.setattr(
-            "pyaptamer.aptatrans._model.torch.load", lambda *a, **kw: state_dict
         )
         model.load_pretrained_weights()
 

--- a/pyaptamer/aptatrans/tests/test_aptatrans.py
+++ b/pyaptamer/aptatrans/tests/test_aptatrans.py
@@ -2,9 +2,6 @@
 
 __author__ = ["nennomp"]
 
-from pathlib import Path
-from unittest.mock import patch
-
 import pytest
 import torch
 import torch.nn as nn
@@ -255,7 +252,8 @@ class TestAptaTransModel:
     def test_load_pretrained_weights_local(
         self,
         embeddings: tuple[EncoderPredictorConfig, EncoderPredictorConfig],
-        tmp_path: Path,
+        tmp_path,
+        monkeypatch,
     ):
         """Check load_pretrained_weights() loads weights from a local file."""
         model = AptaTrans(
@@ -269,25 +267,23 @@ class TestAptaTransModel:
         weights_path = weights_dir / "pretrained.pt"
         torch.save(model.state_dict(), weights_path)
 
-        with (
-            patch(
-                "pyaptamer.aptatrans._model.os.path.relpath",
-                return_value=str(weights_path),
-            ),
-            patch(
-                "pyaptamer.aptatrans._model.os.path.exists",
-                return_value=True,
-            ),
-            patch(
-                "pyaptamer.aptatrans._model.torch.load",
-                return_value=model.state_dict(),
-            ),
-        ):
-            model.load_pretrained_weights()
+        state_dict = model.state_dict()
+        monkeypatch.setattr(
+            "pyaptamer.aptatrans._model.os.path.relpath",
+            lambda *a, **kw: str(weights_path),
+        )
+        monkeypatch.setattr(
+            "pyaptamer.aptatrans._model.os.path.exists", lambda *a, **kw: True
+        )
+        monkeypatch.setattr(
+            "pyaptamer.aptatrans._model.torch.load", lambda *a, **kw: state_dict
+        )
+        model.load_pretrained_weights()
 
     def test_load_pretrained_weights_remote(
         self,
         embeddings: tuple[EncoderPredictorConfig, EncoderPredictorConfig],
+        monkeypatch,
     ):
         """Check load_pretrained_weights() falls back to remote download."""
         model = AptaTrans(
@@ -297,20 +293,22 @@ class TestAptaTransModel:
             n_heads=4,
         )
         fake_state_dict = model.state_dict()
+        calls = []
 
-        with (
-            patch(
-                "pyaptamer.aptatrans._model.os.path.exists",
-                return_value=False,
-            ),
-            patch(
-                "pyaptamer.aptatrans._model.torch.hub.load_state_dict_from_url",
-                return_value=fake_state_dict,
-            ) as mock_download,
-        ):
-            model.load_pretrained_weights()
-            mock_download.assert_called_once()
-            assert "huggingface.co" in mock_download.call_args.kwargs["url"]
+        def fake_load_from_url(url, **kwargs):
+            calls.append(url)
+            return fake_state_dict
+
+        monkeypatch.setattr(
+            "pyaptamer.aptatrans._model.os.path.exists", lambda *a, **kw: False
+        )
+        monkeypatch.setattr(
+            "pyaptamer.aptatrans._model.torch.hub.load_state_dict_from_url",
+            fake_load_from_url,
+        )
+        model.load_pretrained_weights()
+        assert len(calls) == 1
+        assert "huggingface.co" in calls[0]
 
 
 class MockMCTS:
@@ -502,9 +500,9 @@ class TestAptaTransPipeline:
         assert score.device.type == device.type
 
     @pytest.mark.parametrize(
-        "device, target, n_candidates, depth",
+        "device, target, n_candidates, depth, verbose",
         [
-            (torch.device("cpu"), "AUGCAUGC", 3, 5),
+            (torch.device("cpu"), "AUGCAUGC", 3, 5, False),
             (
                 torch.device("cuda")
                 if torch.cuda.is_available()
@@ -512,10 +510,14 @@ class TestAptaTransPipeline:
                 "GCUAGCUA",
                 5,
                 10,
+                False,
             ),
+            (torch.device("cpu"), "AUGCAUGC", 2, 5, True),
         ],
     )
-    def test_recommend(self, device, target, n_candidates, depth, monkeypatch):
+    def test_recommend(
+        self, device, target, n_candidates, depth, verbose, monkeypatch, capsys
+    ):
         """Check AptaTransPipeline.recommend() generates candidate aptamers."""
         # setup
         model = MockAptaTransNeuralNet(device)
@@ -559,12 +561,16 @@ class TestAptaTransPipeline:
 
         monkeypatch.setattr("pyaptamer.aptatrans._pipeline.MCTS", MockMCTS)
 
-        # test recommendation
-        candidates = pipeline.recommend(target=target, n_candidates=n_candidates)
+        candidates = pipeline.recommend(
+            target=target, n_candidates=n_candidates, verbose=verbose
+        )
 
-        # check output
         assert isinstance(candidates, set)
-        assert len(candidates) == n_candidates  # should be exactly n_candidates
+        assert len(candidates) == n_candidates
+        if verbose:
+            captured = capsys.readouterr()
+            assert "Candidate:" in captured.out
+            assert "Score:" in captured.out
 
     @pytest.mark.parametrize(
         "device, candidate, target",
@@ -596,26 +602,3 @@ class TestAptaTransPipeline:
             model.apta_embedding.max_len,
             model.prot_embedding.max_len,
         )
-
-    def test_recommend_verbose(self, monkeypatch, capsys):
-        """Check recommend() with verbose=True prints candidate information."""
-        device = torch.device("cpu")
-        model = MockAptaTransNeuralNet(device)
-        prot_words = {"AUG": 0.8, "GCA": 0.6, "UGC": 0.4, "CUA": 0.2}
-        pipeline = AptaTransPipeline(
-            device=device, model=model, prot_words=prot_words, depth=5
-        )
-        n_candidates = 2
-
-        monkeypatch.setattr("pyaptamer.aptatrans._pipeline.MCTS", MockMCTS)
-        monkeypatch.setattr(pipeline, "_init_aptamer_experiment", lambda t: None)
-
-        candidates = pipeline.recommend(
-            target="AUGCAUGC", n_candidates=n_candidates, verbose=True
-        )
-
-        captured = capsys.readouterr()
-        assert isinstance(candidates, set)
-        assert len(candidates) == n_candidates
-        assert "Candidate:" in captured.out
-        assert "Score:" in captured.out

--- a/pyaptamer/aptatrans/tests/test_aptatrans.py
+++ b/pyaptamer/aptatrans/tests/test_aptatrans.py
@@ -2,6 +2,9 @@
 
 __author__ = ["nennomp"]
 
+from pathlib import Path
+from unittest.mock import patch
+
 import pytest
 import torch
 import torch.nn as nn
@@ -201,6 +204,129 @@ class TestAptaTransModel:
             f"Expected ({batch_size}, 1), got {tuple(output.shape)}. "
             f"seq_len_apta={seq_len_apta}, seq_len_prot={seq_len_prot}"
         )
+
+    def test_forward_encoder_invalid_type(
+        self,
+        embeddings: tuple[EncoderPredictorConfig, EncoderPredictorConfig],
+    ):
+        """Check ValueError is raised when encoder_type is not 'apta' or 'prot'."""
+        model = AptaTrans(
+            apta_embedding=embeddings[0],
+            prot_embedding=embeddings[1],
+            in_dim=32,
+            n_heads=4,
+        )
+        x = torch.randint(0, 16, (2, 8))
+        with pytest.raises(
+            ValueError,
+            match="Unknown encoder_type: invalid. Options are 'apta' or 'prot'.",
+        ):
+            model.forward_encoder(x=(x, x), encoder_type="invalid")
+
+    @pytest.mark.parametrize(
+        "batch_size, seq_len, n_pad",
+        [(4, 10, 3), (2, 8, 0), (4, 12, 6)],
+    )
+    def test_forward_encoder_with_padding(
+        self, batch_size: int, seq_len: int, n_pad: int
+    ):
+        """Check forward_encoder() handles zero-padded input with attention masking."""
+        embedding = EncoderPredictorConfig(
+            num_embeddings=32, target_dim=4, max_len=seq_len
+        )
+        model = AptaTrans(
+            apta_embedding=embedding,
+            prot_embedding=embedding,
+            in_dim=32,
+            n_encoder_layers=1,
+            n_heads=4,
+        )
+
+        x = torch.randint(1, 32, (batch_size, seq_len))
+        if n_pad > 0:
+            x[:, -n_pad:] = 0
+
+        x_mt, x_ss = x.clone(), x.clone()
+        y_mt, y_ss = model.forward_encoder(x=(x_mt, x_ss), encoder_type="apta")
+
+        assert y_mt.shape == (batch_size, seq_len, 32)
+        assert y_ss.shape == (batch_size, seq_len, 4)
+
+    def test_load_pretrained_weights_local(
+        self,
+        embeddings: tuple[EncoderPredictorConfig, EncoderPredictorConfig],
+        tmp_path: Path,
+    ):
+        """Check load_pretrained_weights() loads weights from a local file."""
+        model = AptaTrans(
+            apta_embedding=embeddings[0],
+            prot_embedding=embeddings[1],
+            in_dim=32,
+            n_heads=4,
+        )
+        weights_dir = tmp_path / "weights"
+        weights_dir.mkdir()
+        weights_path = weights_dir / "pretrained.pt"
+        torch.save(model.state_dict(), weights_path)
+
+        with (
+            patch(
+                "pyaptamer.aptatrans._model.os.path.relpath",
+                return_value=str(weights_path),
+            ),
+            patch(
+                "pyaptamer.aptatrans._model.os.path.exists",
+                return_value=True,
+            ),
+            patch(
+                "pyaptamer.aptatrans._model.torch.load",
+                return_value=model.state_dict(),
+            ),
+        ):
+            model.load_pretrained_weights()
+
+    def test_load_pretrained_weights_remote(
+        self,
+        embeddings: tuple[EncoderPredictorConfig, EncoderPredictorConfig],
+    ):
+        """Check load_pretrained_weights() falls back to remote download."""
+        model = AptaTrans(
+            apta_embedding=embeddings[0],
+            prot_embedding=embeddings[1],
+            in_dim=32,
+            n_heads=4,
+        )
+        fake_state_dict = model.state_dict()
+
+        with (
+            patch(
+                "pyaptamer.aptatrans._model.os.path.exists",
+                return_value=False,
+            ),
+            patch(
+                "pyaptamer.aptatrans._model.torch.hub.load_state_dict_from_url",
+                return_value=fake_state_dict,
+            ) as mock_download,
+        ):
+            model.load_pretrained_weights()
+            mock_download.assert_called_once()
+            assert "huggingface.co" in mock_download.call_args.kwargs["url"]
+
+
+class MockMCTS:
+    """Mock MCTS returning incrementally numbered aptamer candidates."""
+
+    def __init__(self, **kwargs):
+        self.counter = 0
+
+    def run(self, verbose: bool = False):
+        result = {
+            "candidate": f"APTAMER_{self.counter:03d}",
+            "sequence": f"seq_{self.counter}",
+            "score": torch.tensor(0.75),
+        }
+        self.counter += 1
+        return result
 
 
 class MockAptaTransNeuralNet(nn.Module):
@@ -470,3 +596,26 @@ class TestAptaTransPipeline:
             model.apta_embedding.max_len,
             model.prot_embedding.max_len,
         )
+
+    def test_recommend_verbose(self, monkeypatch, capsys):
+        """Check recommend() with verbose=True prints candidate information."""
+        device = torch.device("cpu")
+        model = MockAptaTransNeuralNet(device)
+        prot_words = {"AUG": 0.8, "GCA": 0.6, "UGC": 0.4, "CUA": 0.2}
+        pipeline = AptaTransPipeline(
+            device=device, model=model, prot_words=prot_words, depth=5
+        )
+        n_candidates = 2
+
+        monkeypatch.setattr("pyaptamer.aptatrans._pipeline.MCTS", MockMCTS)
+        monkeypatch.setattr(pipeline, "_init_aptamer_experiment", lambda t: None)
+
+        candidates = pipeline.recommend(
+            target="AUGCAUGC", n_candidates=n_candidates, verbose=True
+        )
+
+        captured = capsys.readouterr()
+        assert isinstance(candidates, set)
+        assert len(candidates) == n_candidates
+        assert "Candidate:" in captured.out
+        assert "Score:" in captured.out

--- a/pyaptamer/aptatrans/tests/test_aptatrans.py
+++ b/pyaptamer/aptatrans/tests/test_aptatrans.py
@@ -311,22 +311,6 @@ class TestAptaTransModel:
         assert "huggingface.co" in calls[0]
 
 
-class MockMCTS:
-    """Mock MCTS returning incrementally numbered aptamer candidates."""
-
-    def __init__(self, **kwargs):
-        self.counter = 0
-
-    def run(self, verbose: bool = False):
-        result = {
-            "candidate": f"APTAMER_{self.counter:03d}",
-            "sequence": f"seq_{self.counter}",
-            "score": torch.tensor(0.75),
-        }
-        self.counter += 1
-        return result
-
-
 class MockAptaTransNeuralNet(nn.Module):
     """Mock AptaTrans model for testing pipeline."""
 


### PR DESCRIPTION
<!--
Welcome to pyaptamer, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
Closes: #180 

#### What does this implement/fix? Explain your changes.
Added tests to improve coverage of AptaTrans-related modules:

- `test_positional_encoding_exceeds_max_len` - covers the AssertionError branch in PositionalEncoding.forward() when input exceeds max_len
- `test_forward_encoder_invalid_type` - covers the ValueError branch in forward_encoder() for unknown encoder_type
- `test_forward_encoder_with_padding` - covers the padding-mask branch in _make_encoder(), parametrized over inputs with and without zero-padding
- `test_load_pretrained_weights_local` / `test_load_pretrained_weights_remote` - covers both branches of load_pretrained_weights() (local file and hf download fallback)
- `test_recommend_verbose` - covers the verbose print path in AptaTransPipeline.recommend()

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?

Yes, all changes are new tests.

#### Any other comments?
<!--
We value all user contributions, no matter how small or complex they are. If you have any questions, feel free to post
in the dev-chat channel on the pyaptamer discord channel in gc-os server https://discord.gg/7uKdHfdcJG. If we are slow to review (>7 working days), likewise feel free to ping us on discord. Thank you for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
  To run hooks independent of commit, execute `pre-commit run --all-files`





## Before vs After test results

| Module | Stmts | Miss (before) | Cover (before) | Miss (after) | Cover (after) |
|---|---|---|---|---|---|
| `aptatrans/__init__.py` | 6 | 0 | 100% | 0 | 100% |
| `aptatrans/_model.py` | 82 | 10 | 88% | 1 | **99%** |
| `aptatrans/_model_lightning.py` | 54 | 6 | 89% | 6 | 89% |
| `aptatrans/_pipeline.py` | 43 | 0 | 100% | 0 | 100% |
| `layers/_convolutional.py` | 24 | 0 | 100% | 0 | 100% |
| `layers/_encoder.py` | 38 | 0 | 100% | 0 | 100% |
| `layers/_interaction_map.py` | 14 | 0 | 100% | 0 | 100% |
| `layers/tests/test_all_aptatrans_layers.py` | 78->85 | 0 | 100% | 0 | 100% |
| `tests/test_aptatrans.py` | 146->200 | 4 | 97% | 4 | 98% |
| `tests/test_aptatrans_lightning.py` | 70 | 0 | 100% | 0 | 100% |
| **TOTAL** | **560->621** | **20** | **96%** | **11** | **98%** |

**57 passed, 1 skipped** (before) -> **65 passed, 1 skipped** (after)