### PR TITLE
fix(utils): generate reverse complement instead of reverse

### DIFF
--- a/pyaptamer/utils/_augment.py
+++ b/pyaptamer/utils/_augment.py
@@ -18,10 +18,11 @@ def augment_reverse(*sequence_arrays: np.ndarray) -> tuple[np.ndarray, ...]:
         A tuple of arrays, each containing sequences with their reverse complements
         added.
     """
+    trans = str.maketrans("ACGTUacgtu", "TGCAAtgcaa")
     results = []
     for sequences in sequence_arrays:
         # create array of reversed sequences
-        reversed_sequences = np.array([seq[::-1] for seq in sequences])
+        reversed_sequences = np.array([seq.translate(trans)[::-1] for seq in sequences])
         # concatenate original and reversed sequences
         result = np.concatenate([sequences, reversed_sequences])
         results.append(result)

--- a/pyaptamer/utils/tests/test_augment.py
+++ b/pyaptamer/utils/tests/test_augment.py
@@ -11,7 +11,7 @@ def test_augment_reverse_single_array():
     sequences = np.array(["AAC", "BBB", "ATCG"])
     result = augment_reverse(sequences)
 
-    expected = (np.array(["AAC", "BBB", "ATCG", "CAA", "BBB", "GCTA"]),)
+    expected = (np.array(["AAC", "BBB", "ATCG", "GTT", "BBB", "CGAT"]),)
     assert len(result) == 1
     assert len(result[0]) == 6
     np.testing.assert_array_equal(result[0], expected[0])
@@ -25,7 +25,7 @@ def test_augment_reverse_multiple_arrays():
     result = augment_reverse(seq1, seq2, seq3)
 
     expected = (
-        np.array(["ABC", "DEF", "CBA", "FED"]),
+        np.array(["ABC", "DEF", "GBT", "FED"]),
         np.array(["XYZ", "ZYX"]),
         np.array(["123", "456", "789", "321", "654", "987"]),
     )


### PR DESCRIPTION
##  Fix: Correct `augment_reverse` to Generate Reverse Complements Instead of Simple Reversal

### Description
This PR fixes a critical issue in the `augment_reverse` function where nucleotide sequences were being reversed but not complemented.

Previously, the implementation used Python string slicing (`[::-1]`), which only reversed sequences (e.g., `ATCG → GCTA`). However, the intended behavior—as stated in the docstring—is to generate reverse complements (e.g., `ATCG → CGAT`).

This resulted in biologically invalid augmented data and silent data corruption.

---

### What was fixed
- Added a nucleotide translation step using:
  str.maketrans("ACGTUacgtu", "TGCAAtgcaa")

- Updated sequence transformation to:
  seq.translate(trans)[::-1]

- Kept existing numpy structure and concatenation logic unchanged

---

### Why this matters
- Prevents silent data corruption in datasets
- Ensures biologically valid reverse complement sequences
- Improves downstream ML model reliability
- Eliminates incorrect motif learning

---

### Changes made
- pyaptamer/utils/_augment.py
  - Fixed reverse logic to include complement step

- pyaptamer/utils/tests/test_augment.py
  - Updated expected outputs

---

### Test Verification
- Updated unit tests to reflect correct behavior
- All tests passing:
  pytest pyaptamer/utils/tests/test_augment.py

---

### Example
augment_reverse(np.array(["ATCG"]))

Before:
["ATCG", "GCTA"]

After:
["ATCG", "CGAT"]

---

### Summary
Fixes a critical biological bug by ensuring sequence augmentation produces true reverse complements instead of simple reversed strings.