### PR TITLE
fix(utils): prevent rna2vec from dropping short sequences

### DIFF
--- a/pyaptamer/utils/_rna.py
+++ b/pyaptamer/utils/_rna.py
@@ -151,24 +151,22 @@ def rna2vec(
             triplets.get(sequence[i : i + 3], 0) for i in range(len(sequence) - 2)
         ]
 
-        # skip sequences that convert to an empty list
-        if any(converted):
-            # truncate if too long
-            if max_sequence_length is not None and len(converted) > max_sequence_length:
-                converted = converted[:max_sequence_length]
+        # truncate if too long
+        if max_sequence_length is not None and len(converted) > max_sequence_length:
+            converted = converted[:max_sequence_length]
 
-            # pad if too short
-            if max_sequence_length is not None:
-                pad_length = max_sequence_length - len(converted)
-                padded_sequence = np.pad(
-                    array=converted,
-                    pad_width=(0, pad_length),
-                    constant_values=0,
-                )
-            else:
-                padded_sequence = np.array(converted)
+        # pad if too short
+        if max_sequence_length is not None:
+            pad_length = max_sequence_length - len(converted)
+            padded_sequence = np.pad(
+                array=converted,
+                pad_width=(0, pad_length),
+                constant_values=0,
+            )
+        else:
+            padded_sequence = np.array(converted)
 
-            result.append(padded_sequence)
+        result.append(padded_sequence)
 
     return np.array(result)
 

--- a/pyaptamer/utils/tests/test_rna.py
+++ b/pyaptamer/utils/tests/test_rna.py
@@ -149,22 +149,27 @@ def test_rna2vec_edge_cases():
 
     # empty sequence
     result = rna2vec([""], sequence_type="rna")
-    assert len(result) == 0
+    assert len(result) == 1
+    assert np.all(result == 0)
 
     # single character sequence (can't form triplet)
     result = rna2vec(["A"], sequence_type="rna")
-    assert len(result) == 0
+    assert len(result) == 1
+    assert np.all(result == 0)
 
     # double character sequence (can't form triplet)
     result = rna2vec(["AA"], sequence_type="rna")
-    assert len(result) == 0
+    assert len(result) == 1
+    assert np.all(result == 0)
 
     # test with secondary structure sequences - edge cases
     result = rna2vec(["S"], sequence_type="ss")
-    assert len(result) == 0
+    assert len(result) == 1
+    assert np.all(result == 0)
 
     result = rna2vec(["SS"], sequence_type="ss")
-    assert len(result) == 0
+    assert len(result) == 1
+    assert np.all(result == 0)
 
 
 def test_rna2vec_default_parameters():


### PR DESCRIPTION
## Fix: Prevent silent data loss in `rna2vec`

### Summary
Fixes a critical issue where short or invalid RNA sequences (length < 3) were silently dropped during feature generation, causing sample-label misalignment and downstream crashes.

### What was fixed
- Removed conditional check that skipped sequences with no valid triplets
- Ensured all input sequences return a corresponding output row
- Short/invalid sequences are now represented as zero-vectors

### Impact
- Preserves 1:1 alignment between input sequences and labels
- Prevents shape mismatch errors in training pipelines
- Eliminates risk of silent data corruption

### Files changed
- `pyaptamer/utils/_rna.py`
- `pyaptamer/utils/tests/test_rna.py`

### Verification
- Confirmed output shape matches input length for mixed-quality sequences
- Added test coverage for empty and short sequences

---

Ref: bug reproduction and fix details :contentReference[oaicite:0]{index=0}