### PR TITLE
Move AptaNet features to transformer interface

### DIFF
--- a/pyaptamer/aptanet/_pipeline.py
+++ b/pyaptamer/aptanet/_pipeline.py
@@ -5,11 +5,10 @@ __required__ = ["python>=3.10"]
 from skbase.base import BaseObject
 from sklearn.base import BaseEstimator, clone
 from sklearn.pipeline import Pipeline
-from sklearn.preprocessing import FunctionTransformer
 from sklearn.utils.validation import check_is_fitted
 
 from pyaptamer.aptanet import AptaNetClassifier
-from pyaptamer.utils._aptanet_utils import pairs_to_features
+from pyaptamer.trafos.feature import AptaNetPairTransformer
 
 
 class AptaNetPipeline(BaseObject, BaseEstimator):
@@ -68,11 +67,7 @@ class AptaNetPipeline(BaseObject, BaseEstimator):
         self.estimator = estimator
 
     def _build_pipeline(self):
-        transformer = FunctionTransformer(
-            func=pairs_to_features,
-            kw_args={"k": self.k},
-            validate=False,
-        )
+        transformer = AptaNetPairTransformer(k=self.k)
         self._estimator = self.estimator or AptaNetClassifier()
         return Pipeline([("features", transformer), ("clf", clone(self._estimator))])
 

--- a/pyaptamer/trafos/feature/__init__.py
+++ b/pyaptamer/trafos/feature/__init__.py
@@ -1,6 +1,6 @@
-"""Transformations."""
+"""Feature extraction transformations."""
 
-from pyaptamer.trafos.feature import (
+from pyaptamer.trafos.feature._aptanet import (
     AptaNetKmerTransformer,
     AptaNetPairTransformer,
     AptaNetPSeAACTransformer,

--- a/pyaptamer/trafos/feature/_aptanet.py
+++ b/pyaptamer/trafos/feature/_aptanet.py
@@ -1,0 +1,160 @@
+"""AptaNet feature extraction transformations."""
+
+__author__ = ["NandiniDhanrale"]
+__all__ = [
+    "AptaNetKmerTransformer",
+    "AptaNetPSeAACTransformer",
+    "AptaNetPairTransformer",
+]
+
+from itertools import product
+
+import numpy as np
+import pandas as pd
+from sklearn.base import BaseEstimator as SklearnBaseEstimator
+from sklearn.utils import TransformerTags
+
+from pyaptamer.pseaac import AptaNetPSeAAC
+from pyaptamer.trafos.base import BaseTransform
+
+
+def _aptanet_kmers(k: int) -> list[str]:
+    """Generate all AptaNet DNA k-mers from length 1 to ``k``."""
+    dna_bases = list("ACGT")
+    all_kmers = []
+    for i in range(1, k + 1):
+        all_kmers.extend(["".join(p) for p in product(dna_bases, repeat=i)])
+    return all_kmers
+
+
+def _generate_kmer_vec(aptamer_sequence: str, k: int) -> np.ndarray:
+    """Generate a normalized AptaNet k-mer frequency vector for one sequence."""
+    aptamer_sequence = aptamer_sequence.replace("U", "T")
+    all_kmers = _aptanet_kmers(k)
+    kmer_counts = dict.fromkeys(all_kmers, 0)
+
+    for i in range(len(aptamer_sequence)):
+        for j in range(1, k + 1):
+            if i + j <= len(aptamer_sequence):
+                kmer = aptamer_sequence[i : i + j]
+                if kmer in kmer_counts:
+                    kmer_counts[kmer] += 1
+
+    total_kmers = sum(kmer_counts.values())
+    return np.array(
+        [
+            kmer_counts[kmer] / total_kmers if total_kmers > 0 else 0
+            for kmer in all_kmers
+        ]
+    )
+
+
+class _SklearnTransformerTagsMixin:
+    """Expose sklearn transformer tags for sklearn Pipeline compatibility."""
+
+    def __sklearn_tags__(self):
+        tags = SklearnBaseEstimator.__sklearn_tags__(self)
+        tags.transformer_tags = TransformerTags()
+        return tags
+
+
+class AptaNetKmerTransformer(_SklearnTransformerTagsMixin, BaseTransform):
+    """Transform aptamer sequences into AptaNet k-mer frequency features.
+
+    RNA bases are mapped to the AptaNet DNA convention by normalizing 'U' to 'T'.
+    """
+
+    _tags = {
+        "authors": ["NandiniDhanrale"],
+        "output_type": "numeric",
+        "property:fit_is_empty": True,
+        "capability:multivariate": False,
+    }
+
+    def __init__(self, k: int = 4):
+        self.k = k
+        super().__init__()
+
+    def _transform(self, X):
+        """Transform a one-column DataFrame of aptamer sequences."""
+        sequences = X.values[:, 0].tolist()
+        features = np.vstack(
+            [_generate_kmer_vec(str(seq), self.k) for seq in sequences]
+        )
+        columns = [f"kmer_{kmer}" for kmer in _aptanet_kmers(self.k)]
+        return pd.DataFrame(features, index=X.index, columns=columns)
+
+
+class AptaNetPSeAACTransformer(_SklearnTransformerTagsMixin, BaseTransform):
+    """Transform protein sequences into AptaNet PSeAAC features."""
+
+    _tags = {
+        "authors": ["NandiniDhanrale"],
+        "output_type": "numeric",
+        "property:fit_is_empty": True,
+        "capability:multivariate": False,
+    }
+
+    def __init__(self, lambda_val: int = 30, weight: float = 0.05):
+        self.lambda_val = lambda_val
+        self.weight = weight
+        super().__init__()
+
+    def _transform(self, X):
+        """Transform a one-column DataFrame of protein sequences."""
+        pseaac = AptaNetPSeAAC(lambda_val=self.lambda_val, weight=self.weight)
+        sequences = X.values[:, 0].tolist()
+        features = np.vstack([pseaac.transform(str(seq)) for seq in sequences])
+        columns = [f"pseaac_{i}" for i in range(features.shape[1])]
+        return pd.DataFrame(features, index=X.index, columns=columns)
+
+
+class AptaNetPairTransformer(_SklearnTransformerTagsMixin, BaseTransform):
+    """Transform aptamer-protein sequence pairs into AptaNet features."""
+
+    _tags = {
+        "authors": ["NandiniDhanrale"],
+        "output_type": "numeric",
+        "property:fit_is_empty": True,
+        "capability:multivariate": True,
+    }
+
+    def __init__(
+        self,
+        k: int = 4,
+        lambda_val: int = 30,
+        weight: float = 0.05,
+        aptamer_col: str = "aptamer",
+        protein_col: str = "protein",
+    ):
+        self.k = k
+        self.lambda_val = lambda_val
+        self.weight = weight
+        self.aptamer_col = aptamer_col
+        self.protein_col = protein_col
+        super().__init__()
+
+    def _check_X_y(self, X, y):  # noqa: N802
+        """Check and coerce paired sequence inputs."""
+        if not isinstance(X, pd.DataFrame):
+            X = pd.DataFrame(X, columns=[self.aptamer_col, self.protein_col])
+        return super()._check_X_y(X, y)
+
+    def _check_X(self, X):  # noqa: N802
+        """Check and coerce paired sequence inputs."""
+        X, _ = self._check_X_y(X, None)
+        return X
+
+    def _transform(self, X):
+        """Transform a DataFrame with aptamer and protein sequence columns."""
+        aptamer_col = self.aptamer_col
+        protein_col = self.protein_col
+        if aptamer_col not in X.columns or protein_col not in X.columns:
+            aptamer_col, protein_col = X.columns[:2]
+
+        kmer = AptaNetKmerTransformer(k=self.k).fit_transform(X[[aptamer_col]])
+        pseaac = AptaNetPSeAACTransformer(
+            lambda_val=self.lambda_val, weight=self.weight
+        ).fit_transform(X[[protein_col]])
+
+        return pd.concat([kmer, pseaac], axis=1)

--- a/pyaptamer/trafos/feature/tests/__init__.py
+++ b/pyaptamer/trafos/feature/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for feature extraction transformations."""

--- a/pyaptamer/trafos/feature/tests/test_aptanet.py
+++ b/pyaptamer/trafos/feature/tests/test_aptanet.py
@@ -1,0 +1,72 @@
+"""Tests for AptaNet feature extraction transformations."""
+
+__author__ = ["NandiniDhanrale"]
+
+import numpy as np
+import pandas as pd
+
+from pyaptamer.trafos.feature import (
+    AptaNetKmerTransformer,
+    AptaNetPairTransformer,
+    AptaNetPSeAACTransformer,
+)
+from pyaptamer.utils._aptanet_utils import generate_kmer_vecs, pairs_to_features
+
+
+def test_aptanet_kmer_transformer_matches_legacy_function():
+    """Check the k-mer transformer matches the legacy utility function."""
+    X = pd.DataFrame({"aptamer": ["ATG"]})
+
+    Xt = AptaNetKmerTransformer(k=2).fit_transform(X)
+
+    assert isinstance(Xt, pd.DataFrame)
+    assert Xt.shape == (1, 20)
+    assert np.allclose(Xt.to_numpy()[0], generate_kmer_vecs("ATG", k=2))
+
+
+def test_aptanet_kmer_transformer_normalizes_rna_u_to_dna_t():
+    """Check RNA U bases are mapped to the AptaNet DNA k-mer convention."""
+    X_dna = pd.DataFrame({"aptamer": ["ATG"]})
+    X_rna = pd.DataFrame({"aptamer": ["AUG"]})
+
+    vec_dna = AptaNetKmerTransformer(k=2).fit_transform(X_dna)
+    vec_rna = AptaNetKmerTransformer(k=2).fit_transform(X_rna)
+
+    assert np.array_equal(vec_rna.to_numpy(), vec_dna.to_numpy())
+
+
+def test_aptanet_pseaac_transformer_returns_dataframe():
+    """Check the PSeAAC transformer returns numeric feature columns."""
+    protein = "ACDEFGHIKLMNPQRSTVWYACDEFGHIKLMNPQRSTVWY"
+    X = pd.DataFrame({"protein": [protein]})
+
+    Xt = AptaNetPSeAACTransformer().fit_transform(X)
+
+    assert isinstance(Xt, pd.DataFrame)
+    assert Xt.shape[0] == 1
+    assert Xt.shape[1] == 350
+    assert Xt.index.equals(X.index)
+
+
+def test_aptanet_pair_transformer_matches_pairs_to_features():
+    """Check pair transformer matches the legacy pair feature utility."""
+    protein = "ACDEFGHIKLMNPQRSTVWYACDEFGHIKLMNPQRSTVWY"
+    X = pd.DataFrame({"aptamer": ["ATG"], "protein": [protein]})
+
+    Xt = AptaNetPairTransformer(k=2).fit_transform(X)
+    legacy = pairs_to_features([("ATG", protein)], k=2)
+
+    assert isinstance(Xt, pd.DataFrame)
+    assert Xt.shape == legacy.shape
+    assert np.allclose(Xt.to_numpy().astype(np.float32), legacy)
+
+
+def test_aptanet_pair_transformer_accepts_tuple_pairs():
+    """Check pair transformer accepts the tuple input used by AptaNetPipeline."""
+    protein = "ACDEFGHIKLMNPQRSTVWYACDEFGHIKLMNPQRSTVWY"
+    pairs = [("ATG", protein)]
+
+    Xt = AptaNetPairTransformer(k=2).fit_transform(pairs)
+
+    assert isinstance(Xt, pd.DataFrame)
+    assert Xt.shape[0] == 1

--- a/pyaptamer/utils/_aptanet_utils.py
+++ b/pyaptamer/utils/_aptanet_utils.py
@@ -1,12 +1,10 @@
 __author__ = "satvshr"
 __all__ = ["generate_kmer_vecs", "pairs_to_features"]
 
-from itertools import product
-
 import numpy as np
 import pandas as pd
 
-from pyaptamer.pseaac import AptaNetPSeAAC
+from pyaptamer.trafos.feature import AptaNetKmerTransformer, AptaNetPairTransformer
 
 
 def generate_kmer_vecs(aptamer_sequence, k=4):
@@ -29,32 +27,8 @@ def generate_kmer_vecs(aptamer_sequence, k=4):
         1D numpy array of normalized frequency vector for all possible k-mers from
         length 1 to k.
     """
-    DNA_BASES = list("ACGT")
-
-    # Generate all possible k-mers from 1 to k
-    all_kmers = []
-    for i in range(1, k + 1):
-        all_kmers.extend(["".join(p) for p in product(DNA_BASES, repeat=i)])
-
-    # Count occurrences of each k-mer in the aptamer_sequence
-    kmer_counts = dict.fromkeys(all_kmers, 0)
-    for i in range(len(aptamer_sequence)):
-        for j in range(1, k + 1):
-            if i + j <= len(aptamer_sequence):
-                kmer = aptamer_sequence[i : i + j]
-                if kmer in kmer_counts:
-                    kmer_counts[kmer] += 1
-
-    # Normalize counts to frequencies
-    total_kmers = sum(kmer_counts.values())
-    kmer_freq = np.array(
-        [
-            kmer_counts[kmer] / total_kmers if total_kmers > 0 else 0
-            for kmer in all_kmers
-        ]
-    )
-
-    return kmer_freq
+    X = pd.DataFrame({"aptamer": [aptamer_sequence]})
+    return AptaNetKmerTransformer(k=k).fit_transform(X).to_numpy()[0]
 
 
 def pairs_to_features(X, k=4):
@@ -83,18 +57,12 @@ def pairs_to_features(X, k=4):
         A 2D NumPy array where each row corresponds to the concatenated feature vector
         for a given (aptamer, protein) pair.
     """
-    pseaac = AptaNetPSeAAC()
-    feats = []
-
     if isinstance(X, pd.DataFrame):
-        pairs = zip(X["aptamer"], X["protein"], strict=False)
+        X_inner = X
     else:
-        pairs = X
-
-    for aptamer_seq, protein_seq in pairs:
-        kmer = generate_kmer_vecs(aptamer_seq, k=k)
-        pseaac_vec = np.asarray(pseaac.transform(protein_seq))
-        feats.append(np.concatenate([kmer, pseaac_vec]))
+        X_inner = pd.DataFrame(X, columns=["aptamer", "protein"])
 
     # Ensure float32 for PyTorch compatibility
-    return np.vstack(feats).astype(np.float32)
+    return AptaNetPairTransformer(k=k).fit_transform(X_inner).to_numpy().astype(
+        np.float32
+    )


### PR DESCRIPTION
Closes #174.

## Summary
- Add AptaNet feature transformers for k-mer, PSeAAC, and paired aptamer-protein features under pyaptamer.trafos.feature.
- Wire AptaNetPipeline to use AptaNetPairTransformer instead of FunctionTransformer around pairs_to_features.
- Keep generate_kmer_vecs and pairs_to_features as backward-compatible wrappers over the new transformers.
- Preserve RNA U-to-T normalization in the new k-mer transformer path.
- Add transformer tests covering legacy equivalence, tuple-pair input, PSeAAC output, and RNA normalization.

## Testing
- python -m pytest pyaptamer\trafos\feature\tests\test_aptanet.py
- python -m pytest pyaptamer\aptanet\tests\test_aptanet.py
- python -m ruff check --no-cache pyaptamer\trafos\feature pyaptamer\trafos\__init__.py pyaptamer\utils\_aptanet_utils.py pyaptamer\aptanet\_pipeline.py