### PR TITLE
[BUG] Accept AptaCom-style DataFrames in AptaNetPipeline

### DIFF
--- a/pyaptamer/aptanet/tests/test_aptanet.py
+++ b/pyaptamer/aptanet/tests/test_aptanet.py
@@ -2,6 +2,7 @@ __author__ = ["nennomp", "satvshr"]
 
 
 import numpy as np
+import pandas as pd
 import pytest
 from sklearn.utils.estimator_checks import parametrize_with_checks
 
@@ -68,6 +69,32 @@ def test_pipeline_fit_and_predict_regression(aptamer_seq, protein_seq):
 
     assert preds.shape == (40,)
     assert np.issubdtype(preds.dtype, np.floating)
+
+
+@pytest.mark.parametrize("aptamer_seq, protein_seq", params)
+def test_pipeline_fit_and_predict_with_aptacom_dataframe(aptamer_seq, protein_seq):
+    """AptaNetPipeline should accept the AptaCom X schema directly."""
+    estimator = AptaNetClassifier(
+        hidden_dim=8,
+        n_hidden=1,
+        max_epochs=1,
+        random_state=0,
+    )
+    pipe = AptaNetPipeline(estimator=estimator)
+
+    X_raw = pd.DataFrame(
+        {
+            "aptamer_sequence": [aptamer_seq for _ in range(10)],
+            "target_sequence": [protein_seq for _ in range(10)],
+        }
+    )
+    y = np.array([0] * 5 + [1] * 5, dtype=np.float32)
+
+    pipe.fit(X_raw, y)
+    preds = pipe.predict(X_raw)
+
+    assert preds.shape == (10,)
+    assert set(preds).issubset({0, 1})
 
 
 @parametrize_with_checks(

--- a/pyaptamer/utils/_aptanet_utils.py
+++ b/pyaptamer/utils/_aptanet_utils.py
@@ -8,6 +8,11 @@ import pandas as pd
 
 from pyaptamer.pseaac import AptaNetPSeAAC
 
+_DATAFRAME_COLUMN_PAIRS = (
+    ("aptamer", "protein"),
+    ("aptamer_sequence", "target_sequence"),
+)
+
 
 def generate_kmer_vecs(aptamer_sequence, k=4):
     """
@@ -57,10 +62,25 @@ def generate_kmer_vecs(aptamer_sequence, k=4):
     return kmer_freq
 
 
+def _resolve_pair_columns(X: pd.DataFrame) -> tuple[str, str]:
+    """Resolve supported column names for DataFrame pair inputs."""
+    for aptamer_col, protein_col in _DATAFRAME_COLUMN_PAIRS:
+        if {aptamer_col, protein_col}.issubset(X.columns):
+            return aptamer_col, protein_col
+
+    supported = " or ".join(
+        f"{list(column_pair)!r}" for column_pair in _DATAFRAME_COLUMN_PAIRS
+    )
+    raise ValueError(
+        f"DataFrame input must contain {supported} columns. Got {list(X.columns)!r}."
+    )
+
+
 def pairs_to_features(X, k=4):
     """
     Convert a list of (aptamer_sequence, protein_sequence) pairs into feature vectors.
-    Also supports a pandas DataFrame with 'aptamer' and 'protein' columns.
+    Also supports pandas DataFrames with either ['aptamer', 'protein'] or
+    ['aptamer_sequence', 'target_sequence'] columns.
 
     This function generates feature vectors for each (aptamer, protein) pair using:
 
@@ -87,7 +107,8 @@ def pairs_to_features(X, k=4):
     feats = []
 
     if isinstance(X, pd.DataFrame):
-        pairs = zip(X["aptamer"], X["protein"], strict=False)
+        aptamer_col, protein_col = _resolve_pair_columns(X)
+        pairs = zip(X[aptamer_col], X[protein_col], strict=False)
     else:
         pairs = X
 

--- a/pyaptamer/utils/tests/test_aptanet_utils.py
+++ b/pyaptamer/utils/tests/test_aptanet_utils.py
@@ -1,0 +1,46 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from pyaptamer.utils._aptanet_utils import pairs_to_features
+
+APTAMER_SEQ = "AGCTTAGCGTACAGCTTAAAAGGGTTTCCCCTGCCCGCGTAC"
+PROTEIN_SEQ = "ACDEFGHIKLMNPQRSTVWYACDEFGHIKLMNPQRSTVWY"
+
+
+@pytest.mark.parametrize(
+    ("aptamer_col", "protein_col"),
+    [
+        ("aptamer", "protein"),
+        ("aptamer_sequence", "target_sequence"),
+    ],
+)
+def test_pairs_to_features_accepts_supported_dataframe_schemas(
+    aptamer_col, protein_col
+):
+    """Supported DataFrame schemas should produce the same feature matrix."""
+    pairs = [(APTAMER_SEQ, PROTEIN_SEQ), (APTAMER_SEQ, PROTEIN_SEQ)]
+    df = pd.DataFrame(
+        {
+            aptamer_col: [APTAMER_SEQ, APTAMER_SEQ],
+            protein_col: [PROTEIN_SEQ, PROTEIN_SEQ],
+        }
+    )
+
+    expected = pairs_to_features(pairs)
+    actual = pairs_to_features(df)
+
+    np.testing.assert_allclose(actual, expected)
+
+
+def test_pairs_to_features_rejects_unknown_dataframe_schema():
+    """Unsupported DataFrame schemas should fail with a helpful message."""
+    df = pd.DataFrame(
+        {
+            "aptamer_seq": [APTAMER_SEQ],
+            "protein_seq": [PROTEIN_SEQ],
+        }
+    )
+
+    with pytest.raises(ValueError, match="DataFrame input must contain"):
+        pairs_to_features(df)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #310.

#### What does this implement/fix? Explain your changes.
This updates the AptaNet feature-extraction path to accept both supported DataFrame schemas: the existing `aptamer` / `protein` column pair and the AptaCom loader's `aptamer_sequence` / `target_sequence` pair.

It also adds an explicit validation error for unsupported DataFrame schemas instead of surfacing a bare `KeyError` from pandas.

#### What should a reviewer concentrate their feedback on?
- Whether accepting both DataFrame schemas in `pairs_to_features` is the right compatibility surface for AptaNet callers.
- Whether the new validation error is clear enough for unsupported DataFrame inputs.

#### Did you add any tests for the change?
Yes.

Added regression coverage for:
- `pairs_to_features` with the legacy DataFrame schema.
- `pairs_to_features` with the AptaCom-style DataFrame schema.
- Unsupported DataFrame schemas raising a clear validation error.
- `AptaNetPipeline.fit/predict` working end-to-end with an AptaCom-style DataFrame.

#### Any other comments?
Validated locally with:
- `pytest pyaptamer/utils/tests/test_aptanet_utils.py pyaptamer/aptanet/tests/test_aptanet.py pyaptamer/benchmarking/tests/test_benchmarking.py -q`
- `ruff check pyaptamer/utils/_aptanet_utils.py pyaptamer/utils/tests/test_aptanet_utils.py pyaptamer/aptanet/tests/test_aptanet.py`
- `pre-commit run --files pyaptamer/utils/_aptanet_utils.py pyaptamer/utils/tests/test_aptanet_utils.py pyaptamer/aptanet/tests/test_aptanet.py`

#### PR checklist
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
  To run hooks independent of commit, execute `pre-commit run --all-files`
