### PR TITLE
[ENH] Unify RNA tokenizer core and refactor encode_rna & seq2vec

### DIFF
--- a/pyaptamer/utils/__init__.py
+++ b/pyaptamer/utils/__init__.py
@@ -6,6 +6,7 @@ __all__ = [
     "encode_rna",
     "generate_nplets",
     "rna2vec",
+    "seq2vec",
     "pdb_to_struct",
     "struct_to_aaseq",
     "pdb_to_seq_uniprot",
@@ -13,6 +14,7 @@ __all__ = [
 ]
 
 from pyaptamer.utils._aa_str_to_letter import aa_str_to_letter
+from pyaptamer.utils._aptatrans_utils import seq2vec
 from pyaptamer.utils._pdb_to_aaseq import pdb_to_aaseq
 from pyaptamer.utils._pdb_to_seq_uniprot import pdb_to_seq_uniprot
 from pyaptamer.utils._pdb_to_struct import pdb_to_struct

--- a/pyaptamer/utils/_aptatrans_utils.py
+++ b/pyaptamer/utils/_aptatrans_utils.py
@@ -3,30 +3,17 @@
 __author__ = ["nennomp"]
 __all__ = ["seq2vec"]
 
-import re
 import numpy as np
-from pyaptamer.utils._rna import generate_nplets
+
+from pyaptamer.utils._rna import (
+    _build_greedy_pattern,
+    _pad_token_chunks,
+    generate_nplets,
+)
 
 WORDS_SS = generate_nplets(
     letters=["H", "B", "E", "G", "I", "T", "S", "-"], repeat=range(1, 4)
 )
-
-def _build_pattern(words: dict[str, int], word_max_len: int) -> re.Pattern[str] | None:
-    """Build a greedy longest-match regex pattern from the provided vocabulary."""
-    vocab = sorted(
-        [
-            word
-            for word, word_idx in words.items()
-            if word and 0 < len(word) <= word_max_len and word_idx != 0
-        ],
-        key=lambda word: (len(word), word),
-        reverse=True,
-    )
-    
-    if not vocab:
-        return None
-    
-    return re.compile("|".join(re.escape(word) for word in vocab))
 
 
 def seq2vec(
@@ -38,8 +25,7 @@ def seq2vec(
     """
     Convert sequences to vector representations using word dictionaries.
 
-    TODO: see if this can be merged in a more generic version of `_rna.rna2vec(...)`.
-    TODO: look into ways to speed it up.
+    TODO: look into further ways to speed this up.
 
     Tokenizes input sequences by matching substrings of varying lengths against
     provided vocabularies, then converts matches to indices and pads to uniform length.
@@ -75,48 +61,30 @@ def seq2vec(
     >>> seq2vec(sequences, words, seq_max_len=4)
     (array([[1., 2., 0., 0.]]), array([[9., 0., 0., 0.]]))
     """
-    pattern = _build_pattern(words=words, word_max_len=word_max_len)
+    pattern = _build_greedy_pattern(words=words, word_max_len=word_max_len)
     if pattern is None:
         return np.zeros((0, seq_max_len)), np.zeros((0, seq_max_len))
-    
     outputs = []
     outputs_ss = []
-    
     for seq, ss in zip(*sequence_list, strict=False):
         output = []
         output_ss = []
-        
         for match in pattern.finditer(seq):
             start, end = match.span()
             word = match.group()
-            
             output.append(words[word])
             output_ss.append(WORDS_SS.get(ss[start:end], 0))
-            
             # if at `seq_max_len`, store and reset
             if len(output) == seq_max_len:
                 outputs.append(np.array(output))
                 outputs_ss.append(np.array(output_ss))
                 output = []
                 output_ss = []
-                
         # add remaining output if not empty
         if len(output) > 0:
             outputs.append(np.array(output))
             outputs_ss.append(np.array(output_ss))
 
-    # pad all sequences to `seq_max_len`
-    if outputs:
-        padded_outputs = np.zeros((len(outputs), seq_max_len))
-        padded_outputs_ss = np.zeros((len(outputs_ss), seq_max_len))
-
-        for idx, (seq_array, ss_array) in enumerate(
-            zip(outputs, outputs_ss, strict=False)
-        ):
-            seq_len = len(seq_array)
-            padded_outputs[idx, :seq_len] = seq_array
-            padded_outputs_ss[idx, :seq_len] = ss_array
-
-        return padded_outputs, padded_outputs_ss
-    else:
-        return np.zeros((0, seq_max_len)), np.zeros((0, seq_max_len))
+    return _pad_token_chunks(outputs, seq_max_len), _pad_token_chunks(
+        outputs_ss, seq_max_len
+    )

--- a/pyaptamer/utils/_aptatrans_utils.py
+++ b/pyaptamer/utils/_aptatrans_utils.py
@@ -24,35 +24,30 @@ def seq2vec(
     word_max_len: int = 3,
 ) -> tuple[np.ndarray, np.ndarray]:
     """
-    Convert sequences to vector representations using word dictionaries.
+    Convert paired sequence and secondary-structure strings to fixed-length vectors.
 
-    TODO: look into further ways to speed this up.
-
-    Tokenizes input sequences by matching substrings of varying lengths against
-    provided vocabularies, then converts matches to indices and pads to uniform length.
-    The tokenization process uses a greedy approach, attempting to match the longest
-    possible substring first (from word_max_len down to 1). Unknown words are mapped
-    to index 0. Sequences longer than seq_max_len are split into multiple sequences.
+    The function tokenizes each primary sequence with greedy longest-first matching,
+    converts matched tokens to integer ids, and chunks long outputs into windows of
+    size ``seq_max_len``. For each matched token span, the corresponding
+    secondary-structure substring is encoded with the shared secondary-structure
+    vocabulary.
 
     Parameters
     ----------
     sequence_list : tuple[list[str], list[str]]
-        Tuple of lists containing paired sequences (primary sequence, secondary
-        structure).
+        Paired primary-sequence and secondary-structure lists.
     words : dict[str, int]
-        Dictionary mapping primary sequence words to indices.
+        Mapping from primary-sequence tokens to integer ids.
     seq_max_len : int
-        Maximum sequence length for padding.
+        Maximum number of token ids per output chunk.
     word_max_len : int, optional, default=3
-        Maximum word length to consider during tokenization.
+        Maximum token length considered during greedy matching.
 
     Returns
     -------
     tuple[np.ndarray, np.ndarray]
-        A tuple of numpy arrays, containing the padded primary sequence indices array
-        and the padded secondary structure indices array, respectively. The former has
-        sequence length (n_sequences, seq_max_len), the latter (n_sequences, len
-        (`words_ss`) = 584).
+        Two padded arrays containing primary-sequence ids and
+        secondary-structure ids.
 
     Examples
     --------

--- a/pyaptamer/utils/_aptatrans_utils.py
+++ b/pyaptamer/utils/_aptatrans_utils.py
@@ -3,9 +3,30 @@
 __author__ = ["nennomp"]
 __all__ = ["seq2vec"]
 
+import re
 import numpy as np
+from pyaptamer.utils._rna import generate_nplets
 
-from pyaptamer.utils import generate_nplets
+WORDS_SS = generate_nplets(
+    letters=["H", "B", "E", "G", "I", "T", "S", "-"], repeat=range(1, 4)
+)
+
+def _build_pattern(words: dict[str, int], word_max_len: int) -> re.Pattern[str] | None:
+    """Build a greedy longest-match regex pattern from the provided vocabulary."""
+    vocab = sorted(
+        [
+            word
+            for word, word_idx in words.items()
+            if word and 0 < len(word) <= word_max_len and word_idx != 0
+        ],
+        key=lambda word: (len(word), word),
+        reverse=True,
+    )
+    
+    if not vocab:
+        return None
+    
+    return re.compile("|".join(re.escape(word) for word in vocab))
 
 
 def seq2vec(
@@ -54,49 +75,31 @@ def seq2vec(
     >>> seq2vec(sequences, words, seq_max_len=4)
     (array([[1., 2., 0., 0.]]), array([[9., 0., 0., 0.]]))
     """
-    words_ss = generate_nplets(
-        letters=["H", "B", "E", "G", "I", "T", "S", "-"], repeat=range(1, 4)
-    )
-
+    pattern = _build_pattern(words=words, word_max_len=word_max_len)
+    if pattern is None:
+        return np.zeros((0, seq_max_len)), np.zeros((0, seq_max_len))
+    
     outputs = []
     outputs_ss = []
-
+    
     for seq, ss in zip(*sequence_list, strict=False):
         output = []
         output_ss = []
-        i = 0
-
-        while i < len(seq):
-            matched = False
-
-            # try to match longest possible substring first
-            for j in range(word_max_len, 0, -1):
-                if i + j <= len(seq):
-                    substring = seq[i : i + j]
-                    substring_ss = ss[i : i + j]
-
-                    # check if substring exists in vocabulary (0 is unknown token)
-                    word_idx = words.get(substring, 0)
-                    if word_idx != 0:
-                        matched = True
-                        output.append(word_idx)
-                        # 0 marks unknown secondary structure tokens
-                        output_ss.append(words_ss.get(substring_ss, 0))
-
-                        # if at `seq_max_len`, store and reset
-                        if len(output) == seq_max_len:
-                            outputs.append(np.array(output))
-                            outputs_ss.append(np.array(output_ss))
-                            output = []
-                            output_ss = []
-
-                        i += j
-                        break
-
-            # skip character if no match found
-            if not matched:
-                i += 1
-
+        
+        for match in pattern.finditer(seq):
+            start, end = match.span()
+            word = match.group()
+            
+            output.append(words[word])
+            output_ss.append(WORDS_SS.get(ss[start:end], 0))
+            
+            # if at `seq_max_len`, store and reset
+            if len(output) == seq_max_len:
+                outputs.append(np.array(output))
+                outputs_ss.append(np.array(output_ss))
+                output = []
+                output_ss = []
+                
         # add remaining output if not empty
         if len(output) > 0:
             outputs.append(np.array(output))

--- a/pyaptamer/utils/_aptatrans_utils.py
+++ b/pyaptamer/utils/_aptatrans_utils.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from pyaptamer.utils._rna import (
     _build_greedy_pattern,
+    _greedy_tokenize_to_chunks,
     _pad_token_chunks,
     generate_nplets,
 )
@@ -64,26 +65,28 @@ def seq2vec(
     pattern = _build_greedy_pattern(words=words, word_max_len=word_max_len)
     if pattern is None:
         return np.zeros((0, seq_max_len)), np.zeros((0, seq_max_len))
+
     outputs = []
     outputs_ss = []
     for seq, ss in zip(*sequence_list, strict=False):
-        output = []
-        output_ss = []
-        for match in pattern.finditer(seq):
-            start, end = match.span()
-            word = match.group()
-            output.append(words[word])
-            output_ss.append(WORDS_SS.get(ss[start:end], 0))
-            # if at `seq_max_len`, store and reset
-            if len(output) == seq_max_len:
-                outputs.append(np.array(output))
-                outputs_ss.append(np.array(output_ss))
-                output = []
-                output_ss = []
-        # add remaining output if not empty
-        if len(output) > 0:
-            outputs.append(np.array(output))
-            outputs_ss.append(np.array(output_ss))
+        token_chunks, span_chunks = _greedy_tokenize_to_chunks(
+            sequence=seq,
+            words=words,
+            word_max_len=word_max_len,
+            chunk_size=seq_max_len,
+            unknown_policy="skip",
+            return_spans=True,
+            pattern=pattern,
+        )
+
+        if not token_chunks or span_chunks is None:
+            continue
+
+        for token_chunk, span_chunk in zip(token_chunks, span_chunks, strict=False):
+            outputs.append(np.array(token_chunk))
+            outputs_ss.append(
+                np.array([WORDS_SS.get(ss[start:end], 0) for start, end in span_chunk])
+            )
 
     return _pad_token_chunks(outputs, seq_max_len), _pad_token_chunks(
         outputs_ss, seq_max_len

--- a/pyaptamer/utils/_rna.py
+++ b/pyaptamer/utils/_rna.py
@@ -6,10 +6,44 @@ __all__ = [
     "rna2vec",
 ]
 
+import re
 from collections.abc import Iterable
 from itertools import product
 
 import numpy as np
+
+
+def _build_greedy_pattern(
+    words: dict[str, int], word_max_len: int
+) -> re.Pattern[str] | None:
+    """Build longest-first regex pattern for greedy tokenization."""
+    vocab = sorted(
+        [
+            word
+            for word, word_idx in words.items()
+            if word and 0 < len(word) <= word_max_len and word_idx != 0
+        ],
+        key=lambda word: (len(word), word),
+        reverse=True,
+    )
+
+    if not vocab:
+        return None
+
+    return re.compile("|".join(re.escape(word) for word in vocab))
+
+
+def _pad_token_chunks(outputs: list[np.ndarray], seq_max_len: int) -> np.ndarray:
+    """Pad variable-length token chunks to fixed length arrays."""
+    if not outputs:
+        return np.zeros((0, seq_max_len))
+
+    padded_outputs = np.zeros((len(outputs), seq_max_len))
+    for idx, seq_array in enumerate(outputs):
+        seq_len = len(seq_array)
+        padded_outputs[idx, :seq_len] = seq_array
+
+    return padded_outputs
 
 
 def dna2rna(sequence: str) -> str:

--- a/pyaptamer/utils/_rna.py
+++ b/pyaptamer/utils/_rna.py
@@ -17,7 +17,12 @@ import numpy as np
 def _build_greedy_pattern(
     words: dict[str, int], word_max_len: int
 ) -> re.Pattern[str] | None:
-    """Build longest-first regex pattern for greedy tokenization."""
+    """Build a longest-first regular expression for greedy tokenization.
+
+    Only non-empty words with positive ids and length up to ``word_max_len`` are
+    included. Tokens are ordered from longest to shortest so regex matching preserves
+    greedy preference.
+    """
     vocab = sorted(
         [
             word
@@ -35,7 +40,21 @@ def _build_greedy_pattern(
 
 
 def _pad_token_chunks(outputs: list[np.ndarray], seq_max_len: int) -> np.ndarray:
-    """Pad variable-length token chunks to fixed length arrays."""
+    """Pad variable-length token chunks to a fixed 2D array.
+
+    Parameters
+    ----------
+    outputs : list[np.ndarray]
+        List of one-dimensional token-id arrays.
+    seq_max_len : int
+        Target width for each output row.
+
+    Returns
+    -------
+    np.ndarray
+        Padded array with shape ``(len(outputs), seq_max_len)``. If ``outputs`` is
+        empty, an empty array with shape ``(0, seq_max_len)`` is returned.
+    """
     if not outputs:
         return np.zeros((0, seq_max_len))
 
@@ -57,7 +76,31 @@ def _greedy_tokenize(
     pattern: re.Pattern[str] | None = None,
     max_tokens: int | None = None,
 ) -> tuple[list[int], list[tuple[int, int]] | None]:
-    """Tokenize a sequence using a configurable greedy longest-first strategy."""
+    """Tokenize a sequence with a greedy longest-first strategy.
+
+    Parameters
+    ----------
+    sequence : str
+        Input sequence to tokenize.
+    words : dict[str, int]
+        Token vocabulary mapping token strings to ids.
+    word_max_len : int
+        Maximum candidate token length checked at each position.
+    unknown_policy : {"append_zero", "skip"}, optional, default="append_zero"
+        Policy for unknown regions. ``append_zero`` emits a zero token and advances by
+        one character. ``skip`` skips unknown regions and returns only matched tokens.
+    return_spans : bool, optional, default=False
+        Whether to also return character spans for each produced token.
+    pattern : re.Pattern[str] or None, optional, default=None
+        Precompiled regex pattern used when ``unknown_policy`` is ``skip``.
+    max_tokens : int or None, optional, default=None
+        Optional cap on number of emitted tokens.
+
+    Returns
+    -------
+    tuple[list[int], list[tuple[int, int]] or None]
+        Token ids and optional token spans.
+    """
     if unknown_policy not in {"append_zero", "skip"}:
         raise ValueError("`unknown_policy` must be either 'append_zero' or 'skip'.")
 
@@ -112,7 +155,27 @@ def _chunk_tokens(
     chunk_size: int | None,
     spans: list[tuple[int, int]] | None = None,
 ) -> tuple[list[list[int]], list[list[tuple[int, int]]] | None]:
-    """Split token (and optional span) streams into fixed-size chunks."""
+    """Split token streams and optional span streams into fixed-size chunks.
+
+    Parameters
+    ----------
+    tokens : list[int]
+        Token-id stream.
+    chunk_size : int or None
+        Chunk size. If ``None``, the full stream is returned as a single chunk.
+    spans : list[tuple[int, int]] or None, optional, default=None
+        Optional token spans aligned with ``tokens``.
+
+    Returns
+    -------
+    tuple[list[list[int]], list[list[tuple[int, int]]] or None]
+        Token chunks and optional aligned span chunks.
+
+    Raises
+    ------
+    ValueError
+        If ``chunk_size`` is provided and is not positive.
+    """
     if chunk_size is None:
         token_chunks = [tokens] if tokens else []
         if spans is None:
@@ -146,7 +209,11 @@ def _greedy_tokenize_to_chunks(
     pattern: re.Pattern[str] | None = None,
     max_tokens: int | None = None,
 ) -> tuple[list[list[int]], list[list[tuple[int, int]]] | None]:
-    """Tokenize greedily and optionally chunk the output for downstream encoders."""
+    """Tokenize with greedy matching and chunk results for downstream encoders.
+
+    This helper combines :func:`_greedy_tokenize` and :func:`_chunk_tokens` in one
+    call.
+    """
     tokens, spans = _greedy_tokenize(
         sequence=sequence,
         words=words,
@@ -163,13 +230,12 @@ def dna2rna(sequence: str) -> str:
     """
     Convert a DNA sequence to an RNA sequence.
 
-    Nucleotides 'T' in the DNA sequence are replaced with 'U' in the RNA sequence.
-    Unknown nucleotides are replaced with 'N'. Other nucleotides ('A', 'C', 'G') remain
-    unchanged.
+    Nucleotides ``T`` are replaced by ``U``. Any character outside ``ACGU`` is
+    normalized to ``N``.
 
     Parameters
     ----------
-    seq : str
+    sequence : str
         The DNA sequence to be converted.
 
     Returns
@@ -189,8 +255,7 @@ def generate_nplets(letters: list[str], repeat: int | Iterable[int]) -> dict[str
     """
     Generate a dictionary containing all possible n-plets of given characters.
 
-    This method generates all possible n-plets, specified by the `repeat` parameter, of
-    characters contained in `letters`. Each n-plet is mapped to a unique integer ID.
+    Each generated n-plet is assigned a unique 1-indexed integer id in iteration order.
 
     Parameters
     ----------
@@ -204,7 +269,7 @@ def generate_nplets(letters: list[str], repeat: int | Iterable[int]) -> dict[str
     Returns
     -------
     dict[str, int]
-        A dictionary mapping each n-plet to a unique integer ID (1-indexed).
+        Mapping from each generated n-plet to its integer id.
     """
     if isinstance(repeat, int):
         repeat = [repeat]
@@ -223,36 +288,25 @@ def rna2vec(
     sequence_list: list[str], sequence_type: str = "rna", max_sequence_length: int = 275
 ) -> np.ndarray:
     """
-    Convert a list of RNA sequence or RNA secondary structures into a numerical
-    representation.
+    Convert RNA sequences or RNA secondary-structure strings to fixed-length vectors.
 
-    For RNA sequences, if not already in RNA format, the sequences are converted from
-    DNA to RNA. For both RNA and secondary structure sequences, all overlapping
-    triplets (3-nucleotide/character combinations) are extracted from each sequence and
-    mapped to unique indices. Finally, the sequences are zero padded to length
-    `max_sequence_length`. The result is a numpy array where each row corresponds to a
-    sequence, and each column corresponds to an integer representing the triplet's
-    index in the dictionary.
-
-    If the number of extracted triplets is greater than `max_sequence_length`, the
-    sequence is truncated to fit.
+    RNA inputs are normalized with :func:`dna2rna` first. Then overlapping triplets
+    are mapped to integer ids and padded or truncated to ``max_sequence_length``.
 
     Parameters
     ----------
     sequence_list : list[str]
-        A list containing sequences as strings (RNA sequences or secondary structure
-        sequences).
+        Input sequences as strings.
     sequence_type : str, optional, default="rna"
-        The type of sequence to process. Either "rna" for RNA sequences or "ss" for
-        secondary structure sequences.
+        Sequence domain. Use ``"rna"`` for nucleotide sequences and ``"ss"`` for
+        secondary-structure strings.
     max_sequence_length : int, optional, default=275
-        The maximum length of the output sequences.
+        Maximum output length per encoded sequence.
 
     Returns
     -------
     np.ndarray
-        A numpy array containing the numerical representation of the sequences, of
-        shape (len(sequence_list), `max_sequence_length`).
+        Encoded array of shape ``(n_sequences, max_sequence_length)``.
 
     Raises
     ------
@@ -327,33 +381,31 @@ def encode_rna(
     word_max_len: int = 3,
     return_type: str = "tensor",
 ):
-    """Encode RNA sequences into their numerical representations.
+    """Encode RNA sequences into integer token ids.
 
-    This function tokenizes protein sequences using a greedy longest-match approach,
-    where longer amino acid patterns are preferred over shorter ones. Sequences are
-    either trunacted or zero-padded to `max_len` tokens.
+    The function performs greedy longest-match tokenization against ``words``, then
+    truncates or zero-pads each sequence to ``max_len``.
 
     Parameters
     ----------
     sequences : list[str]
-        List of RNA sequences to be encoded.
+        RNA sequences to encode.
     words : dict[str, int]
-        A dictionary mappings RNA 3-mers to unique indices.
+        Mapping from RNA tokens to integer ids.
     max_len : int
-        Maximum length of each encoded sequence. Sequences will be truncated
-        or padded to this length.
+        Maximum length of each encoded sequence.
     word_max_len : int, optional, default=3
-        Maximum length of amino acid patterns to consider during tokenization.
+        Maximum token length considered during greedy matching.
     return_type : str, optional, default="tensor"
-        The type of the returned encoded sequences.
+        Output container type.
 
         * "tensor": returns a PyTorch Tensor
         * "numpy": returns a NumPy ndarray
 
     Returns
     -------
-    Tensor
-        Encoded sequences with shape (n_sequences, `max_len`).
+    torch.Tensor or np.ndarray
+        Encoded sequences with shape ``(n_sequences, max_len)``.
 
     Examples
     --------
@@ -362,7 +414,7 @@ def encode_rna(
     >>> print(encode_rna("ACD", words, max_len=5))
     tensor([[4, 3, 0, 0, 0]])
     """
-    # handle single protein input
+    # handle single sequence input
     if isinstance(sequences, str):
         sequences = [sequences]
 

--- a/pyaptamer/utils/_rna.py
+++ b/pyaptamer/utils/_rna.py
@@ -9,6 +9,7 @@ __all__ = [
 import re
 from collections.abc import Iterable
 from itertools import product
+from typing import Literal
 
 import numpy as np
 
@@ -44,6 +45,118 @@ def _pad_token_chunks(outputs: list[np.ndarray], seq_max_len: int) -> np.ndarray
         padded_outputs[idx, :seq_len] = seq_array
 
     return padded_outputs
+
+
+def _greedy_tokenize(
+    sequence: str,
+    words: dict[str, int],
+    word_max_len: int,
+    *,
+    unknown_policy: Literal["append_zero", "skip"] = "append_zero",
+    return_spans: bool = False,
+    pattern: re.Pattern[str] | None = None,
+    max_tokens: int | None = None,
+) -> tuple[list[int], list[tuple[int, int]] | None]:
+    """Tokenize a sequence using a configurable greedy longest-first strategy."""
+    if unknown_policy not in {"append_zero", "skip"}:
+        raise ValueError("`unknown_policy` must be either 'append_zero' or 'skip'.")
+
+    if max_tokens is not None and max_tokens <= 0:
+        return [], [] if return_spans else None
+
+    tokens: list[int] = []
+    spans: list[tuple[int, int]] | None = [] if return_spans else None
+
+    if unknown_policy == "skip":
+        compiled_pattern = pattern or _build_greedy_pattern(words, word_max_len)
+        if compiled_pattern is None:
+            return tokens, spans
+
+        for match in compiled_pattern.finditer(sequence):
+            tokens.append(words[match.group()])
+            if spans is not None:
+                spans.append(match.span())
+
+            if max_tokens is not None and len(tokens) >= max_tokens:
+                break
+
+        return tokens, spans
+
+    index = 0
+    while index < len(sequence):
+        matched = False
+        for pattern_len in range(min(word_max_len, len(sequence) - index), 0, -1):
+            candidate = sequence[index : index + pattern_len]
+            if candidate in words:
+                tokens.append(words[candidate])
+                if spans is not None:
+                    spans.append((index, index + pattern_len))
+                index += pattern_len
+                matched = True
+                break
+
+        if not matched:
+            tokens.append(0)
+            if spans is not None:
+                spans.append((index, index + 1))
+            index += 1
+
+        if max_tokens is not None and len(tokens) >= max_tokens:
+            break
+
+    return tokens, spans
+
+
+def _chunk_tokens(
+    tokens: list[int],
+    chunk_size: int | None,
+    spans: list[tuple[int, int]] | None = None,
+) -> tuple[list[list[int]], list[list[tuple[int, int]]] | None]:
+    """Split token (and optional span) streams into fixed-size chunks."""
+    if chunk_size is None:
+        token_chunks = [tokens] if tokens else []
+        if spans is None:
+            return token_chunks, None
+        span_chunks = [spans] if spans else []
+        return token_chunks, span_chunks
+
+    if chunk_size <= 0:
+        raise ValueError("`chunk_size` must be greater than 0 when provided.")
+
+    token_chunks = [
+        tokens[idx : idx + chunk_size] for idx in range(0, len(tokens), chunk_size)
+    ]
+    if spans is None:
+        return token_chunks, None
+
+    span_chunks = [
+        spans[idx : idx + chunk_size] for idx in range(0, len(spans), chunk_size)
+    ]
+    return token_chunks, span_chunks
+
+
+def _greedy_tokenize_to_chunks(
+    sequence: str,
+    words: dict[str, int],
+    word_max_len: int,
+    *,
+    chunk_size: int | None,
+    unknown_policy: Literal["append_zero", "skip"] = "append_zero",
+    return_spans: bool = False,
+    pattern: re.Pattern[str] | None = None,
+    max_tokens: int | None = None,
+) -> tuple[list[list[int]], list[list[tuple[int, int]]] | None]:
+    """Tokenize greedily and optionally chunk the output for downstream encoders."""
+    tokens, spans = _greedy_tokenize(
+        sequence=sequence,
+        words=words,
+        word_max_len=word_max_len,
+        unknown_policy=unknown_policy,
+        return_spans=return_spans,
+        pattern=pattern,
+        max_tokens=max_tokens,
+    )
+    return _chunk_tokens(tokens=tokens, chunk_size=chunk_size, spans=spans)
 
 
 def dna2rna(sequence: str) -> str:
@@ -255,29 +368,18 @@ def encode_rna(
 
     encoded_sequences = []
     for seq in sequences:
-        tokens = []
-        i = 0
-
-        while i < len(seq):
-            # try to match the longest possible pattern first
-            matched = False
-            for pattern_len in range(min(word_max_len, len(seq) - i), 0, -1):
-                pattern = seq[i : i + pattern_len]
-                if pattern in words:
-                    tokens.append(words[pattern])
-                    i += pattern_len
-                    matched = True
-                    break
-
-            # if no pattern matched, use unknown token (0) and advance by 1
-            if not matched:
-                tokens.append(0)
-                i += 1
-
-            # stop if we've reached max_len tokens
-            if len(tokens) >= max_len:
-                tokens = tokens[:max_len]
-                break
+        tokens, _ = _greedy_tokenize(
+            sequence=seq,
+            words=words,
+            word_max_len=word_max_len,
+            unknown_policy="append_zero",
+            return_spans=False,
+            max_tokens=max_len,
+        )
+        if max_len > 0:
+            tokens = tokens[:max_len]
+        else:
+            tokens = []
 
         # pad sequence to max_len
         padded_tokens = tokens + [0] * (max_len - len(tokens))

--- a/pyaptamer/utils/tests/test_rna.py
+++ b/pyaptamer/utils/tests/test_rna.py
@@ -9,6 +9,12 @@ import pytest
 import torch
 
 from pyaptamer.utils import dna2rna, encode_rna, generate_nplets, rna2vec
+from pyaptamer.utils._rna import (
+    _build_greedy_pattern,
+    _chunk_tokens,
+    _greedy_tokenize,
+    _greedy_tokenize_to_chunks,
+)
 
 
 @pytest.mark.parametrize(
@@ -242,3 +248,71 @@ def test_encode_rna(sequences, words, max_len, word_max_len, expected):
 
     # verify all values are non-negative
     assert (encoded >= 0).all()
+
+
+def test_greedy_tokenize_append_zero_policy():
+    """Unknown characters should append zero tokens under append_zero policy."""
+    words = {"AC": 1, "G": 2}
+
+    tokens, spans = _greedy_tokenize(
+        sequence="ACXG",
+        words=words,
+        word_max_len=2,
+        unknown_policy="append_zero",
+        return_spans=True,
+    )
+
+    assert tokens == [1, 0, 2]
+    assert spans == [(0, 2), (2, 3), (3, 4)]
+
+
+def test_greedy_tokenize_skip_policy():
+    """Unknown regions should be skipped under skip policy."""
+    words = {"AC": 1, "G": 2}
+    pattern = _build_greedy_pattern(words=words, word_max_len=2)
+
+    tokens, spans = _greedy_tokenize(
+        sequence="ACXG",
+        words=words,
+        word_max_len=2,
+        unknown_policy="skip",
+        return_spans=True,
+        pattern=pattern,
+    )
+
+    assert tokens == [1, 2]
+    assert spans == [(0, 2), (3, 4)]
+
+
+def test_chunk_tokens_with_spans():
+    """Token and span chunking should remain aligned."""
+    tokens = [1, 2, 3, 4, 5]
+    spans = [(0, 1), (1, 2), (2, 3), (3, 4), (4, 5)]
+
+    token_chunks, span_chunks = _chunk_tokens(tokens=tokens, chunk_size=2, spans=spans)
+
+    assert token_chunks == [[1, 2], [3, 4], [5]]
+    assert span_chunks == [[(0, 1), (1, 2)], [(2, 3), (3, 4)], [(4, 5)]]
+
+
+def test_chunk_tokens_invalid_size():
+    """Non-positive chunk sizes should be rejected."""
+    with pytest.raises(ValueError, match="`chunk_size` must be greater than 0"):
+        _chunk_tokens(tokens=[1, 2], chunk_size=0)
+
+
+def test_greedy_tokenize_to_chunks_output():
+    """Combined tokenization+chunking helper should preserve order and spans."""
+    words = {"A": 1, "C": 2}
+
+    token_chunks, span_chunks = _greedy_tokenize_to_chunks(
+        sequence="AACX",
+        words=words,
+        word_max_len=1,
+        chunk_size=2,
+        unknown_policy="append_zero",
+        return_spans=True,
+    )
+
+    assert token_chunks == [[1, 1], [2, 0]]
+    assert span_chunks == [[(0, 1), (1, 2)], [(2, 3), (3, 4)]]

--- a/pyaptamer/utils/tests/test_seq2vec.py
+++ b/pyaptamer/utils/tests/test_seq2vec.py
@@ -1,0 +1,162 @@
+import numpy as np
+from pyaptamer.utils import generate_nplets, seq2vec
+
+def _seq2vec_legacy(
+    sequence_list: tuple[list[str], list[str]],
+    words: dict[str, int],
+    seq_max_len: int,
+    word_max_len: int = 3,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Reference implementation used to verify backward compatibility."""
+    words_ss = generate_nplets(
+        letters=["H", "B", "E", "G", "I", "T", "S", "-"], repeat=range(1, 4)
+    )
+    outputs = []
+    outputs_ss = []
+    for seq, ss in zip(*sequence_list, strict=False):
+        output = []
+        output_ss = []
+        i = 0
+        while i < len(seq):
+            matched = False
+            for j in range(word_max_len, 0, -1):
+                if i + j <= len(seq):
+                    substring = seq[i : i + j]
+                    word_idx = words.get(substring, 0)
+                    if word_idx != 0:
+                        matched = True
+                        output.append(word_idx)
+                        output_ss.append(words_ss.get(ss[i : i + j], 0))
+                        if len(output) == seq_max_len:
+                            outputs.append(np.array(output))
+                            outputs_ss.append(np.array(output_ss))
+                            output = []
+                            output_ss = []
+                        i += j
+                        break
+            if not matched:
+                i += 1
+        if len(output) > 0:
+            outputs.append(np.array(output))
+            outputs_ss.append(np.array(output_ss))
+    if outputs:
+        padded_outputs = np.zeros((len(outputs), seq_max_len))
+        padded_outputs_ss = np.zeros((len(outputs_ss), seq_max_len))
+        for idx, (seq_array, ss_array) in enumerate(
+            zip(outputs, outputs_ss, strict=False)
+        ):
+            seq_len = len(seq_array)
+            padded_outputs[idx, :seq_len] = seq_array
+            padded_outputs_ss[idx, :seq_len] = ss_array
+        return padded_outputs, padded_outputs_ss
+    return np.zeros((0, seq_max_len)), np.zeros((0, seq_max_len))
+
+
+def test_seq2vec_matches_legacy_behavior():
+    """Ensure the optimized implementation matches the old behavior."""
+    words = {
+        "A": 1,
+        "C": 2,
+        "G": 3,
+        "U": 4,
+        "AA": 5,
+        "CG": 6,
+        "ACG": 7,
+    }
+    sequences = (
+        ["AAACGUX", "NNNACG", "ACGACGACG"],
+        ["HHHSSS-", "TTTHHH", "HHHBBBEEE"],
+    )
+    legacy_seq, legacy_ss = _seq2vec_legacy(
+        sequence_list=sequences,
+        words=words,
+        seq_max_len=4,
+        word_max_len=3,
+    )
+    new_seq, new_ss = seq2vec(
+        sequence_list=sequences,
+        words=words,
+        seq_max_len=4,
+        word_max_len=3,
+    )
+    
+    np.testing.assert_array_equal(new_seq, legacy_seq)
+    np.testing.assert_array_equal(new_ss, legacy_ss)
+
+
+def test_seq2vec_empty_vocab_guard():
+    """Empty or effectively empty vocabularies should return empty outputs."""
+    sequences = (["ACGU"], ["HHHH"])
+    out_seq, out_ss = seq2vec(
+        sequence_list=sequences,
+        words={},
+        seq_max_len=5,
+    )
+    
+    np.testing.assert_array_equal(out_seq, np.zeros((0, 5)))
+    np.testing.assert_array_equal(out_ss, np.zeros((0, 5)))
+
+
+def test_seq2vec_skips_unknown_characters():
+    """Unknown sequence regions should be skipped and not create tokens."""
+    words = {"AC": 1, "GU": 2}
+    sequences = (["XXACYYGUZZ"], ["--HH--TT--"])
+    
+    out_seq, out_ss = seq2vec(
+        sequence_list=sequences,
+        words=words,
+        seq_max_len=4,
+        word_max_len=2,
+    )
+    
+    np.testing.assert_array_equal(out_seq, np.array([[1.0, 2.0, 0.0, 0.0]]))
+    np.testing.assert_array_equal(out_ss, np.array([[9.0, 54.0, 0.0, 0.0]]))
+
+
+def test_seq2vec_shorter_than_pattern():
+    """Sequence shorter than any usable token should produce empty output rows."""
+    words = {"AC": 1, "GU": 2}
+    sequences = (["A", "G"], ["H", "T"])
+    out_seq, out_ss = seq2vec(
+        sequence_list=sequences,
+        words=words,
+        seq_max_len=3,
+        word_max_len=2,
+    )
+    
+    np.testing.assert_array_equal(out_seq, np.zeros((0, 3)))
+    np.testing.assert_array_equal(out_ss, np.zeros((0, 3)))
+
+
+def test_seq2vec_chunking_and_padding():
+    """Long outputs should be chunked to seq_max_len and the tail padded."""
+    words = {"A": 1}
+    sequences = (["AAAAA"], ["HHHHH"])
+    
+    out_seq, out_ss = seq2vec(
+        sequence_list=sequences,
+        words=words,
+        seq_max_len=2,
+        word_max_len=1,
+    )
+
+    np.testing.assert_array_equal(
+        out_seq,
+        np.array(
+            [
+                [1.0, 1.0],
+                [1.0, 1.0],
+                [1.0, 0.0],
+            ]
+        ),
+    )
+    np.testing.assert_array_equal(
+        out_ss,
+        np.array(
+            [
+                [1.0, 1.0],
+                [1.0, 1.0],
+                [1.0, 0.0],
+            ]
+        ),
+    )

--- a/pyaptamer/utils/tests/test_seq2vec.py
+++ b/pyaptamer/utils/tests/test_seq2vec.py
@@ -1,5 +1,7 @@
 import numpy as np
+
 from pyaptamer.utils import generate_nplets, seq2vec
+
 
 def _seq2vec_legacy(
     sequence_list: tuple[list[str], list[str]],
@@ -79,7 +81,7 @@ def test_seq2vec_matches_legacy_behavior():
         seq_max_len=4,
         word_max_len=3,
     )
-    
+
     np.testing.assert_array_equal(new_seq, legacy_seq)
     np.testing.assert_array_equal(new_ss, legacy_ss)
 
@@ -92,7 +94,7 @@ def test_seq2vec_empty_vocab_guard():
         words={},
         seq_max_len=5,
     )
-    
+
     np.testing.assert_array_equal(out_seq, np.zeros((0, 5)))
     np.testing.assert_array_equal(out_ss, np.zeros((0, 5)))
 
@@ -101,14 +103,13 @@ def test_seq2vec_skips_unknown_characters():
     """Unknown sequence regions should be skipped and not create tokens."""
     words = {"AC": 1, "GU": 2}
     sequences = (["XXACYYGUZZ"], ["--HH--TT--"])
-    
+
     out_seq, out_ss = seq2vec(
         sequence_list=sequences,
         words=words,
         seq_max_len=4,
         word_max_len=2,
     )
-    
     np.testing.assert_array_equal(out_seq, np.array([[1.0, 2.0, 0.0, 0.0]]))
     np.testing.assert_array_equal(out_ss, np.array([[9.0, 54.0, 0.0, 0.0]]))
 
@@ -123,7 +124,6 @@ def test_seq2vec_shorter_than_pattern():
         seq_max_len=3,
         word_max_len=2,
     )
-    
     np.testing.assert_array_equal(out_seq, np.zeros((0, 3)))
     np.testing.assert_array_equal(out_ss, np.zeros((0, 3)))
 
@@ -132,7 +132,6 @@ def test_seq2vec_chunking_and_padding():
     """Long outputs should be chunked to seq_max_len and the tail padded."""
     words = {"A": 1}
     sequences = (["AAAAA"], ["HHHHH"])
-    
     out_seq, out_ss = seq2vec(
         sequence_list=sequences,
         words=words,


### PR DESCRIPTION
#### Reference Issues/PRs
Closes #282 .

#### What does this implement/fix? Explain your changes.
This PR improves sequence vectorization and completes tokenizer unification for the current scope.

- Added a shared internal greedy tokenizer core in `pyaptamer/utils/_rna.py`.
- Refactored `encode_rna` in `pyaptamer/utils/_rna.py` to use the shared core.
- Refactored `seq2vec` in `pyaptamer/utils/_aptatrans_utils.py` to use the same shared core with span-aware secondary-structure alignment.
- Kept public APIs stable for `encode_rna` and `seq2vec`.
- Preserved behavior contracts for unknown handling, truncation/chunking, and zero-padding.
- Added shared-core tests in `pyaptamer/utils/tests/test_rna.py` and kept parity/edge-case tests in `pyaptamer/utils/tests/test_seq2vec.py`.

#### What should a reviewer concentrate their feedback on?
- Behavior parity of `encode_rna` and `seq2vec` after tokenizer unification.
- Correctness of greedy longest-first matching and unknown-token policy handling.
- Correctness of span-based secondary-structure alignment in `seq2vec`.
- Whether shared-core placement in `pyaptamer/utils/_rna.py` is appropriate for follow-up reuse.

#### Did you add any tests for the change?
Yes.

Added/updated tests include:
- `pyaptamer/utils/tests/test_rna.py`:
  - append-zero policy behavior
  - skip policy behavior
  - chunking with span alignment
  - invalid chunk-size guard
  - tokenize-to-chunks combined behavior
- `pyaptamer/utils/tests/test_seq2vec.py`:
  - legacy parity check
  - empty-vocabulary guard
  - unknown-region skipping behavior
  - shorter-than-pattern edge case
  - chunking and padding behavior

#### Any other comments?
- This PR completes tokenizer unification for `encode_rna` and `seq2vec`.
- Benchmark and lockfile artifacts are intentionally excluded from this PR.

#### PR checklist
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
  To run hooks independent of commit, execute `pre-commit run --all-files`
