### PR TITLE
Reconstruct encoded sequence before evaluation in MCTS simulation

### DIFF
--- a/pyaptamer/mcts/_algorithm.py
+++ b/pyaptamer/mcts/_algorithm.py
@@ -228,6 +228,9 @@ class MCTS(BaseObject):
         for _ in range(remaining_length):
             sequence += random.choice(self.states)
 
+        # reconstruct the encoded sequence (e.g., "A__C" -> "CA") before evaluation
+        sequence = self._reconstruct(sequence)
+
         # evaluate the candidate sequence with the goal function
         return self.experiment.evaluate(sequence)
 


### PR DESCRIPTION
## Fix incorrect sequence evaluation in MCTS simulation

### What was happening
During simulation, we were passing encoded sequences (with `_` markers) directly to the evaluator. These got converted into invalid sequences internally (full of `N`s), so the scores driving the MCTS search were basically meaningless.

### What’s changed
We now reconstruct the sequence using `_reconstruct()` before evaluation, so the model sees the actual nucleotide sequence.

### Why it matters
This ensures the search is guided by real scores instead of corrupted ones, making the generated candidates much more reliable.