### PR TITLE
Fix rna2vec silently dropping short sequences

### DIFF
--- a/pyaptamer/utils/_rna.py
+++ b/pyaptamer/utils/_rna.py
@@ -151,24 +151,22 @@ def rna2vec(
             triplets.get(sequence[i : i + 3], 0) for i in range(len(sequence) - 2)
         ]
 
-        # skip sequences that convert to an empty list
-        if any(converted):
-            # truncate if too long
-            if max_sequence_length is not None and len(converted) > max_sequence_length:
-                converted = converted[:max_sequence_length]
+        # truncate if too long
+        if max_sequence_length is not None and len(converted) > max_sequence_length:
+            converted = converted[:max_sequence_length]
 
-            # pad if too short
-            if max_sequence_length is not None:
-                pad_length = max_sequence_length - len(converted)
-                padded_sequence = np.pad(
-                    array=converted,
-                    pad_width=(0, pad_length),
-                    constant_values=0,
-                )
-            else:
-                padded_sequence = np.array(converted)
+        # pad if too short
+        if max_sequence_length is not None:
+            pad_length = max_sequence_length - len(converted)
+            padded_sequence = np.pad(
+                array=converted,
+                pad_width=(0, pad_length),
+                constant_values=0,
+            )
+        else:
+            padded_sequence = np.array(converted)
 
-            result.append(padded_sequence)
+        result.append(padded_sequence)
 
     return np.array(result)
 

--- a/pyaptamer/utils/tests/test_rna.py
+++ b/pyaptamer/utils/tests/test_rna.py
@@ -147,24 +147,36 @@ def test_rna2vec_edge_cases():
     result = rna2vec(["AAACGU"], sequence_type="rna", max_sequence_length=4)
     assert result.shape[1] == 4  # should truncate to 4 triplets
 
-    # empty sequence
+    # empty sequence (should return a zero-padded row, not be dropped)
     result = rna2vec([""], sequence_type="rna")
-    assert len(result) == 0
+    assert result.shape == (1, 275)
+    assert np.all(result[0] == 0)
 
-    # single character sequence (can't form triplet)
+    # single character sequence (can't form triplet, zero-padded row)
     result = rna2vec(["A"], sequence_type="rna")
-    assert len(result) == 0
+    assert result.shape == (1, 275)
+    assert np.all(result[0] == 0)
 
-    # double character sequence (can't form triplet)
+    # double character sequence (can't form triplet, zero-padded row)
     result = rna2vec(["AA"], sequence_type="rna")
-    assert len(result) == 0
+    assert result.shape == (1, 275)
+    assert np.all(result[0] == 0)
 
     # test with secondary structure sequences - edge cases
     result = rna2vec(["S"], sequence_type="ss")
-    assert len(result) == 0
+    assert result.shape == (1, 275)
+    assert np.all(result[0] == 0)
 
     result = rna2vec(["SS"], sequence_type="ss")
-    assert len(result) == 0
+    assert result.shape == (1, 275)
+    assert np.all(result[0] == 0)
+
+
+def test_rna2vec_preserves_row_count():
+    """Check that rna2vec always returns one row per input sequence."""
+    sequences = ["AAAA", "AC", "", "GGGN", "A"]
+    result = rna2vec(sequences, sequence_type="rna", max_sequence_length=10)
+    assert result.shape == (len(sequences), 10)
 
 
 def test_rna2vec_default_parameters():


### PR DESCRIPTION
### Fix: preserve row alignment in `rna2vec` to prevent dataset corruption

**Summary**  
Fixes a critical bug where `rna2vec` silently dropped sequences (e.g., short or invalid ones), causing misalignment between aptamer, protein, and label arrays during training.

**Changes**
- Removed conditional skip (`if any(converted)`) in `rna2vec`
- Ensured every input sequence produces an output row (zero-padded if needed)
- Updated edge-case tests to reflect new behavior
- Added invariant test to guarantee `len(output) == len(input)`

**Impact**
- Prevents silent data corruption in training datasets  
- Fixes incorrect aptamer–protein–label pairing  
- Avoids crashes during evaluation on short/invalid sequences  
- Maintains backward compatibility for valid inputs  

**Note**  
This restores the expected 1:1 mapping between input sequences and encoded outputs, which downstream components rely on.