### PR TITLE
fix(aptatrans): validate encoder_type at construction time in AptaTransEncoderLightning

### DIFF
--- a/pyaptamer/aptatrans/_model_lightning.py
+++ b/pyaptamer/aptatrans/_model_lightning.py
@@ -269,6 +269,12 @@ class AptaTransEncoderLightning(AptaTransLightning):
         weight_mlm: float = 2.0,
         weight_ssp: float = 1.0,
     ) -> None:
+        _valid_encoder_types = ("apta", "prot")
+        if encoder_type not in _valid_encoder_types:
+            raise ValueError(
+                f"Invalid encoder_type '{encoder_type}'. "
+                f"Must be one of {_valid_encoder_types}."
+            )
         super().__init__(model, lr, weight_decay, betas)
         self.encoder_type = encoder_type
         self.weight_mlm = weight_mlm

--- a/pyaptamer/aptatrans/tests/test_aptatrans_lightning.py
+++ b/pyaptamer/aptatrans/tests/test_aptatrans_lightning.py
@@ -128,3 +128,16 @@ class TestAptaTransEncoderLightning:
         assert isinstance(loss, torch.Tensor)
         assert loss.dim() == 0
         assert loss.item() >= 0
+
+    @pytest.mark.parametrize("encoder_type", ["apta", "prot"])
+    def test_init_valid_encoder_types(self, mock_model, encoder_type):
+        """Check that valid encoder_type values are accepted without error."""
+        model = AptaTransEncoderLightning(mock_model, encoder_type=encoder_type)
+        assert model.encoder_type == encoder_type
+
+
+    def test_init_invalid_encoder_type_raises(self, mock_model):
+        """Regression test for #338: invalid encoder_type must raise ValueError
+        at construction time, not as UnboundLocalError in configure_optimizers."""
+        with pytest.raises(ValueError, match="Invalid encoder_type 'invalid'"):
+            AptaTransEncoderLightning(mock_model, encoder_type="invalid")


### PR DESCRIPTION
Fixes #338

## Problem
`AptaTransEncoderLightning` accepted any `encoder_type` value silently.
When an invalid value was passed, the `params` variable in
`configure_optimizers()` was never assigned, causing an `UnboundLocalError`
deep inside Lightning's training setup — far from where the bad value
was introduced.

## Fix
Added early validation in `__init__` that raises a clear `ValueError`
immediately at construction time:

```python
ValueError: Invalid encoder_type 'invalid'. Must be one of ('apta', 'prot').
```

## Regression tests added
- `test_init_valid_encoder_types` — both `"apta"` and `"prot"` are accepted
- `test_init_invalid_encoder_type_raises` — invalid value raises `ValueError`
  at construction, not in `configure_optimizers()`