### PR TITLE
[BUG] Fix Benchmarking duplicate estimator label collisions

### DIFF
--- a/pyaptamer/benchmarking/_base.py
+++ b/pyaptamer/benchmarking/_base.py
@@ -95,6 +95,30 @@ class Benchmarking:
             scorers[name] = make_scorer(metric)
         return scorers
 
+    def _get_estimator_names(self):
+        """Return stable display names for estimators.
+
+        If multiple estimators share the same class, append a 1-based index to keep
+        their result rows distinct.
+        """
+        class_names = [estimator.__class__.__name__ for estimator in self.estimators]
+        class_counts = {
+            class_name: class_names.count(class_name) for class_name in set(class_names)
+        }
+        class_positions = {class_name: 0 for class_name in class_counts}
+
+        names = []
+        for estimator in self.estimators:
+            class_name = estimator.__class__.__name__
+            if class_counts[class_name] == 1:
+                names.append(class_name)
+                continue
+
+            class_positions[class_name] += 1
+            names.append(f"{class_name}[{class_positions[class_name]}]")
+
+        return names
+
     def _to_df(self, results):
         """Convert nested results to a unified DataFrame."""
         records = []
@@ -127,10 +151,11 @@ class Benchmarking:
         """
         self.scorers_ = self._to_scorers(self.metrics)
         results = {}
+        estimator_names = self._get_estimator_names()
 
-        for estimator in self.estimators:
-            est_name = estimator.__class__.__name__
-
+        for estimator, est_name in zip(
+            self.estimators, estimator_names, strict=False
+        ):
             cv_results = cross_validate(
                 estimator,
                 self.X,

--- a/pyaptamer/benchmarking/_base.py
+++ b/pyaptamer/benchmarking/_base.py
@@ -100,8 +100,8 @@ class Benchmarking:
     def _get_estimator_names(self):
         """Return stable display names for estimators.
 
-        If multiple estimators share the same class, append a 1-based index to keep
-        their result rows distinct.
+        If multiple estimators share the same class, append a deterministic 1-based
+        suffix (e.g., ``DummyClassifier_1``) to keep their result rows distinct.
         """
         class_names = [estimator.__class__.__name__ for estimator in self.estimators]
         class_counts = Counter(class_names)
@@ -115,7 +115,7 @@ class Benchmarking:
                 continue
 
             class_positions[class_name] += 1
-            names.append(f"{class_name}[{class_positions[class_name]}]")
+            names.append(f"{class_name}_{class_positions[class_name]}")
 
         return names
 

--- a/pyaptamer/benchmarking/_base.py
+++ b/pyaptamer/benchmarking/_base.py
@@ -1,6 +1,8 @@
 __author__ = "satvshr"
 __all__ = ["Benchmarking"]
 
+from collections import Counter
+
 import numpy as np
 import pandas as pd
 from sklearn.metrics import make_scorer
@@ -102,9 +104,7 @@ class Benchmarking:
         their result rows distinct.
         """
         class_names = [estimator.__class__.__name__ for estimator in self.estimators]
-        class_counts = {
-            class_name: class_names.count(class_name) for class_name in set(class_names)
-        }
+        class_counts = Counter(class_names)
         class_positions = {class_name: 0 for class_name in class_counts}
 
         names = []
@@ -153,9 +153,7 @@ class Benchmarking:
         results = {}
         estimator_names = self._get_estimator_names()
 
-        for estimator, est_name in zip(
-            self.estimators, estimator_names, strict=False
-        ):
+        for estimator, est_name in zip(self.estimators, estimator_names, strict=True):
             cv_results = cross_validate(
                 estimator,
                 self.X,

--- a/pyaptamer/benchmarking/_base.py
+++ b/pyaptamer/benchmarking/_base.py
@@ -105,7 +105,7 @@ class Benchmarking:
         """
         class_names = [estimator.__class__.__name__ for estimator in self.estimators]
         class_counts = Counter(class_names)
-        class_positions = {class_name: 0 for class_name in class_counts}
+        class_positions = dict.fromkeys(class_counts, 0)
 
         names = []
         for estimator in self.estimators:

--- a/pyaptamer/benchmarking/tests/test_benchmarking_core.py
+++ b/pyaptamer/benchmarking/tests/test_benchmarking_core.py
@@ -23,8 +23,8 @@ def test_benchmarking_keeps_duplicate_estimator_classes_distinct():
 
     summary = bench.run()
 
-    assert ("DummyClassifier[1]", "accuracy_score") in summary.index
-    assert ("DummyClassifier[2]", "accuracy_score") in summary.index
+    assert ("DummyClassifier_1", "accuracy_score") in summary.index
+    assert ("DummyClassifier_2", "accuracy_score") in summary.index
     assert len(summary) == 2
 
 

--- a/pyaptamer/benchmarking/tests/test_benchmarking_core.py
+++ b/pyaptamer/benchmarking/tests/test_benchmarking_core.py
@@ -1,0 +1,46 @@
+import numpy as np
+from sklearn.dummy import DummyClassifier, DummyRegressor
+from sklearn.metrics import accuracy_score
+
+from pyaptamer.benchmarking._base import Benchmarking
+
+
+def test_benchmarking_keeps_duplicate_estimator_classes_distinct():
+    """Estimators with the same class should not overwrite one another."""
+    X = np.array([[0], [1], [0], [1], [0], [1], [0], [1]])
+    y = np.array([0, 1, 0, 1, 0, 1, 0, 1])
+
+    bench = Benchmarking(
+        estimators=[
+            DummyClassifier(strategy="most_frequent"),
+            DummyClassifier(strategy="stratified", random_state=0),
+        ],
+        metrics=[accuracy_score],
+        X=X,
+        y=y,
+        cv=2,
+    )
+
+    summary = bench.run()
+
+    assert ("DummyClassifier[1]", "accuracy_score") in summary.index
+    assert ("DummyClassifier[2]", "accuracy_score") in summary.index
+    assert len(summary) == 2
+
+
+def test_benchmarking_preserves_unique_estimator_names():
+    """Different estimator classes should keep their original class names."""
+    bench = Benchmarking(
+        estimators=[
+            DummyClassifier(strategy="most_frequent"),
+            DummyRegressor(strategy="mean"),
+        ],
+        metrics=[accuracy_score],
+        X=np.array([[0], [1]]),
+        y=np.array([0, 1]),
+        cv=2,
+    )
+
+    names = bench._get_estimator_names()
+
+    assert names == ["DummyClassifier", "DummyRegressor"]


### PR DESCRIPTION
Closes #297.

## What this changes
- disambiguates duplicate estimator class names in `Benchmarking` results with deterministic 1-based suffixes
- preserves the original class name when there is only one estimator of that class
- adds a regression test proving two `DummyClassifier` instances no longer overwrite one another
- adds a regression test proving distinct estimator classes keep their original labels

## Validation
- `pytest -q pyaptamer/benchmarking/tests/test_benchmarking_core.py`
