### PR TITLE
fix(aptanet): AptaNetPipeline fit() returns self and predict_proba() validates estimator type

### DIFF
--- a/pyaptamer/aptanet/_pipeline.py
+++ b/pyaptamer/aptanet/_pipeline.py
@@ -79,9 +79,16 @@ class AptaNetPipeline(BaseObject, BaseEstimator):
     def fit(self, X, y):
         self.pipeline_ = self._build_pipeline()
         self.pipeline_.fit(X, y)
+        return self
 
     def predict_proba(self, X):
         check_is_fitted(self)
+        estimator = self.pipeline_.named_steps["clf"]
+        if not hasattr(estimator, "predict_proba"):
+            raise AttributeError(
+                f"{type(estimator).__name__} does not support predict_proba(). "
+                "Switch to a classifier estimator."
+            )   
         return self.pipeline_.predict_proba(X)
 
     def predict(self, X):

--- a/pyaptamer/aptanet/tests/test_aptanet.py
+++ b/pyaptamer/aptanet/tests/test_aptanet.py
@@ -81,3 +81,36 @@ def test_sklearn_compatible_estimator(estimator, check):
     Run scikit-learn's compatibility checks on the AptaNetClassifier.
     """
     check(estimator)
+
+
+@pytest.mark.parametrize("aptamer_seq, protein_seq", params)
+def test_pipeline_fit_returns_self(aptamer_seq, protein_seq):
+    """
+    Regression test for #333: fit() must return self to enable sklearn-style
+    method chaining.
+    """
+    pipe = AptaNetPipeline()
+    X_raw = [(aptamer_seq, protein_seq) for _ in range(40)]
+    y = np.array([0] * 20 + [1] * 20, dtype=np.float32)
+
+    fit_result = pipe.fit(X_raw, y)
+
+    assert fit_result is pipe
+
+
+@pytest.mark.parametrize("aptamer_seq, protein_seq", params)
+def test_pipeline_predict_proba_raises_on_regressor(aptamer_seq, protein_seq):
+    """
+    Regression test for #333: predict_proba() must raise a clear AttributeError
+    when the pipeline is backed by a regressor, not a raw sklearn internal error.
+    """
+    from sklearn.linear_model import Ridge
+
+    pipe = AptaNetPipeline(estimator=Ridge())
+    X_raw = [(aptamer_seq, protein_seq) for _ in range(40)]
+    y = np.linspace(0, 1, 40).astype(np.float32)
+
+    pipe.fit(X_raw, y)
+
+    with pytest.raises(AttributeError, match="does not support predict_proba"):
+        pipe.predict_proba(X_raw)


### PR DESCRIPTION
Fixes #333

## Changes

**`pyaptamer/aptanet/_pipeline.py`**
- `fit()` now returns `self`, enabling standard sklearn method chaining
  (e.g. `pipe.fit(X, y).predict(X)`)
- `predict_proba()` now validates the underlying estimator before
  delegating, raising a clear `AttributeError` with an actionable
  message instead of leaking sklearn internals

## Regression tests added

**`pyaptamer/aptanet/tests/test_aptanet.py`**
- `test_pipeline_fit_returns_self` — asserts `fit()` returns the
  pipeline instance
- `test_pipeline_predict_proba_raises_on_regressor` — asserts a clean
  `AttributeError` is raised when `predict_proba()` is called on a
  regressor-backed pipeline

## How to reproduce (before fix)
```python
pipe = AptaNetPipeline()
fit_result = pipe.fit(X, y)
assert fit_result is pipe  # Failed: returned None

pipe2 = AptaNetPipeline(estimator=Ridge())
pipe2.fit(X, y)
pipe2.predict_proba(X)  # Raised raw sklearn AttributeError
```