### PR TITLE
Make dna2rna conversion linear time

### DIFF
--- a/pyaptamer/utils/_rna.py
+++ b/pyaptamer/utils/_rna.py
@@ -32,10 +32,7 @@ def dna2rna(sequence: str) -> str:
     """
     # replace nucleotides 'T' with 'U'
     result = sequence.translate(str.maketrans("T", "U"))
-    for char in result:
-        if char not in "ACGU":
-            result = result.replace(char, "N")  # replace unknown nucleotides with 'N'
-    return result
+    return "".join(char if char in "ACGU" else "N" for char in result)
 
 
 def generate_nplets(letters: list[str], repeat: int | Iterable[int]) -> dict[str, int]:

--- a/pyaptamer/utils/tests/test_rna.py
+++ b/pyaptamer/utils/tests/test_rna.py
@@ -36,6 +36,11 @@ def test_dna2rna_edge_cases():
     assert dna2rna("AcGt") == "ANGN"
 
 
+def test_dna2rna_handles_repeated_unknown_nucleotides():
+    """Check repeated unknown nucleotides are converted in a single pass."""
+    assert dna2rna("AXT" * 1000) == "ANU" * 1000
+
+
 @pytest.mark.parametrize("repeat", [2, 3, 4])
 def test_generate_nplets(repeat):
     """Check generation of all possible n-plets."""


### PR DESCRIPTION
Closes #323.

## Summary
- Replace repeated full-string replace calls in dna2rna with a single-pass conversion.
- Preserve existing T-to-U and unknown-to-N behavior.
- Add a regression test for repeated unknown nucleotides.

## Testing
- python -m pytest pyaptamer\utils\tests\test_rna.py
- python -m ruff check --no-cache pyaptamer\utils\_rna.py pyaptamer\utils\tests\test_rna.py