### PR TITLE
Normalize RNA bases in AptaNet k-mer features

### DIFF
--- a/pyaptamer/utils/_aptanet_utils.py
+++ b/pyaptamer/utils/_aptanet_utils.py
@@ -14,7 +14,8 @@ def generate_kmer_vecs(aptamer_sequence, k=4):
     Generate normalized k-mer frequency vectors for the aptamer sequence.
 
     For all possible k-mers from length 1 to k, count their occurrences in the sequence
-    and normalize to form a frequency vector.
+    and normalize to form a frequency vector. RNA bases are mapped to the AptaNet DNA
+    convention by normalizing 'U' to 'T' before k-mer counting.
 
     Parameters
     ----------
@@ -30,6 +31,7 @@ def generate_kmer_vecs(aptamer_sequence, k=4):
         length 1 to k.
     """
     DNA_BASES = list("ACGT")
+    aptamer_sequence = aptamer_sequence.replace("U", "T")
 
     # Generate all possible k-mers from 1 to k
     all_kmers = []

--- a/pyaptamer/utils/tests/test_aptanet_utils.py
+++ b/pyaptamer/utils/tests/test_aptanet_utils.py
@@ -1,0 +1,17 @@
+"""Test suite for the AptaNet utility functions."""
+
+__author__ = ["NandiniDhanrale"]
+
+import numpy as np
+
+from pyaptamer.utils._aptanet_utils import generate_kmer_vecs
+
+
+def test_generate_kmer_vecs_normalizes_rna_u_to_dna_t():
+    """Check RNA U bases are mapped to the AptaNet DNA k-mer convention."""
+    vec_dna = generate_kmer_vecs("ATG", k=2)
+    vec_rna = generate_kmer_vecs("AUG", k=2)
+
+    assert vec_rna.shape == vec_dna.shape
+    assert np.isclose(vec_rna.sum(), 1.0)
+    assert np.array_equal(vec_rna, vec_dna)


### PR DESCRIPTION
Closes #322.

## Summary
- Normalize RNA U bases to T before generating AptaNet k-mer features.
- Document that RNA-style input is mapped to the existing DNA k-mer convention.
- Add a regression test asserting AUG and ATG produce identical k-mer vectors.

## Testing
- python -m pytest pyaptamer\utils\tests\test_aptanet_utils.py
- python -m pytest pyaptamer\aptanet\tests\test_aptanet.py
- python -m ruff check --no-cache pyaptamer\utils\_aptanet_utils.py pyaptamer\utils\tests\test_aptanet_utils.py