### PR TITLE
fix: make max_len optional in GreedyEncoder constructor to match docs and tests

### DIFF
--- a/pyaptamer/trafos/encode/_greedy.py
+++ b/pyaptamer/trafos/encode/_greedy.py
@@ -60,7 +60,7 @@ class GreedyEncoder(BaseTransform):
     def __init__(
         self,
         words: dict[str, int],
-        max_len: int,
+        max_len: int = None,
         word_max_len: int = None,
     ):
         self.words = words


### PR DESCRIPTION
## SUMMARY

This PR fixes a mismatch in `GreedyEncoder` where `max_len` was required in code but optional in docs and tests. It updates `pyaptamer/trafos/encode/_greedy.py` to make `max_len` optional as intended.

---

## FIX

**Before**

```python
max_len: int,
```

**After**

```python
max_len: int = None,
```

---

## VERIFICATION

Instantiating `GreedyEncoder` without `max_len` no longer throws a `TypeError`. It now works as documented, and existing test params run without issues.
