### PR TITLE
[BUG] Honor MoleculeLoader ignore_duplicates when exporting sequences

### DIFF
--- a/pyaptamer/data/loader.py
+++ b/pyaptamer/data/loader.py
@@ -68,10 +68,15 @@ class MoleculeLoader:
                 sequences.append(row["sequence"])
 
         index = pd.MultiIndex.from_tuples(index_tuples, names=["path", "chain_id"])
+        df = pd.DataFrame(sequences, index=index, columns=["sequence"])
 
-        columns = ["sequence"] if self.columns is None else self.columns
+        if self.ignore_duplicates:
+            df = df.loc[~df["sequence"].duplicated(keep="first")]
 
-        return pd.DataFrame(sequences, index=index, columns=columns)
+        if self.columns is not None:
+            df.columns = self.columns
+
+        return df
 
     def _determine_type(self, path):
         suffix = path.suffix.lower()

--- a/pyaptamer/data/tests/test_loader.py
+++ b/pyaptamer/data/tests/test_loader.py
@@ -46,3 +46,24 @@ def test_pathlib_path():
     assert df.index.names == ["path", "chain_id"]
     assert df["sequence"].map(type).eq(str).all()
     assert any(seq.startswith("QTDMSRK") for seq in df["sequence"])
+
+
+def test_ignore_duplicates_removes_duplicate_sequences():
+    """`ignore_duplicates=True` should drop duplicate sequence rows."""
+    root_path = Path(__file__).parent.parent.parent
+    duplicate_path = root_path / "datasets" / "data" / "1gnh.pdb"
+
+    loader = MoleculeLoader([duplicate_path, duplicate_path], ignore_duplicates=True)
+    df = loader.to_df_seq()
+
+    assert list(df.columns) == ["sequence"]
+    assert df.index.nlevels == 2
+    assert not df["sequence"].duplicated().any()
+    assert len(df) == 1
+
+    renamed_df = MoleculeLoader(
+        [duplicate_path, duplicate_path],
+        columns=["seq"],
+        ignore_duplicates=True,
+    ).to_df_seq()
+    assert list(renamed_df.columns) == ["seq"]


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #312.

#### What does this implement/fix? Explain your changes.
This fixes `MoleculeLoader.to_df_seq()` so the documented `ignore_duplicates` flag is actually honored. The loader now builds the sequence DataFrame first, drops duplicate sequence rows while keeping the first occurrence when the flag is enabled, and then applies any optional column renaming.

#### What should a reviewer concentrate their feedback on?
The duplicate-removal behavior in `MoleculeLoader.to_df_seq()` and whether preserving the first indexed occurrence matches the intended contract for sequence exports.

#### Did you add any tests for the change?
Yes. I added a regression test that reproduces the bug with duplicate PDB inputs and verifies that:
- duplicate sequence rows are removed when `ignore_duplicates=True`
- optional custom column names still work after deduplication

#### Any other comments?
Validation run locally:
- `.venv/bin/pytest pyaptamer -p no:warnings`
- `.venv/bin/pre-commit run --files pyaptamer/data/loader.py pyaptamer/data/tests/test_loader.py`

#### PR checklist
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
  To run hooks independent of commit, execute `pre-commit run --all-files`
