### PR TITLE
Respect ignore_duplicates in MoleculeLoader

### DIFF
--- a/pyaptamer/data/loader.py
+++ b/pyaptamer/data/loader.py
@@ -71,7 +71,11 @@ class MoleculeLoader:
 
         columns = ["sequence"] if self.columns is None else self.columns
 
-        return pd.DataFrame(sequences, index=index, columns=columns)
+        df = pd.DataFrame(sequences, index=index, columns=columns)
+        if self.ignore_duplicates:
+            df = df.drop_duplicates(subset=[columns[0]], keep="first")
+
+        return df
 
     def _determine_type(self, path):
         suffix = path.suffix.lower()

--- a/pyaptamer/data/tests/test_loader.py
+++ b/pyaptamer/data/tests/test_loader.py
@@ -46,3 +46,27 @@ def test_pathlib_path():
     assert df.index.names == ["path", "chain_id"]
     assert df["sequence"].map(type).eq(str).all()
     assert any(seq.startswith("QTDMSRK") for seq in df["sequence"])
+
+
+def test_to_df_seq_keeps_duplicates_by_default():
+    """Test that duplicate sequences are preserved by default."""
+    root_path = Path(__file__).parent.parent.parent
+    pdb_path = root_path / "datasets/data/1gnh.pdb"
+
+    loader = MoleculeLoader([pdb_path, pdb_path])
+    df = loader.to_df_seq()
+
+    assert df["sequence"].duplicated().any()
+
+
+def test_to_df_seq_ignores_duplicates_when_requested():
+    """Test that duplicate sequences are removed when requested."""
+    root_path = Path(__file__).parent.parent.parent
+    pdb_path = root_path / "datasets/data/1gnh.pdb"
+
+    loader = MoleculeLoader([pdb_path, pdb_path], ignore_duplicates=True)
+    df = loader.to_df_seq()
+
+    assert df.index.nlevels == 2
+    assert df.index.names == ["path", "chain_id"]
+    assert not df["sequence"].duplicated().any()


### PR DESCRIPTION
Closes #312.

## Summary
- Apply ignore_duplicates in MoleculeLoader.to_df_seq().
- Remove duplicate sequences while keeping the first occurrence and preserving the existing MultiIndex output.
- Add tests for default duplicate preservation and requested deduplication.

## Testing
- python -m pytest pyaptamer\data\tests\test_loader.py
- python -m ruff check --no-cache pyaptamer\data\loader.py pyaptamer\data\tests\test_loader.py