### PR TITLE
[BUG] Handle missing package metadata when importing from source

### DIFF
--- a/pyaptamer/__init__.py
+++ b/pyaptamer/__init__.py
@@ -1,5 +1,8 @@
 """pyaptamer: Python library for aptamer design."""
 
-from importlib.metadata import version
+from importlib.metadata import PackageNotFoundError, version
 
-__version__ = version("pyaptamer")
+try:
+    __version__ = version("pyaptamer")
+except PackageNotFoundError:
+    __version__ = "0+unknown"

--- a/pyaptamer/tests/test_import.py
+++ b/pyaptamer/tests/test_import.py
@@ -1,0 +1,17 @@
+"""Tests for package import behavior."""
+
+import subprocess
+import sys
+
+
+def test_import_from_source_checkout_without_installed_metadata():
+    """Importing pyaptamer from a checkout should not require wheel metadata."""
+    result = subprocess.run(
+        [sys.executable, "-c", "import pyaptamer; print(pyaptamer.__version__)"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip()

--- a/pyaptamer/tests/test_import.py
+++ b/pyaptamer/tests/test_import.py
@@ -6,12 +6,32 @@ import sys
 
 def test_import_from_source_checkout_without_installed_metadata():
     """Importing pyaptamer from a checkout should not require wheel metadata."""
+    # This forces the "no installed metadata" path even in CI where the package is
+    # installed. The patch happens before importing pyaptamer, so the module-level
+    # `from importlib.metadata import version` picks up the patched function.
+    python_code = "\n".join(
+        [
+            "import importlib.metadata as m",
+            "orig = m.version",
+            "def fake(name):",
+            "    if name == 'pyaptamer':",
+            "        raise m.PackageNotFoundError(name)",
+            "    return orig(name)",
+            "m.version = fake",
+            "import pyaptamer",
+            "print(pyaptamer.__version__)",
+        ]
+    )
     result = subprocess.run(
-        [sys.executable, "-c", "import pyaptamer; print(pyaptamer.__version__)"],
+        [
+            sys.executable,
+            "-c",
+            python_code,
+        ],
         capture_output=True,
         text=True,
         check=False,
     )
 
     assert result.returncode == 0, result.stderr
-    assert result.stdout.strip()
+    assert result.stdout.strip() == "0+unknown"


### PR DESCRIPTION
Closes #298.

## Summary
Importing `pyaptamer` directly from a source checkout can fail when distribution metadata is not present (e.g. no editable/wheel install, no `pyaptamer.egg-info`). This PR makes `pyaptamer` import robust in that scenario.

## What changed
- `pyaptamer/__init__.py`: wrap `importlib.metadata.version("pyaptamer")` in `try/except PackageNotFoundError` and fall back to `__version__ = "0+unknown"`.
- `pyaptamer/tests/test_import.py`: add a subprocess regression test that forces the no-metadata path by patching `importlib.metadata.version` to raise `PackageNotFoundError` before importing `pyaptamer`.

## Validation
- `pytest -q pyaptamer/tests/test_import.py`


