### PR TITLE
[BUG] Remove stale and duplicate entries from datasets __all__

### DIFF
--- a/pyaptamer/datasets/__init__.py
+++ b/pyaptamer/datasets/__init__.py
@@ -17,13 +17,11 @@ __all__ = [
     "load_aptacom_full",
     "load_aptacom_x_y",
     "load_csv_dataset",
-    "load_hf_dataset",
     "load_from_rcsb",
     "load_1brq",
     "load_5nu7",
     "load_1gnh",
     "load_pfoa",
-    "load_from_rcsb",
     "load_li2014",
     "load_hf_to_dataset",
 ]


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #301

#### What does this implement/fix? Explain your changes.
The `__all__` list in `pyaptamer/datasets/__init__.py` contained two problems:
- `"load_hf_dataset"` was left behind when the function was renamed to `load_hf_to_dataset` in #204.
- `"load_from_rcsb"` appeared twice.

This PR removes the stale `"load_hf_dataset"` entry and the duplicate `"load_from_rcsb"` entry.

#### What should a reviewer concentrate their feedback on?
Verify that the corrected `__all__` list matches the actual imports in the module.

#### Did you add any tests for the change?
No tests needed -- this is a metadata-only fix to the public API surface list.

#### Any other comments?
None.

#### PR checklist
- [x] The PR title starts with [BUG]
- [x] Used pre-commit hooks