### PR TITLE
[BUG] Make dna2rna conversion linear time

### DIFF
--- a/pyaptamer/utils/_rna.py
+++ b/pyaptamer/utils/_rna.py
@@ -32,10 +32,7 @@ def dna2rna(sequence: str) -> str:
     """
     # replace nucleotides 'T' with 'U'
     result = sequence.translate(str.maketrans("T", "U"))
-    for char in result:
-        if char not in "ACGU":
-            result = result.replace(char, "N")  # replace unknown nucleotides with 'N'
-    return result
+    return "".join(char if char in "ACGU" else "N" for char in result)
 
 
 def generate_nplets(letters: list[str], repeat: int | Iterable[int]) -> dict[str, int]:

--- a/pyaptamer/utils/tests/test_rna.py
+++ b/pyaptamer/utils/tests/test_rna.py
@@ -36,6 +36,11 @@ def test_dna2rna_edge_cases():
     assert dna2rna("AcGt") == "ANGN"
 
 
+def test_dna2rna_handles_repeated_unknown_nucleotides():
+    """Check repeated unknown nucleotides are converted in a single pass."""
+    assert dna2rna("AXT" * 1000) == "ANU" * 1000
+
+
 @pytest.mark.parametrize("repeat", [2, 3, 4])
 def test_generate_nplets(repeat):
     """Check generation of all possible n-plets."""


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #323.

#### What does this implement/fix? Explain your changes.
This PR fixes the quadratic behavior in `dna2rna()` caused by repeated full-string `replace()` calls inside a loop. The implementation is changed to a single-pass conversion that preserves the current output behavior:
- `T` is still converted to `U`
- unknown characters are still converted to `N`

The code change is limited to `pyaptamer/utils/_rna.py`, with one regression test added in `pyaptamer/utils/tests/test_rna.py`.

#### What should a reviewer concentrate their feedback on?
- Whether the single-pass implementation preserves the existing output contract for valid and invalid nucleotides
- Whether the added regression test is the right level of coverage for this performance bug without adding a flaky timing assertion

#### Did you add any tests for the change?
Yes.
- Added `test_dna2rna_handles_repeated_unknown_nucleotides()` in `pyaptamer/utils/tests/test_rna.py`
- Ran `python -m pytest pyaptamer\utils\tests\test_rna.py`
- Ran `python -m ruff check --no-cache pyaptamer\utils\_rna.py pyaptamer\utils\tests\test_rna.py`

#### Any other comments?
I commented on issue #323 before opening this PR with the exact scope and local validation results: https://github.com/gc-os-ai/pyaptamer/issues/323#issuecomment-4208144414

I also attempted `pre-commit run --all-files` locally. On Windows it triggered repository-wide mixed line ending rewrites unrelated to this fix, so those unrelated edits were reverted and are not included in this PR.

#### PR checklist
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
- [x] Added/modified tests
- [ ] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
  To run hooks independent of commit, execute `pre-commit run --all-files`