### PR TITLE
[ENH] Add AptaDB loader for all six database tables

### DIFF
--- a/pyaptamer/datasets/__init__.py
+++ b/pyaptamer/datasets/__init__.py
@@ -7,6 +7,14 @@ from pyaptamer.datasets._loaders._aptacom_loader import (
     load_aptacom_full,
     load_aptacom_x_y,
 )
+from pyaptamer.datasets._loaders._aptadb_loader import (
+    load_aptadb_aptamer,
+    load_aptadb_cell,
+    load_aptadb_interaction,
+    load_aptadb_molecule,
+    load_aptadb_other,
+    load_aptadb_protein,
+)
 from pyaptamer.datasets._loaders._csv_loader import load_csv_dataset
 from pyaptamer.datasets._loaders._hf_to_dataset_loader import load_hf_to_dataset
 from pyaptamer.datasets._loaders._li2014 import load_li2014
@@ -16,6 +24,12 @@ from pyaptamer.datasets._loaders._pfoa import load_pfoa
 __all__ = [
     "load_aptacom_full",
     "load_aptacom_x_y",
+    "load_aptadb_interaction",
+    "load_aptadb_aptamer",
+    "load_aptadb_protein",
+    "load_aptadb_molecule",
+    "load_aptadb_cell",
+    "load_aptadb_other",
     "load_csv_dataset",
     "load_hf_dataset",
     "load_from_rcsb",

--- a/pyaptamer/datasets/_loaders/_aptadb_loader.py
+++ b/pyaptamer/datasets/_loaders/_aptadb_loader.py
@@ -1,0 +1,342 @@
+__author__ = "Jayant-kernel"
+__all__ = [
+    "load_aptadb_interaction",
+    "load_aptadb_aptamer",
+    "load_aptadb_protein",
+    "load_aptadb_molecule",
+    "load_aptadb_cell",
+    "load_aptadb_other",
+]
+
+from pathlib import Path
+
+import pandas as pd
+import requests
+
+_APTADB_BASE_URL = "https://lmmd.ecust.edu.cn/aptadb/download/"
+
+_TABLES = {
+    "interaction": "interaction.csv",
+    "aptamer": "aptamer.csv",
+    "protein": "protein.csv",
+    "molecule": "molecule.csv",
+    "cell": "cell.csv",
+    "other": "other.csv",
+}
+
+_DEFAULT_CACHE_DIR = Path.home() / ".pyaptamer" / "cache" / "aptadb"
+
+
+def _download_csv(table_name, cache_dir, force_download=False):
+    """Download a single AptaDB CSV file to the local cache directory.
+
+    Parameters
+    ----------
+    table_name : str
+        One of: ``"interaction"``, ``"aptamer"``, ``"protein"``,
+        ``"molecule"``, ``"cell"``, or ``"other"``.
+    cache_dir : pathlib.Path
+        Directory to cache downloaded files.
+    force_download : bool, default False
+        If ``True``, re-download even if the file already exists.
+
+    Returns
+    -------
+    pathlib.Path
+        Local path of the downloaded CSV file.
+    """
+    filename = _TABLES[table_name]
+    local_path = cache_dir / filename
+    if not local_path.exists() or force_download:
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        url = _APTADB_BASE_URL + filename
+        response = requests.get(url, timeout=60)
+        response.raise_for_status()
+        local_path.write_bytes(response.content)
+    return local_path
+
+
+def _load_table(table_name, cache_dir=None, force_download=False, **read_csv_kwargs):
+    """Download (if needed) and load an AptaDB CSV table as a pandas DataFrame.
+
+    Parameters
+    ----------
+    table_name : str
+        One of: ``"interaction"``, ``"aptamer"``, ``"protein"``,
+        ``"molecule"``, ``"cell"``, or ``"other"``.
+    cache_dir : str or pathlib.Path, optional
+        Directory for caching downloaded CSV files.
+        Defaults to ``~/.pyaptamer/cache/aptadb/``.
+    force_download : bool, default False
+        Re-download the file even when a cached copy exists.
+    **read_csv_kwargs
+        Additional keyword arguments forwarded to ``pandas.read_csv``.
+
+    Returns
+    -------
+    pandas.DataFrame
+        The loaded table as a DataFrame.
+    """
+    if cache_dir is None:
+        cache_dir = _DEFAULT_CACHE_DIR
+    else:
+        cache_dir = Path(cache_dir)
+    local_path = _download_csv(table_name, cache_dir, force_download=force_download)
+    return pd.read_csv(local_path, encoding="latin-1", **read_csv_kwargs)
+
+
+def load_aptadb_interaction(cache_dir=None, force_download=False, **kwargs):
+    """Load the AptaDB aptamer-target interaction table.
+
+    Downloads ``interaction.csv`` from https://lmmd.ecust.edu.cn/aptadb
+    and returns it as a ``pandas.DataFrame``. The file is cached locally
+    after the first download.
+
+    Parameters
+    ----------
+    cache_dir : str or pathlib.Path, optional
+        Directory for caching the downloaded CSV.
+        Defaults to ``~/.pyaptamer/cache/aptadb/``.
+    force_download : bool, default False
+        If ``True``, re-download even when a cached copy exists.
+    **kwargs
+        Additional keyword arguments forwarded to ``pandas.read_csv``.
+
+    Returns
+    -------
+    pandas.DataFrame
+        The AptaDB interaction table. Each row describes one aptamer-target
+        interaction. Columns include at minimum:
+
+        - ``Aptamer_ID`` - AptaDB internal aptamer identifier.
+        - ``Target_ID`` - AptaDB internal target identifier.
+        - ``Aptamer_Sequence`` - Nucleotide sequence of the aptamer.
+        - ``Target_Name`` - Name of the binding target.
+        - ``Kd`` - Dissociation constant (affinity) value.
+        - ``Kd_Unit`` - Unit for the Kd value.
+        - ``Selection_Method`` - SELEX or other selection method used.
+        - ``Reference`` - Literature reference (PubMed ID or DOI).
+
+    Examples
+    --------
+    >>> from pyaptamer.datasets import load_aptadb_interaction
+    >>> df = load_aptadb_interaction()
+    >>> type(df).__name__
+    'DataFrame'
+    """
+    return _load_table(
+        "interaction", cache_dir=cache_dir, force_download=force_download, **kwargs
+    )
+
+
+def load_aptadb_aptamer(cache_dir=None, force_download=False, **kwargs):
+    """Load the AptaDB aptamer sequence and property table.
+
+    Downloads ``aptamer.csv`` from https://lmmd.ecust.edu.cn/aptadb
+    and returns it as a ``pandas.DataFrame``. The file is cached locally
+    after the first download.
+
+    Parameters
+    ----------
+    cache_dir : str or pathlib.Path, optional
+        Directory for caching the downloaded CSV.
+        Defaults to ``~/.pyaptamer/cache/aptadb/``.
+    force_download : bool, default False
+        If ``True``, re-download even when a cached copy exists.
+    **kwargs
+        Additional keyword arguments forwarded to ``pandas.read_csv``.
+
+    Returns
+    -------
+    pandas.DataFrame
+        The AptaDB aptamer table. Each row describes one aptamer.
+        Columns include at minimum:
+
+        - ``Aptamer_ID`` - AptaDB internal aptamer identifier.
+        - ``Aptamer_Name`` - Common name of the aptamer.
+        - ``Aptamer_Sequence`` - Nucleotide sequence.
+        - ``Aptamer_Type`` - Chemistry type (DNA, RNA, or modified).
+        - ``Aptamer_Length`` - Length of the aptamer sequence.
+        - ``GC_Content`` - GC content percentage.
+        - ``Molecular_Weight`` - Estimated molecular weight.
+        - ``Structure`` - Secondary structure notation (if available).
+
+    Examples
+    --------
+    >>> from pyaptamer.datasets import load_aptadb_aptamer
+    >>> df = load_aptadb_aptamer()
+    >>> type(df).__name__
+    'DataFrame'
+    """
+    return _load_table(
+        "aptamer", cache_dir=cache_dir, force_download=force_download, **kwargs
+    )
+
+
+def load_aptadb_protein(cache_dir=None, force_download=False, **kwargs):
+    """Load the AptaDB protein target table.
+
+    Downloads ``protein.csv`` from https://lmmd.ecust.edu.cn/aptadb
+    and returns it as a ``pandas.DataFrame``. The file is cached locally
+    after the first download.
+
+    Parameters
+    ----------
+    cache_dir : str or pathlib.Path, optional
+        Directory for caching the downloaded CSV.
+        Defaults to ``~/.pyaptamer/cache/aptadb/``.
+    force_download : bool, default False
+        If ``True``, re-download even when a cached copy exists.
+    **kwargs
+        Additional keyword arguments forwarded to ``pandas.read_csv``.
+
+    Returns
+    -------
+    pandas.DataFrame
+        The AptaDB protein table. Each row describes one protein target.
+        Columns include at minimum:
+
+        - ``Target_ID`` - AptaDB internal target identifier.
+        - ``Target_Name`` - Protein name.
+        - ``UniProt_ID`` - UniProt accession number.
+        - ``Protein_Sequence`` - Amino acid sequence.
+        - ``Organism`` - Source organism.
+        - ``RCSB_PDB_ID`` - PDB structure identifier (if available).
+
+    Examples
+    --------
+    >>> from pyaptamer.datasets import load_aptadb_protein
+    >>> df = load_aptadb_protein()
+    >>> type(df).__name__
+    'DataFrame'
+    """
+    return _load_table(
+        "protein", cache_dir=cache_dir, force_download=force_download, **kwargs
+    )
+
+
+def load_aptadb_molecule(cache_dir=None, force_download=False, **kwargs):
+    """Load the AptaDB small molecule target table.
+
+    Downloads ``molecule.csv`` from https://lmmd.ecust.edu.cn/aptadb
+    and returns it as a ``pandas.DataFrame``. The file is cached locally
+    after the first download.
+
+    Parameters
+    ----------
+    cache_dir : str or pathlib.Path, optional
+        Directory for caching the downloaded CSV.
+        Defaults to ``~/.pyaptamer/cache/aptadb/``.
+    force_download : bool, default False
+        If ``True``, re-download even when a cached copy exists.
+    **kwargs
+        Additional keyword arguments forwarded to ``pandas.read_csv``.
+
+    Returns
+    -------
+    pandas.DataFrame
+        The AptaDB small molecule table. Each row describes one small
+        molecule target. Columns include at minimum:
+
+        - ``Target_ID`` - AptaDB internal target identifier.
+        - ``Target_Name`` - Molecule name.
+        - ``CAS_Number`` - CAS registry number.
+        - ``Molecular_Formula`` - Chemical formula.
+        - ``Molecular_Weight`` - Molecular weight in g/mol.
+        - ``SMILES`` - SMILES notation.
+        - ``PubChem_CID`` - PubChem compound identifier.
+
+    Examples
+    --------
+    >>> from pyaptamer.datasets import load_aptadb_molecule
+    >>> df = load_aptadb_molecule()
+    >>> type(df).__name__
+    'DataFrame'
+    """
+    return _load_table(
+        "molecule", cache_dir=cache_dir, force_download=force_download, **kwargs
+    )
+
+
+def load_aptadb_cell(cache_dir=None, force_download=False, **kwargs):
+    """Load the AptaDB cellular target table.
+
+    Downloads ``cell.csv`` from https://lmmd.ecust.edu.cn/aptadb
+    and returns it as a ``pandas.DataFrame``. The file is cached locally
+    after the first download.
+
+    Parameters
+    ----------
+    cache_dir : str or pathlib.Path, optional
+        Directory for caching the downloaded CSV.
+        Defaults to ``~/.pyaptamer/cache/aptadb/``.
+    force_download : bool, default False
+        If ``True``, re-download even when a cached copy exists.
+    **kwargs
+        Additional keyword arguments forwarded to ``pandas.read_csv``.
+
+    Returns
+    -------
+    pandas.DataFrame
+        The AptaDB cell table. Each row describes one cellular target.
+        Columns include at minimum:
+
+        - ``Target_ID`` - AptaDB internal target identifier.
+        - ``Cell_Name`` - Cell line or cell type name.
+        - ``Cell_Type`` - Classification (e.g. cancer, normal).
+        - ``Organism`` - Source organism.
+        - ``Tissue`` - Tissue of origin.
+        - ``Disease`` - Associated disease (if applicable).
+
+    Examples
+    --------
+    >>> from pyaptamer.datasets import load_aptadb_cell
+    >>> df = load_aptadb_cell()
+    >>> type(df).__name__
+    'DataFrame'
+    """
+    return _load_table(
+        "cell", cache_dir=cache_dir, force_download=force_download, **kwargs
+    )
+
+
+def load_aptadb_other(cache_dir=None, force_download=False, **kwargs):
+    """Load the AptaDB miscellaneous target table.
+
+    Downloads ``other.csv`` from https://lmmd.ecust.edu.cn/aptadb
+    and returns it as a ``pandas.DataFrame``. The file is cached locally
+    after the first download.
+
+    Parameters
+    ----------
+    cache_dir : str or pathlib.Path, optional
+        Directory for caching the downloaded CSV.
+        Defaults to ``~/.pyaptamer/cache/aptadb/``.
+    force_download : bool, default False
+        If ``True``, re-download even when a cached copy exists.
+    **kwargs
+        Additional keyword arguments forwarded to ``pandas.read_csv``.
+
+    Returns
+    -------
+    pandas.DataFrame
+        The AptaDB other-targets table. Each row describes one target that
+        does not fall under protein, molecule, or cell categories. Columns
+        include at minimum:
+
+        - ``Target_ID`` - AptaDB internal target identifier.
+        - ``Target_Name`` - Target name.
+        - ``Target_Type`` - Category (virus, bacterium, etc.).
+        - ``Organism`` - Source organism (if applicable).
+        - ``Description`` - Free-text description of the target.
+
+    Examples
+    --------
+    >>> from pyaptamer.datasets import load_aptadb_other
+    >>> df = load_aptadb_other()
+    >>> type(df).__name__
+    'DataFrame'
+    """
+    return _load_table(
+        "other", cache_dir=cache_dir, force_download=force_download, **kwargs
+    )

--- a/pyaptamer/datasets/tests/test_aptadb_loader.py
+++ b/pyaptamer/datasets/tests/test_aptadb_loader.py
@@ -1,0 +1,57 @@
+__author__ = "Jayant-kernel"
+
+import pytest
+from pandas import DataFrame
+
+from pyaptamer.datasets import (
+    load_aptadb_aptamer,
+    load_aptadb_cell,
+    load_aptadb_interaction,
+    load_aptadb_molecule,
+    load_aptadb_other,
+    load_aptadb_protein,
+)
+
+
+@pytest.mark.parametrize(
+    "loader",
+    [
+        load_aptadb_interaction,
+        load_aptadb_aptamer,
+        load_aptadb_protein,
+        load_aptadb_molecule,
+        load_aptadb_cell,
+        load_aptadb_other,
+    ],
+)
+def test_load_aptadb_returns_dataframe(loader):
+    """Each AptaDB loader should return a non-empty pandas DataFrame."""
+    df = loader()
+    assert isinstance(df, DataFrame), (
+        f"{loader.__name__} returned {type(df)}, expected DataFrame"
+    )
+    assert len(df) > 0, f"{loader.__name__} returned an empty DataFrame"
+
+
+def test_load_aptadb_interaction_has_columns():
+    """Interaction table should have at least one column."""
+    df = load_aptadb_interaction()
+    assert isinstance(df, DataFrame)
+    assert df.shape[1] > 0
+
+
+def test_load_aptadb_cache(tmp_path):
+    """Loader should respect a custom cache_dir and not re-download."""
+    df1 = load_aptadb_interaction(cache_dir=tmp_path)
+    assert isinstance(df1, DataFrame)
+
+    # Second call must use cache (no network needed)
+    df2 = load_aptadb_interaction(cache_dir=tmp_path)
+    assert df1.shape == df2.shape
+
+
+def test_load_aptadb_force_download(tmp_path):
+    """force_download=True should re-download and still return a DataFrame."""
+    df = load_aptadb_interaction(cache_dir=tmp_path, force_download=True)
+    assert isinstance(df, DataFrame)
+    assert len(df) > 0


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #152. See also #159 (closed without merge).

#### What does this implement/fix? Explain your changes.

Adds Python loaders for all six AptaDB CSV tables
(`interaction`, `aptamer`, `protein`, `molecule`, `cell`, `other`),
downloading directly from https://lmmd.ecust.edu.cn/aptadb with
local caching under `~/.pyaptamer/cache/aptadb/`.

Each loader returns a `pandas.DataFrame` of the raw CSV as-is,
exactly as requested in the issue. No external credentials are
required — the AptaDB CSVs are publicly accessible.

**New files:**
- `pyaptamer/datasets/_loaders/_aptadb_loader.py` — six public loader
  functions (`load_aptadb_interaction`, `load_aptadb_aptamer`,
  `load_aptadb_protein`, `load_aptadb_molecule`, `load_aptadb_cell`,
  `load_aptadb_other`) plus two private helpers. All public functions
  have full NumPy-style docstrings including column descriptions.
- `pyaptamer/datasets/tests/test_aptadb_loader.py` — tests covering
  all six loaders, custom `cache_dir`, and `force_download`.

**Modified:**
- `pyaptamer/datasets/__init__.py` — registers all six loaders.

**Why not Kaggle (vs closed PR #159):**
The previous PR used the Kaggle API which requires credentials.
Loading directly from the AptaDB website is simpler, needs no auth,
and covers all six tables (not just interactions).

#### What should a reviewer concentrate their feedback on?

- The column descriptions in docstrings are based on the AptaDB website
  description. If the actual CSV headers differ, the docstrings should
  be updated after a test run.
- Whether `encoding="latin-1"` is the right default for all six tables
  (verified on `interaction.csv`; others may vary).
- Whether the cache location `~/.pyaptamer/cache/aptadb/` is consistent
  with project conventions.

#### Did you add any tests for the change?

Yes — `pyaptamer/datasets/tests/test_aptadb_loader.py`:

- `test_load_aptadb_returns_dataframe` — parametrized over all 6 loaders
- `test_load_aptadb_interaction_has_columns` — sanity check on shape
- `test_load_aptadb_cache` — verifies caching (second call matches first)
- `test_load_aptadb_force_download` — verifies `force_download=True`

#### Any other comments?

This picks up where #159 left off, addressing the reviewer feedback
from that PR (docstrings on all public functions, no Kaggle dependency,
proper test coverage).

#### PR checklist

- [x] The PR title starts with [ENH]
- [x] Added/modified tests
- [x] Code passes `ruff check` and `ruff format --check`