### PR TITLE
[BUG] Fix typo "grater" to "greater" in AptaTransPipeline validation …

### DIFF
--- a/pyaptamer/aptatrans/_pipeline.py
+++ b/pyaptamer/aptatrans/_pipeline.py
@@ -102,7 +102,7 @@ class AptaTransPipeline:
         """
         if depth < 3:
             raise ValueError(
-                f"Invalid depth value: {depth}. Must be grater or equal than 3."
+                f"Invalid depth value: {depth}. Must be greater than or equal to 3."
             )
 
         self.device = device


### PR DESCRIPTION
#### Reference Issues/PRs

  

Fixes #305

  

#### What does this implement/fix? Explain your changes.

  

Fixes a typo in the `AptaTransPipeline` depth validation error message. Changed "Must be grater or equal than 3" to "Must be greater than or equal to 3."

  

#### What should a reviewer concentrate their feedback on?

  

- One-line string change in `pyaptamer/aptatrans/_pipeline.py`, line 105

  

#### Did you add any tests for the change?

  

No — this is a string-only fix with no logic change.

  

#### Any other comments?

  

N/A

  

#### PR checklist

  

- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.

- [ ] Added/modified tests

- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.

To run hooks independent of commit, execute `pre-commit run --all-files`