### PR TITLE
[BUG] Fix candidate deduplication in recommend()

### DIFF
--- a/pyaptamer/aptatrans/_pipeline.py
+++ b/pyaptamer/aptatrans/_pipeline.py
@@ -237,17 +237,17 @@ class AptaTransPipeline:
         )
 
         # generate aptamer candidates
-        candidates = set()
+        candidates = {}
         while len(candidates) < n_candidates:
-            candidate = mcts.run(verbose=verbose)
-            candidates.add(tuple(candidate.values()))
+            result = mcts.run(verbose=verbose)
+            candidate, sequence, score = tuple(result.values())
+            if candidate not in candidates:
+                candidates[candidate] = (candidate, sequence, score.item())
 
         if verbose:
-            for candidate, sequence, score in candidates:
+            for candidate, sequence, score in candidates.values():
                 print(
-                    f"Candidate: {candidate}, "
-                    f"Sequence: {sequence}, "
-                    f"Score: {score.item():.4f}"
+                    f"Candidate: {candidate}, Sequence: {sequence}, Score: {score:.4f}"
                 )
 
-        return candidates
+        return set(candidates.values())


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #324 

#### What does this implement/fix? Explain your changes.
`recommend()` was not deduplicating candidates because `PyTorch` tensors hash by object identity. Replaced the set with a `dict` keyed by candidate sequence and converted scores to plain floats via `.item(). 

#### What should a reviewer concentrate their feedback on?
The change is minimal — only the candidate collection loop in _pipeline.py is modified.

#### Did you add any tests for the change?
No — existing tests continue to pass. The fix is a one-line logic change in how candidates are stored.

#### PR checklist
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
- [ ] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks.

##### Tests and checks

pytest is passing
<img width="1919" height="108" alt="Image" src="https://github.com/user-attachments/assets/73dfe2ff-037a-4362-8e26-4090baf414c6" />

pre-commit is passing
<img width="1919" height="151" alt="Image" src="https://github.com/user-attachments/assets/19c3b406-2bb1-4b20-a765-48d6bc0760a2" />

detect-notebooks-change
<img width="1913" height="99" alt="image" src="https://github.com/user-attachments/assets/73cc091b-4b42-462d-9122-bf9c7a84cef3" />

run-jupyter-notebooks
<img width="1835" height="510" alt="image" src="https://github.com/user-attachments/assets/8d8d8160-132e-48fa-b0ae-014debc8f332" />
