### PR TITLE
[ENH] Improve AptaTrans test coverage

### DIFF
--- a/pyaptamer/aptatrans/tests/test_aptatrans.py
+++ b/pyaptamer/aptatrans/tests/test_aptatrans.py
@@ -159,6 +159,100 @@ class TestAptaTransModel:
         assert torch.all(output >= 0.0) and torch.all(output <= 1.0)
         assert not torch.allclose(output[0], output[1], atol=1e-5)
 
+    def test_forward_encoder_invalid_encoder_type(
+        self,
+        embeddings: tuple[EncoderPredictorConfig, EncoderPredictorConfig],
+    ):
+        """Check that ValueError is raised for invalid encoder_type."""
+        model = AptaTrans(
+            apta_embedding=embeddings[0],
+            prot_embedding=embeddings[1],
+            in_dim=128,
+        )
+
+        x = (
+            torch.randint(0, 16, (2, 16)),
+            torch.randint(0, 16, (2, 16)),
+        )
+
+        with pytest.raises(ValueError, match="Unknown encoder_type"):
+            model.forward_encoder(x, encoder_type="invalid")
+
+    def test_load_pretrained_weights_local(
+        self,
+        embeddings: tuple[EncoderPredictorConfig, EncoderPredictorConfig],
+        monkeypatch,
+        tmp_path,
+    ):
+        """Check loading pretrained weights from a local file."""
+        model = AptaTrans(
+            apta_embedding=embeddings[0],
+            prot_embedding=embeddings[1],
+            in_dim=128,
+            pretrained=False,
+        )
+
+        # save the model's current state dict to a temp file
+        weights_path = tmp_path / "pretrained.pt"
+        torch.save(model.state_dict(), weights_path)
+
+        # patch so load_pretrained_weights finds our temp file
+        monkeypatch.setattr(
+            "os.path.exists", lambda path: True
+        )
+        monkeypatch.setattr(
+            "os.path.relpath",
+            lambda path: str(weights_path),
+        )
+
+        model.load_pretrained_weights()
+
+    def test_load_pretrained_weights_download(
+        self,
+        embeddings: tuple[EncoderPredictorConfig, EncoderPredictorConfig],
+        monkeypatch,
+    ):
+        """Check downloading pretrained weights when local file is missing."""
+        model = AptaTrans(
+            apta_embedding=embeddings[0],
+            prot_embedding=embeddings[1],
+            in_dim=128,
+            pretrained=False,
+        )
+
+        state_dict = model.state_dict()
+
+        monkeypatch.setattr("os.path.exists", lambda path: False)
+        monkeypatch.setattr(
+            "torch.hub.load_state_dict_from_url",
+            lambda *args, **kwargs: state_dict,
+        )
+
+        model.load_pretrained_weights()
+
+    @pytest.mark.parametrize(
+        "conv_layers",
+        [[1, 1, 1], [2, 3, 2], [5, 5, 5]],
+    )
+    def test_forward_custom_conv_layers(
+        self,
+        embeddings: tuple[EncoderPredictorConfig, EncoderPredictorConfig],
+        conv_layers: list[int],
+    ):
+        """Check forward pass with various conv_layers configurations."""
+        model = AptaTrans(
+            apta_embedding=embeddings[0],
+            prot_embedding=embeddings[1],
+            in_dim=128,
+            conv_layers=conv_layers,
+        )
+
+        x_apta = torch.randint(high=16, size=(2, 16), dtype=torch.long)
+        x_prot = torch.randint(high=16, size=(2, 16), dtype=torch.long)
+
+        output = model(x_apta, x_prot)
+        assert output.shape == (2, 1)
+
 
 class MockAptaTransNeuralNet(nn.Module):
     """Mock AptaTrans model for testing pipeline."""
@@ -427,3 +521,55 @@ class TestAptaTransPipeline:
             model.apta_embedding.max_len,
             model.prot_embedding.max_len,
         )
+
+    def test_initialization_minimum_depth(self):
+        """Check pipeline initializes with the minimum valid depth of 3."""
+        model = MockAptaTransNeuralNet(torch.device("cpu"))
+        prot_words = {"AAA": 0.5, "AAC": 0.3, "AAG": 0.8}
+
+        pipeline = AptaTransPipeline(
+            device=torch.device("cpu"),
+            model=model,
+            prot_words=prot_words,
+            depth=3,
+        )
+
+        assert pipeline.depth == 3
+
+    def test_recommend_verbose_false(self, monkeypatch):
+        """Check recommend works with verbose=False and does not error."""
+        device = torch.device("cpu")
+        model = MockAptaTransNeuralNet(device)
+        prot_words = {"AUG": 0.8, "GCA": 0.6, "UGC": 0.4}
+        pipeline = AptaTransPipeline(
+            device=device, model=model, prot_words=prot_words, depth=5
+        )
+
+        class MockExperiment:
+            def evaluate(self, candidate):
+                return torch.tensor(0.75)
+
+        monkeypatch.setattr(
+            "pyaptamer.aptatrans._pipeline.AptamerEvalAptaTrans",
+            lambda **kwargs: MockExperiment(),
+        )
+
+        class MockMCTS:
+            def __init__(self, **kwargs):
+                self.counter = 0
+
+            def run(self, verbose=False):
+                self.counter += 1
+                return {
+                    "candidate": f"APT{self.counter}",
+                    "sequence": f"seq_{self.counter}",
+                    "score": torch.tensor(0.5),
+                }
+
+        monkeypatch.setattr("pyaptamer.aptatrans._pipeline.MCTS", MockMCTS)
+
+        candidates = pipeline.recommend(
+            target="AUGCAUGC", n_candidates=2, verbose=False
+        )
+        assert isinstance(candidates, set)
+        assert len(candidates) == 2

--- a/pyaptamer/aptatrans/tests/test_aptatrans_lightning.py
+++ b/pyaptamer/aptatrans/tests/test_aptatrans_lightning.py
@@ -128,3 +128,71 @@ class TestAptaTransEncoderLightning:
         assert isinstance(loss, torch.Tensor)
         assert loss.dim() == 0
         assert loss.item() >= 0
+
+    @pytest.mark.parametrize(
+        "batch_size, seq_len",
+        [(4, 50), (8, 100), (2, 75)],
+    )
+    def test_test_step(self, lightning_model, batch_size, seq_len):
+        """Check test_step computes loss correctly for encoder pretraining."""
+        x_mlm = torch.randint(0, 125, (batch_size, seq_len))
+        x_ssp = torch.randint(0, 125, (batch_size, seq_len))
+        y_mlm = torch.randint(0, 125, (batch_size, seq_len))
+        y_ssp = torch.randint(0, 8, (batch_size, seq_len))
+
+        batch = (x_mlm, x_ssp, y_mlm, y_ssp)
+
+        loss = lightning_model.test_step(batch, batch_idx=0)
+
+        assert isinstance(loss, torch.Tensor)
+        assert loss.dim() == 0
+        assert loss.item() >= 0
+
+    @pytest.mark.parametrize("encoder_type", ["apta", "prot"])
+    def test_training_step_both_encoder_types(self, mock_model, encoder_type):
+        """Check training_step works for both aptamer and protein encoder types."""
+        model = AptaTransEncoderLightning(mock_model, encoder_type=encoder_type)
+
+        x_mlm = torch.randint(0, 125, (4, 50))
+        x_ssp = torch.randint(0, 125, (4, 50))
+        y_mlm = torch.randint(0, 125, (4, 50))
+        y_ssp = torch.randint(0, 8, (4, 50))
+
+        batch = (x_mlm, x_ssp, y_mlm, y_ssp)
+
+        loss = model.training_step(batch, batch_idx=0)
+
+        assert isinstance(loss, torch.Tensor)
+        assert loss.dim() == 0
+        assert loss.item() >= 0
+
+    @pytest.mark.parametrize("encoder_type", ["apta", "prot"])
+    def test_configure_optimizers(self, encoder_type):
+        """Check optimizer is configured with the correct encoder parameters."""
+
+        class MockAptaTransWithEncoders(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.encoder_apta = nn.Linear(10, 10)
+                self.encoder_prot = nn.Linear(10, 10)
+                self.token_predictor_apta = nn.Linear(10, 10)
+                self.token_predictor_prot = nn.Linear(10, 10)
+
+        mock = MockAptaTransWithEncoders()
+        model = AptaTransEncoderLightning(mock, encoder_type=encoder_type)
+        optimizer = model.configure_optimizers()
+
+        assert isinstance(optimizer, torch.optim.Adam)
+        assert optimizer.defaults["lr"] == model.lr
+
+    def test_init_custom_weights(self, mock_model):
+        """Check custom MLM and SSP loss weights are stored correctly."""
+        model = AptaTransEncoderLightning(
+            mock_model,
+            encoder_type="apta",
+            weight_mlm=3.0,
+            weight_ssp=0.5,
+        )
+
+        assert model.weight_mlm == 3.0
+        assert model.weight_ssp == 0.5


### PR DESCRIPTION
#### Reference Issues/PRs

Addresses #180.

Note: PR #273 covers pretrained weight loading tests separately. This PR focuses on the remaining uncovered code paths.

#### What does this implement/fix? Explain your changes.

Adds 16 new tests across `test_aptatrans.py` and `test_aptatrans_lightning.py` to cover previously untested branches and edge cases.

**`test_aptatrans.py` — AptaTrans model (6 new tests):**
- `test_forward_encoder_invalid_encoder_type` — covers the ValueError branch for invalid `encoder_type` in `forward_encoder()`
- `test_load_pretrained_weights_local` — covers local file loading path in `load_pretrained_weights()` via monkeypatch
- `test_load_pretrained_weights_download` — covers HuggingFace download path via monkeypatch
- `test_forward_custom_conv_layers` — parametrized with 3 different conv_layers configs

**`test_aptatrans.py` — AptaTransPipeline (2 new tests):**
- `test_initialization_minimum_depth` — edge case with depth=3 (minimum valid)
- `test_recommend_verbose_false` — verifies recommend() works with verbose=False

**`test_aptatrans_lightning.py` — AptaTransEncoderLightning (8 new tests):**
- `test_test_step` — parametrized (3 configs), covers the previously untested test_step method
- `test_training_step_both_encoder_types` — parametrized for both "apta" and "prot"
- `test_configure_optimizers` — parametrized for both encoder types, uses a mock with encoder attributes
- `test_init_custom_weights` — verifies custom weight_mlm and weight_ssp

#### What should a reviewer concentrate their feedback on?

- The monkeypatching approach for `load_pretrained_weights` tests — patches `os.path.exists` and `torch.hub.load_state_dict_from_url` to avoid network calls
- Whether any additional branches or edge cases should be covered

#### Did you add any tests for the change?

Yes, this PR is entirely about adding tests. 16 new tests, all passing (50 passed, 1 skipped for CUDA).

#### Any other comments?

Test count for AptaTrans modules goes from 35 to 51 with this PR.

#### PR checklist

- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks.