### PR TITLE
Add HTTP response validation in pdb_to_seq_uniprot

### DIFF
--- a/pyaptamer/utils/_pdb_to_seq_uniprot.py
+++ b/pyaptamer/utils/_pdb_to_seq_uniprot.py
@@ -27,7 +27,8 @@ def pdb_to_seq_uniprot(pdb_id, return_type="list"):
     pdb_id = pdb_id.lower()
 
     mapping_url = f"https://www.ebi.ac.uk/pdbe/api/mappings/uniprot/{pdb_id}"
-    mapping_resp = requests.get(mapping_url)
+    mapping_resp = requests.get(mapping_url, timeout=30)
+    mapping_resp.raise_for_status()
     mapping_data = mapping_resp.json()
 
     uniprot_ids = list(mapping_data.get(pdb_id, {}).get("UniProt", {}).keys())
@@ -37,10 +38,16 @@ def pdb_to_seq_uniprot(pdb_id, return_type="list"):
     uniprot_id = uniprot_ids[0]
 
     fasta_url = f"https://rest.uniprot.org/uniprotkb/{uniprot_id}.fasta"
-    fasta_resp = requests.get(fasta_url)
+    fasta_resp = requests.get(fasta_url, timeout=30)
+    fasta_resp.raise_for_status()
     fasta_data = fasta_resp.text
 
-    record = next(SeqIO.parse(io.StringIO(fasta_data), "fasta"))
+    record = next(SeqIO.parse(io.StringIO(fasta_data), "fasta"), None)
+    if record is None:
+        raise ValueError(
+            f"No FASTA record found for UniProt ID '{uniprot_id}' "
+            f"(mapped from PDB ID '{pdb_id}')"
+        )
     sequence = str(record.seq)
 
     df = pd.DataFrame({"sequence": [sequence]})


### PR DESCRIPTION
## Fix: Handle HTTP failures and parsing errors in `pdb_to_seq_uniprot`

### Summary
Improves robustness of `pdb_to_seq_uniprot` by validating HTTP responses, adding request timeouts, and handling missing FASTA records safely.

### Changes
- Added `response.raise_for_status()` for both API calls  
- Introduced `timeout=30` to prevent hanging requests  
- Replaced unsafe `next()` with `next(..., None)` and explicit error handling  

### Impact
Prevents cryptic crashes (`JSONDecodeError`, `StopIteration`) and provides clear, actionable errors for invalid PDB IDs or failed API responses