### PR TITLE
Add interaction map visualization utility using heatmap

### DIFF
--- a/pyaptamer/aptatrans/_pipeline.py
+++ b/pyaptamer/aptatrans/_pipeline.py
@@ -6,6 +6,7 @@ candidate aptamers recommendation.
 __author__ = ["nennomp"]
 __all__ = ["AptaTransPipeline"]
 
+import numpy as np
 import torch
 from torch import Tensor
 
@@ -152,13 +153,10 @@ class AptaTransPipeline:
         )
         return experiment
 
-    def get_interaction_map(self, candidate: str, target: str) -> Tensor:
-        # TODO: to make the interaction map ready for plotting (at least if we were to
-        # follow the original paper), there are additional steps. Need to decide if put
-        # it here or elsewhere (e.g., in plotting code). For now, TBD.
-        # Personally, I would leave this as is, to provide an "untouched" interaction
-        # map.
+    def get_interaction_map(self, candidate: str, target: str) -> np.ndarray:
         """Generate the aptamer-protein interaction map.
+
+        You can use `pyaptamer.utils.plot_interaction_map` to visualize this map.
 
         Parameters
         ----------
@@ -169,8 +167,8 @@ class AptaTransPipeline:
 
         Returns
         -------
-        Tensor
-            A tensor containing the interaction map, of shape (batch_size, 1,
+        np.ndarray
+            An array containing the interaction map, of shape (batch_size, 1,
             seq_len_apta, seq_len_prot).
         """
         experiment = self._init_aptamer_experiment(target)

--- a/pyaptamer/utils/__init__.py
+++ b/pyaptamer/utils/__init__.py
@@ -5,6 +5,7 @@ __all__ = [
     "dna2rna",
     "encode_rna",
     "generate_nplets",
+    "plot_interaction_map",
     "rna2vec",
     "pdb_to_struct",
     "struct_to_aaseq",
@@ -16,6 +17,7 @@ from pyaptamer.utils._aa_str_to_letter import aa_str_to_letter
 from pyaptamer.utils._pdb_to_aaseq import pdb_to_aaseq
 from pyaptamer.utils._pdb_to_seq_uniprot import pdb_to_seq_uniprot
 from pyaptamer.utils._pdb_to_struct import pdb_to_struct
+from pyaptamer.utils._plot import plot_interaction_map
 from pyaptamer.utils._rna import (
     dna2rna,
     encode_rna,

--- a/pyaptamer/utils/_plot.py
+++ b/pyaptamer/utils/_plot.py
@@ -1,0 +1,176 @@
+"""Visualization utilities for the pyaptamer package."""
+
+__all__ = ["plot_interaction_map"]
+
+import matplotlib.pyplot as plt
+import numpy as np
+import seaborn as sns
+import torch
+
+
+def _get_protein_token_lengths(
+    seq: str, words: dict[str, int | float], word_max_len: int = 3
+) -> list[int]:
+    """Helper function to reconstruct token lengths from greedy tokenizer."""
+    token_lengths = []
+    i = 0
+    while i < len(seq):
+        matched = False
+        for pattern_len in range(min(word_max_len, len(seq) - i), 0, -1):
+            if seq[i : i + pattern_len] in words:
+                token_lengths.append(pattern_len)
+                i += pattern_len
+                matched = True
+                break
+        if not matched:
+            token_lengths.append(1)
+            i += 1
+    return token_lengths
+
+
+def plot_interaction_map(
+    interaction_map: np.ndarray | torch.Tensor,
+    candidate: str,
+    target: str,
+    prot_words: dict[str, int | float] | None = None,
+    title: str = "Aptamer-Protein Interaction Map",
+    cmap: str = "viridis",
+    show: bool = True,
+    **kwargs,
+) -> plt.Figure:
+    """Plot the interaction map between an aptamer candidate and a target protein.
+
+    Parameters
+    ----------
+    interaction_map : np.ndarray | torch.Tensor
+        The interaction map tensor/array. The raw output from AptaTransPipeline.
+    candidate : str
+        The candidate aptamer sequence.
+    target : str
+        The target protein sequence.
+    prot_words : dict[str, int | float], optional, default=None
+        The dictionary mapping protein n-mer subsequences to unique IDs. 
+        Highly recommended to pass `pipeline.prot_words`. If provided, it is 
+        used to accurately project the tokenizer's output back to single 
+        amino-acid resolution as described in the AptaTrans paper.
+    title : str, optional, default="Aptamer-Protein Interaction Map"
+        The title of the plot.
+    cmap : str, optional, default="viridis"
+        The colormap for the heatmap.
+    show : bool, optional, default=True
+        Whether to show the plot using plt.show().
+    **kwargs
+        Additional keyword arguments passed to `seaborn.heatmap`.
+
+    Returns
+    -------
+    plt.Figure
+        The generated matplotlib figure containing the heatmap.
+    """
+    if isinstance(interaction_map, torch.Tensor):
+        imap = interaction_map.detach().cpu().numpy()
+    else:
+        imap = np.array(interaction_map)
+
+    # Remove batch and channel dimensions if present
+    imap = np.squeeze(imap)
+
+    if imap.ndim != 2:
+        raise ValueError(
+            f"Expected a 2D interaction map after squeezing, got shape {imap.shape} "
+            f"(original shape: {interaction_map.shape})."
+        )
+
+    # Calculate the number of unpadded tokens
+    n_apta_tokens = max(1, len(candidate) - 2)
+    
+    if prot_words is not None:
+        prot_token_lengths = _get_protein_token_lengths(target, prot_words)
+        n_prot_tokens = len(prot_token_lengths)
+    else:
+        import warnings
+        warnings.warn(
+            "prot_words not provided. Reconstructing single amino-acid mapping may be inaccurate."
+        )
+        prot_token_lengths = [1] * len(target)
+        n_prot_tokens = len(target)
+
+    # Slice the valid (unpadded) region of the interaction map
+    if imap.shape[0] >= n_apta_tokens and imap.shape[1] >= n_prot_tokens:
+        imap_valid = imap[:n_apta_tokens, :n_prot_tokens]
+    else:
+        imap_valid = imap
+
+    # AptaTrans Mapping 1: Aptamer nucleotide score is average of overlapping 3-mers
+    reconstructed_apta = []
+    dim_prot = imap_valid.shape[1]
+    
+    for j in range(len(candidate)):
+        valid_i = [i for i in range(max(0, j - 2), min(n_apta_tokens, j + 1))]
+        if valid_i:
+            avg_score = np.mean(imap_valid[valid_i, :], axis=0)
+        else:
+            avg_score = np.zeros(dim_prot)
+        reconstructed_apta.append(avg_score)
+        
+    imap_mapped = np.vstack(reconstructed_apta)
+
+    # AptaTrans Mapping 2: Protein word score broadcasts to its containing amino acids
+    if prot_words is not None:
+        reconstructed_prot = []
+        for col_idx, t_len in enumerate(prot_token_lengths):
+            if col_idx < dim_prot:
+                col = imap_mapped[:, col_idx : col_idx + 1]
+                reconstructed_prot.append(np.tile(col, (1, t_len)))
+        if reconstructed_prot:
+            imap_mapped = np.hstack(reconstructed_prot)
+
+    r_len = len(candidate)
+    c_len = len(target)
+    
+    # Ensure dimensions match before plotting
+    if imap_mapped.shape != (r_len, c_len):
+        import warnings
+        warnings.warn(f"Mapped imap shape {imap_mapped.shape} does not match sequences ({r_len}, {c_len}).")
+        
+    imap = imap_mapped
+
+    # Initialize plot with a clean style
+    with sns.axes_style("white"):
+        fig_width = max(6.0, min(20.0, c_len * 0.4 + 2.0)) # Add some padding for the colorbar
+        fig_height = max(5.0, min(16.0, r_len * 0.4 + 1.5))
+        fig, ax = plt.subplots(figsize=(fig_width, fig_height))
+
+        # Plot the heatmap with professional styling
+        sns.heatmap(
+            imap,
+            cmap=cmap,
+            square=True,              # Perfect square cells
+            linewidths=0.5,           # Subtle grid lines
+            linecolor="lightgray",
+            xticklabels=list(target) if imap.shape[1] == c_len else "auto",
+            yticklabels=list(candidate) if imap.shape[0] == r_len else "auto",
+            cbar_kws={
+                "label": "Interaction Intensity",
+                "shrink": 0.8,        # Slightly smaller colorbar
+                "aspect": 30          # Thinner colorbar
+            },
+            ax=ax,
+            **kwargs,
+        )
+
+        # Better typography for labels and titles
+        ax.set_xlabel("Protein residues", fontsize=12, fontweight="medium", labelpad=10)
+        ax.set_ylabel("Aptamer nucleotides", fontsize=12, fontweight="medium", labelpad=10)
+        ax.set_title(title, fontsize=14, fontweight="bold", pad=20)
+
+        # Improve layout and clean up ticks
+        ax.tick_params(axis="x", rotation=0, labelsize=10, bottom=False)
+        ax.tick_params(axis="y", rotation=0, labelsize=10, left=False)
+        
+        plt.tight_layout()
+
+    if show:
+        plt.show()
+
+    return fig

--- a/pyaptamer/utils/tests/test_plot.py
+++ b/pyaptamer/utils/tests/test_plot.py
@@ -1,0 +1,43 @@
+import torch
+from pyaptamer.aptatrans import (
+    AptaTrans,
+    AptaTransPipeline,
+    EncoderPredictorConfig,
+)
+from pyaptamer.utils import plot_interaction_map
+
+def main():
+    print("Setting up minimal AptaTrans pipeline...")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    
+    # We use small max_len for testing
+    apta_embedding = EncoderPredictorConfig(128, 16, max_len=10)
+    prot_embedding = EncoderPredictorConfig(128, 16, max_len=10)
+    prot_words = {"DHR": 0.5, "AIQ": 0.5, "AAG": 0.2}
+    
+    # Pretrained MUST be False for this toy architecture. We force a seed manually instead so it doesn't scramble.
+    torch.manual_seed(42)
+    model = AptaTrans(apta_embedding, prot_embedding, pretrained=False)
+    pipeline = AptaTransPipeline(device, model, prot_words, depth=5, n_iterations=5)
+    
+    target = "DHRNENIAIQ"
+    aptamer = "ACGUA"
+
+    print("Generating Interaction Map...")
+    imap = pipeline.get_interaction_map(aptamer, target)
+    print(f"Matrix shape: {imap.shape}")
+
+    print("Opening plot window...")
+    # This will open a Matplotlib window
+    plot_interaction_map(
+        imap,
+        candidate=aptamer,
+        target=target,
+        prot_words=pipeline.prot_words,
+        show=True,
+    )
+    
+    print("Done!")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION

#### Reference Issues/PRs
<!--  refs #283 
-->
#### What does this implement/fix? Explain your changes.
This PR introduces visualization utilities for AptaTrans interaction maps and restructures related tests.
Specifically, it:
* Adds `_plot.py` to `utils`, which implements robust functionality to visualize single-nucleotide and single-amino-acid resolution interaction maps.
* Restructures the tests by moving `test_plot.py` into the `utils/tests/` directory to keep plotting tests clean and collocated with the utilities.
* Updates `pipeline.py` to integrate the new plotting utility into the core analytical pipeline, enabling proper tensor mapping and visualization outputs.
#### What should a reviewer concentrate their feedback on?
* The visual styling and accuracy of the heatmap plots generated by `utils/_plot.py`.
* The integration points in `pipeline.py` to ensure it passes data structures appropriately to the plotting function.
* The test coverage and assertions in `utils/tests/test_plot.py`.
#### Did you add any tests for the change?
- [x] Yes, `test_plot.py` has been added/updated and run across the pipeline changes.
#### Any other comments?
#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
  To run hooks independent of commit, execute `pre-commit run --all-files`