### PR TITLE
[BUG] Raise error for non-DNA characters in generate_kmer_vecs (#322)

### DIFF
--- a/pyaptamer/utils/_aptanet_utils.py
+++ b/pyaptamer/utils/_aptanet_utils.py
@@ -28,8 +28,20 @@ def generate_kmer_vecs(aptamer_sequence, k=4):
     np.ndarray
         1D numpy array of normalized frequency vector for all possible k-mers from
         length 1 to k.
+
+    Raises
+    ------
+    ValueError
+        If the sequence contains non-DNA characters (e.g., 'U' from RNA).
     """
     DNA_BASES = list("ACGT")
+
+    invalid_chars = set(aptamer_sequence.upper()) - set(DNA_BASES)
+    if invalid_chars:
+        raise ValueError(
+            f"Sequence contains non-DNA characters: {invalid_chars}. "
+            "This function only supports DNA sequences (A, C, G, T)."
+        )
 
     # Generate all possible k-mers from 1 to k
     all_kmers = []

--- a/pyaptamer/utils/_aptanet_utils.py
+++ b/pyaptamer/utils/_aptanet_utils.py
@@ -36,10 +36,10 @@ def generate_kmer_vecs(aptamer_sequence, k=4):
     """
     DNA_BASES = list("ACGT")
 
-    invalid_chars = set(aptamer_sequence.upper()) - set(DNA_BASES)
+    invalid_chars = sorted(set(aptamer_sequence) - set(DNA_BASES))
     if invalid_chars:
         raise ValueError(
-            f"Sequence contains non-DNA characters: {invalid_chars}. "
+            f"Sequence contains non-DNA characters: {', '.join(invalid_chars)}. "
             "This function only supports DNA sequences (A, C, G, T)."
         )
 

--- a/pyaptamer/utils/tests/test_aptanet_utils.py
+++ b/pyaptamer/utils/tests/test_aptanet_utils.py
@@ -1,0 +1,59 @@
+"""Test suite for the AptaNet utility functions."""
+
+import numpy as np
+import pytest
+
+from pyaptamer.utils._aptanet_utils import generate_kmer_vecs
+
+
+class TestGenerateKmerVecs:
+    """Tests for generate_kmer_vecs function."""
+
+    def test_dna_sequence_returns_correct_shape(self):
+        """Check that DNA sequences produce correct output shape."""
+        seq = "ACGTACGT"
+        result = generate_kmer_vecs(seq, k=2)
+        # k=2: 4 unigrams + 16 bigrams = 20
+        assert result.shape == (20,)
+
+    def test_dna_sequence_k4_shape(self):
+        """Check shape for default k=4 with DNA bases."""
+        seq = "ACGTACGT"
+        result = generate_kmer_vecs(seq, k=4)
+        # 4 + 16 + 64 + 256 = 340
+        assert result.shape == (340,)
+
+    def test_frequencies_are_normalized(self):
+        """Check that the output frequencies sum to 1."""
+        seq = "ACGTACGT"
+        result = generate_kmer_vecs(seq, k=2)
+        assert np.isclose(result.sum(), 1.0)
+
+    @pytest.mark.parametrize("k", [1, 2, 3, 4])
+    def test_various_k_values(self, k):
+        """Check correct output shape for various k values."""
+        seq = "ACGTACGT"
+        result = generate_kmer_vecs(seq, k=k)
+        expected_len = sum(4**i for i in range(1, k + 1))
+        assert result.shape == (expected_len,)
+
+    def test_single_base_sequence(self):
+        """Check that a single base sequence works."""
+        result = generate_kmer_vecs("A", k=1)
+        assert result.shape == (4,)
+        assert result.sum() > 0
+
+    def test_empty_sequence(self):
+        """Check that an empty sequence returns all zeros."""
+        result = generate_kmer_vecs("", k=2)
+        assert np.all(result == 0)
+
+    def test_rna_sequence_raises_error(self):
+        """Check that RNA sequences with 'U' raise a ValueError."""
+        with pytest.raises(ValueError, match="non-DNA characters"):
+            generate_kmer_vecs("ACGUACGU", k=2)
+
+    def test_invalid_characters_raise_error(self):
+        """Check that sequences with invalid characters raise a ValueError."""
+        with pytest.raises(ValueError, match="non-DNA characters"):
+            generate_kmer_vecs("ACGXACGT", k=2)

--- a/pyaptamer/utils/tests/test_aptanet_utils.py
+++ b/pyaptamer/utils/tests/test_aptanet_utils.py
@@ -57,3 +57,8 @@ class TestGenerateKmerVecs:
         """Check that sequences with invalid characters raise a ValueError."""
         with pytest.raises(ValueError, match="non-DNA characters"):
             generate_kmer_vecs("ACGXACGT", k=2)
+
+    def test_lowercase_dna_raises_error(self):
+        """Check that lowercase DNA sequences raise a ValueError."""
+        with pytest.raises(ValueError, match="non-DNA characters"):
+            generate_kmer_vecs("acgtacgt", k=2)


### PR DESCRIPTION
## Title:
  [BUG] Raise error for non-DNA characters in generate_kmer_vecs 

  Fixes #322

## Description

`generate_kmer_vecs` silently ignores RNA k-mers containing 'U' because , it only recognizes DNA bases (A, C, G, T). Instead of silently producing zero frequencies, the function now raises a `ValueError` when the sequence contains non-DNA characters.

As discussed in #322, this function is DNA-only by design — the fix raises an error rather than normalizing RNA input.

## Changes

  - Added input validation in `generate_kmer_vecs` to reject non-DNA characters
  - Added `Raises` section to the docstring
  - Added test coverage for `generate_kmer_vecs` (previously had none)

  ## Tests

  - 11 new tests in `test_aptanet_utils.py`
  - All existing tests pass with no regressions

 