### PR TITLE
Handle failed RCSB downloads

### DIFF
--- a/pyaptamer/datasets/_loaders/_online_databank.py
+++ b/pyaptamer/datasets/_loaders/_online_databank.py
@@ -27,6 +27,8 @@ def load_from_rcsb(pdb_id, overwrite=False):
     pdb_file_path = pdbl.retrieve_pdb_file(
         pdb_id, file_format="pdb", overwrite=overwrite
     )
+    if pdb_file_path is None:
+        raise FileNotFoundError(f"Failed to download PDB structure '{pdb_id}'.")
 
     structure = pdb_to_struct(pdb_file_path)
 

--- a/pyaptamer/datasets/tests/test_online_loader.py
+++ b/pyaptamer/datasets/tests/test_online_loader.py
@@ -1,5 +1,7 @@
 __author__ = "satvshr"
 
+from unittest.mock import patch
+
 import pytest
 from Bio.PDB.Structure import Structure
 
@@ -16,3 +18,14 @@ def test_download_structure(pdb_id):
     assert isinstance(structure, Structure), (
         f"Expected a Bio.PDB.Structure.Structure, got {type(structure)}"
     )
+
+
+def test_download_structure_raises_clear_error_when_download_fails():
+    """A failed RCSB download raises a clear error before parsing."""
+    with patch("pyaptamer.datasets._loaders._online_databank.PDBList") as mock_pdbl:
+        mock_pdbl.return_value.retrieve_pdb_file.return_value = None
+
+        with pytest.raises(FileNotFoundError) as exc_info:
+            load_from_rcsb("XXXX")
+
+    assert str(exc_info.value) == "Failed to download PDB structure 'XXXX'."


### PR DESCRIPTION
Closes #314.

## Summary
- Add a None check after PDBList.retrieve_pdb_file() in load_from_rcsb.
- Raise a clear FileNotFoundError when the RCSB download fails instead of passing None into pdb_to_struct.
- Add a mocked regression test for the failed-download path.

## Testing
- python -m pytest pyaptamer\datasets\tests\test_online_loader.py::test_download_structure_raises_clear_error_when_download_fails
- python -m ruff check --no-cache pyaptamer\datasets\_loaders\_online_databank.py pyaptamer\datasets\tests\test_online_loader.py