### PR TITLE
[BUG] Fix AMP crash: replace binary_cross_entropy with binary_cross_entropy_with_logits

### DIFF
--- a/pyaptamer/aptatrans/_model.py
+++ b/pyaptamer/aptatrans/_model.py
@@ -162,7 +162,6 @@ class AptaTrans(nn.Module):
                     ("linear1", nn.Linear(self.inplanes, self.inplanes // 2)),
                     ("activation1", nn.GELU()),
                     ("linear2", nn.Linear(self.inplanes // 2, 1)),
-                    ("activation2", nn.Sigmoid()),
                 ]
             )
         )

--- a/pyaptamer/aptatrans/_model_lightning.py
+++ b/pyaptamer/aptatrans/_model_lightning.py
@@ -101,11 +101,11 @@ class AptaTransLightning(L.LightningModule):
         """
         # (input aptamers, input proteins, ground-truth targets)
         x_apta, x_prot, y = batch
-        y_hat = torch.flatten(self.model(x_apta, x_prot))
-        loss = F.binary_cross_entropy(y_hat, y.float())
+        logits = torch.flatten(self.model(x_apta, x_prot))
+        loss = F.binary_cross_entropy_with_logits(logits, y.float())
 
         # compute accuracy
-        y_pred = (y_hat > 0.5).float()
+        y_pred = (logits > 0.0).float()
         accuracy = (y_pred == y.float()).float().mean()
 
         self._log_metric(f"{stage}_loss", loss)

--- a/pyaptamer/aptatrans/tests/test_aptatrans.py
+++ b/pyaptamer/aptatrans/tests/test_aptatrans.py
@@ -155,8 +155,7 @@ class TestAptaTransModel:
         output = aptatrans(x_apta, x_prot)
 
         assert output.shape == (batch_size, 1)
-        # output should be in [0, 1] (sigmoid activation)
-        assert torch.all(output >= 0.0) and torch.all(output <= 1.0)
+        # output is raw logits (unbounded), verify non-trivial outputs
         assert not torch.allclose(output[0], output[1], atol=1e-5)
 
 

--- a/pyaptamer/experiments/_aptamer_aptatrans.py
+++ b/pyaptamer/experiments/_aptamer_aptatrans.py
@@ -111,9 +111,8 @@ class AptamerEvalAptaTrans(BaseAptamerEval):
                 .numpy()
             )
         else:
-            return np.float64(
-                self.model(
-                    aptamer_candidate.to(self.device),
-                    self.target_encoded,
-                ).item()
+            logits = self.model(
+                aptamer_candidate.to(self.device),
+                self.target_encoded,
             )
+            return np.float64(torch.sigmoid(logits).item())


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #230.

#### What does this implement/fix? Explain your changes.

When finetuning AptaTrans with `precision=16-mixed` (AMP), training crashes with:

> `RuntimeError: torch.nn.functional.binary_cross_entropy and torch.nn.BCELoss are unsafe to autocast.`

The fix:

1. **`_model.py`**: Removed `nn.Sigmoid()` from the `fc` head so the model outputs raw logits instead of probabilities
2. **`_model_lightning.py`**: Replaced `F.binary_cross_entropy` with `F.binary_cross_entropy_with_logits` (AMP-safe). Changed accuracy threshold from `> 0.5` (probability) to `> 0.0` (logit) accordingly
3. **`_aptamer_aptatrans.py`**: Applied `torch.sigmoid()` explicitly at inference time so prediction scores remain in [0, 1]

This is the standard PyTorch pattern — `binary_cross_entropy_with_logits` combines sigmoid + BCE in a numerically stable way and is safe under autocast.

#### What should a reviewer concentrate their feedback on?

- The change in `_model.py` removes the sigmoid from the model's forward pass, which is a behavioral change. Any downstream code calling `model()` directly (outside the Lightning wrapper or experiment evaluator) will now receive logits instead of probabilities.
- Verify that `AptamerEvalAptaTrans.evaluate()` is the only inference path that needs the explicit sigmoid.

#### Did you add any tests for the change?

Updated existing test `test_forward` in `test_aptatrans.py` to remove the `[0, 1]` range assertion, since the model now outputs unbounded logits. All existing tests pass (34 passed, 1 skipped for CUDA).

#### Any other comments?

Pretraining (`AptaTransEncoderLightning`) was not affected since it uses `F.cross_entropy`, which is already AMP-safe.

#### PR checklist

- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks.