### PR TITLE
[BUG] Fix augment_reverse() to compute actual reverse complement

### DIFF
--- a/pyaptamer/utils/_augment.py
+++ b/pyaptamer/utils/_augment.py
@@ -3,9 +3,22 @@ __all__ = ["augment_reverse"]
 
 import numpy as np
 
+# Watson-Crick complement table covering both DNA (T) and RNA (U) nucleotides.
+# Characters not in the table (e.g. 'N', non-biological characters) are left unchanged.
+_COMPLEMENT = str.maketrans("ACGTUacgtu", "TGCAAtgcaa")
+
+
+def _reverse_complement(seq: str) -> str:
+    """Return the reverse complement of a nucleotide sequence."""
+    return seq.translate(_COMPLEMENT)[::-1]
+
 
 def augment_reverse(*sequence_arrays: np.ndarray) -> tuple[np.ndarray, ...]:
     """Augment arrays of sequences by adding their reverse complement.
+
+    Computes the Watson-Crick reverse complement of each sequence using
+    standard base-pairing rules (A↔T/U, C↔G) and appends the results
+    to the original arrays.
 
     Parameters
     ----------
@@ -20,10 +33,10 @@ def augment_reverse(*sequence_arrays: np.ndarray) -> tuple[np.ndarray, ...]:
     """
     results = []
     for sequences in sequence_arrays:
-        # create array of reversed sequences
-        reversed_sequences = np.array([seq[::-1] for seq in sequences])
-        # concatenate original and reversed sequences
-        result = np.concatenate([sequences, reversed_sequences])
+        # compute the reverse complement of each sequence
+        rc_sequences = np.array([_reverse_complement(seq) for seq in sequences])
+        # concatenate original and reverse-complemented sequences
+        result = np.concatenate([sequences, rc_sequences])
         results.append(result)
 
     return tuple(results)

--- a/pyaptamer/utils/tests/test_augment.py
+++ b/pyaptamer/utils/tests/test_augment.py
@@ -7,33 +7,75 @@ import numpy as np
 from pyaptamer.utils._augment import augment_reverse
 
 
-def test_augment_reverse_single_array():
-    sequences = np.array(["AAC", "BBB", "ATCG"])
+def test_augment_reverse_dna_sequences():
+    """Check reverse complement with standard DNA nucleotides."""
+    sequences = np.array(["AACG", "TTTT", "ATCG"])
     result = augment_reverse(sequences)
 
-    expected = (np.array(["AAC", "BBB", "ATCG", "CAA", "BBB", "GCTA"]),)
+    # AACG -> complement TTGC -> reverse CGTT
+    # TTTT -> complement AAAA -> reverse AAAA
+    # ATCG -> complement TAGC -> reverse CGAT
+    expected = (np.array(["AACG", "TTTT", "ATCG", "CGTT", "AAAA", "CGAT"]),)
     assert len(result) == 1
     assert len(result[0]) == 6
     np.testing.assert_array_equal(result[0], expected[0])
 
 
+def test_augment_reverse_rna_sequences():
+    """Check reverse complement with RNA nucleotides (U instead of T).
+
+    The complement table uses DNA convention (A→T) so U in the input is
+    complemented to A, while A is complemented to T. This matches biological
+    base-pairing rules and the downstream dna2rna() handles T→U conversion.
+    """
+    sequences = np.array(["ACGU", "AACU"])
+    result = augment_reverse(sequences)
+
+    # ACGU -> complement TGCA -> reverse ACGT
+    # AACU -> complement TTGA -> reverse AGTT
+    expected = (np.array(["ACGU", "AACU", "ACGT", "AGTT"]),)
+    assert len(result) == 1
+    assert len(result[0]) == 4
+    np.testing.assert_array_equal(result[0], expected[0])
+
+
 def test_augment_reverse_multiple_arrays():
-    seq1 = np.array(["ABC", "DEF"])
-    seq2 = np.array(["XYZ"])
-    seq3 = np.array(["123", "456", "789"])
+    """Check augmentation works correctly across multiple arrays."""
+    seq1 = np.array(["ACG", "TGA"])
+    seq2 = np.array(["ACGT"])
 
-    result = augment_reverse(seq1, seq2, seq3)
+    result = augment_reverse(seq1, seq2)
 
+    # ACG -> complement TGC -> reverse CGT
+    # TGA -> complement ACT -> reverse TCA
+    # ACGT -> complement TGCA -> reverse ACGT (palindrome)
     expected = (
-        np.array(["ABC", "DEF", "CBA", "FED"]),
-        np.array(["XYZ", "ZYX"]),
-        np.array(["123", "456", "789", "321", "654", "987"]),
+        np.array(["ACG", "TGA", "CGT", "TCA"]),
+        np.array(["ACGT", "ACGT"]),
     )
-    assert len(result) == 3
+    assert len(result) == 2
     assert len(result[0]) == 4
     assert len(result[1]) == 2
-    assert len(result[2]) == 6
 
     np.testing.assert_array_equal(result[0], expected[0])
     np.testing.assert_array_equal(result[1], expected[1])
-    np.testing.assert_array_equal(result[2], expected[2])
+
+
+def test_augment_reverse_non_nucleotide_characters():
+    """Check that non-nucleotide characters pass through unchanged."""
+    sequences = np.array(["ANXG"])
+    result = augment_reverse(sequences)
+
+    # A->T, N->N (unchanged), X->X (unchanged), G->C
+    # complement: TNXC -> reverse: CXNT
+    expected = (np.array(["ANXG", "CXNT"]),)
+    np.testing.assert_array_equal(result[0], expected[0])
+
+
+def test_augment_reverse_empty_array():
+    """Check that empty arrays are handled correctly."""
+    sequences = np.array([], dtype=str)
+    result = augment_reverse(sequences)
+
+    assert len(result) == 1
+    assert len(result[0]) == 0


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #335.

#### What does this implement/fix? Explain your changes.

`augment_reverse()` in `pyaptamer/utils/_augment.py` was documented as computing the reverse complement of nucleotide sequences, but the implementation only reversed the strings without applying Watson–Crick complement rules (A↔T/U, C↔G).

This fix adds a complement translation table and applies it before reversal, producing biologically correct reverse complements. The table uses DNA convention (A→T, T→A, U→A, C→G, G→C), which works for both DNA and RNA inputs since the downstream `dna2rna()` function handles T→U normalization. Non-nucleotide characters pass through unchanged.

The fix affects `APIDataset._prepare_data()` in `pyaptamer/datasets/dataclasses/_api.py`, which uses `augment_reverse()` to augment aptamer training data for AptaTrans. Previously, the augmented sequences were biologically meaningless reversals; now they are proper reverse complements.

#### What should a reviewer concentrate their feedback on?

- Whether the DNA-convention complement table (A→T instead of A→U) is the right choice given the downstream `dna2rna()` conversion
- Whether additional integration-level tests for `APIDataset` augmentation are needed

#### Did you add any tests for the change?

Yes, the test suite in `pyaptamer/utils/tests/test_augment.py` was updated with five focused tests:
- DNA reverse complement correctness
- RNA reverse complement correctness (verifying DNA-convention output)
- Multiple array handling
- Non-nucleotide character passthrough
- Empty array edge case

#### Any other comments?

Full test suite passes locally: 338 passed, 3 skipped.

#### PR checklist
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
  To run hooks independent of commit, execute `pre-commit run --all-files`