### PR TITLE
[BUG] replace BCE with BCEWithLogitsLoss for AMP safety (fixes #230)

### DIFF
--- a/pyaptamer/aptatrans/_model.py
+++ b/pyaptamer/aptatrans/_model.py
@@ -162,7 +162,6 @@ class AptaTrans(nn.Module):
                     ("linear1", nn.Linear(self.inplanes, self.inplanes // 2)),
                     ("activation1", nn.GELU()),
                     ("linear2", nn.Linear(self.inplanes // 2, 1)),
-                    ("activation2", nn.Sigmoid()),
                 ]
             )
         )
@@ -351,10 +350,14 @@ class AptaTrans(nn.Module):
         return self.imap(x_apta, x_prot)
 
     def forward(self, x_apta: Tensor, x_prot: Tensor) -> Tensor:
-        """Forward pass.
+        """Forward pass returning raw logits.
 
         This methods performs a forward pass through the entire neural network, minus
-        the token predictors, to perform inference and/or fine-tuning.
+        the token predictors. Returns raw logits (before sigmoid) to enable use of
+        ``F.binary_cross_entropy_with_logits``, which is numerically stable and
+        safe to use with Automatic Mixed Precision (AMP/fp16).
+
+        Use :meth:`predict` to obtain probability predictions during inference.
 
         Parameters
         ----------
@@ -365,7 +368,7 @@ class AptaTrans(nn.Module):
         Returns
         -------
         Tensor
-            Output tensor of shape (batch__size, 1) containing the model's predictions.
+            Output tensor of shape (batch_size, 1) containing raw logits.
         """
         out = self.forward_imap(x_apta, x_prot)
 
@@ -380,3 +383,23 @@ class AptaTrans(nn.Module):
         out = self.fc(out)
 
         return out
+
+    def predict(self, x_apta: Tensor, x_prot: Tensor) -> Tensor:
+        """Forward pass returning probability predictions.
+
+        Applies a sigmoid activation to the raw logits returned by :meth:`forward`
+        to produce probability predictions in the range [0, 1]. Use this method
+        during inference.
+
+        Parameters
+        ----------
+        x_apta, x_prot : Tensor
+            Input tensors for aptamers and proteins, respectively. Shapes are
+            (batch_size, seq_len (s1)) and (batch_size, seq_len (s2)), respectively.
+
+        Returns
+        -------
+        Tensor
+            Output tensor of shape (batch_size, 1) with probabilities in [0, 1].
+        """
+        return torch.sigmoid(self.forward(x_apta, x_prot))

--- a/pyaptamer/aptatrans/_model_lightning.py
+++ b/pyaptamer/aptatrans/_model_lightning.py
@@ -1,4 +1,4 @@
-"""AptaTrans' deep neural network wrapper fro Lightning."""
+"""AptaTrans' deep neural network wrapper for Lightning."""
 
 __author__ = ["nennomp"]
 __all__ = ["AptaTransLightning", "AptaTransEncoderLightning"]
@@ -85,6 +85,10 @@ class AptaTransLightning(L.LightningModule):
     ) -> Tensor:
         """Defines a single (mini-batch) step in the training/test loop.
 
+        Uses ``F.binary_cross_entropy_with_logits`` which:
+        - is safe with Automatic Mixed Precision (AMP/fp16) training
+        - is numerically more stable than applying sigmoid followed by BCE
+
         Parameters
         ----------
         batch: tuple[Tensor, Tensor, Tensor]
@@ -101,11 +105,12 @@ class AptaTransLightning(L.LightningModule):
         """
         # (input aptamers, input proteins, ground-truth targets)
         x_apta, x_prot, y = batch
-        y_hat = torch.flatten(self.model(x_apta, x_prot))
-        loss = F.binary_cross_entropy(y_hat, y.float())
+        # model returns raw logits (no sigmoid); BCEWithLogitsLoss is AMP-safe
+        y_logits = torch.flatten(self.model(x_apta, x_prot))
+        loss = F.binary_cross_entropy_with_logits(y_logits, y.float())
 
-        # compute accuracy
-        y_pred = (y_hat > 0.5).float()
+        # compute accuracy: apply sigmoid to logits before thresholding
+        y_pred = (torch.sigmoid(y_logits) > 0.5).float()
         accuracy = (y_pred == y.float()).float().mean()
 
         self._log_metric(f"{stage}_loss", loss)

--- a/pyaptamer/aptatrans/tests/test_aptatrans_lightning.py
+++ b/pyaptamer/aptatrans/tests/test_aptatrans_lightning.py
@@ -7,6 +7,7 @@ import torch
 import torch.nn as nn
 
 from pyaptamer.aptatrans import AptaTransEncoderLightning, AptaTransLightning
+from pyaptamer.aptatrans import AptaTrans, EncoderPredictorConfig
 
 
 @pytest.fixture
@@ -29,8 +30,9 @@ def mock_model():
             )
 
         def forward(self, x_apta, x_prot):
+            """Return raw logits (not probabilities), matching the real AptaTrans model."""
             batch_size = x_apta.shape[0]
-            return torch.rand(batch_size, 1)
+            return torch.randn(batch_size, 1)  # raw logits
 
     return MockAptaTrans()
 
@@ -97,6 +99,28 @@ class TestAptaTransLightning:
         assert optimizer.defaults["lr"] == lightning_model.lr
         assert optimizer.defaults["weight_decay"] == lightning_model.weight_decay
         assert optimizer.defaults["betas"] == lightning_model.betas
+
+    @pytest.mark.parametrize("batch_size, seq_len", [(4, 50), (8, 100)])
+    def test_step_amp_safe(self, lightning_model, batch_size, seq_len):
+        """Check training_step does not crash under autocast (AMP).
+
+        Regression test for issue #230: AptaTrans finetuning crashed with AMP
+        because F.binary_cross_entropy is unsafe to autocast. The fix replaces
+        it with F.binary_cross_entropy_with_logits which is AMP-safe.
+        """
+        x_apta = torch.randint(0, 4, (batch_size, seq_len))
+        x_prot = torch.randint(0, 20, (batch_size, seq_len))
+        y = torch.randint(0, 2, (batch_size,)).float()
+        batch = (x_apta, x_prot, y)
+
+        device_type = "cuda" if torch.cuda.is_available() else "cpu"
+        # torch.autocast simulates AMP; BCEWithLogitsLoss must not raise here
+        with torch.autocast(device_type=device_type):
+            loss = lightning_model.training_step(batch, batch_idx=0)
+
+        assert isinstance(loss, torch.Tensor)
+        assert loss.dim() == 0
+        assert torch.isfinite(loss)
 
 
 class TestAptaTransEncoderLightning:


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #230 
#### What does this implement/fix? Explain your changes.
Fixes the crash when training `AptaTrans` with Automatic Mixed Precision (`precision='16-mixed'`).
When running `AptaTransLightning` finetuning with AMP, training crashed immediately because `torch.nn.functional.binary_cross_entropy` is unsafe to autocast on probabilities. 

Changes implemented:
+ Removed `nn.Sigmoid()` from `AptaTrans.fc` so `forward()` returns raw logits
+ Replaced `F.binary_cross_entropy` with `F.binary_cross_entropy_with_logits` in `AptaTransLightning._step` (which is AMP-safe and numerically more stable)
+ Updated accuracy calculation to apply sigmoid logically before thresholding
+ Added `AptaTrans.predict()` for probability output during inference.

#### What should a reviewer concentrate their feedback on?
+ Verification that `AptaTrans.predict()` effectively maps to previous `forward()` use-cases where probabilities were expected to be returned.

#### Did you add any tests for the change?
+ [x] Yes, I have added `test_step_amp_safe`, a regression test using `torch.autocast` that verifies `training_step` does not crash under mixed precision.

#### Any other comments?
Thank you to the reviewer for pointing me to the PR template!

#### PR checklist
+ [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
+ [x] Added/modified tests
+ [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks.