### PR TITLE
[BUG] Fix minor bugs across multiple modules

### DIFF
--- a/pyaptamer/aptanet/_pipeline.py
+++ b/pyaptamer/aptanet/_pipeline.py
@@ -79,6 +79,7 @@ class AptaNetPipeline(BaseObject, BaseEstimator):
     def fit(self, X, y):
         self.pipeline_ = self._build_pipeline()
         self.pipeline_.fit(X, y)
+        return self
 
     def predict_proba(self, X):
         check_is_fitted(self)

--- a/pyaptamer/aptatrans/layers/_encoder.py
+++ b/pyaptamer/aptatrans/layers/_encoder.py
@@ -78,9 +78,11 @@ class PositionalEncoding(nn.Module):
             Output tensor of shape (batch_size, seq_len, n_features (`d_model`)), with
             positional encodings applied.
         """
-        assert x.shape[1] <= self.max_len, (
-            f"Input sequence length {x.shape[1]} exceeds maximum length {self.max_len}."
-        )
+        if x.shape[1] > self.max_len:
+            raise ValueError(
+                f"Input sequence length {x.shape[1]} exceeds maximum length"
+                f" {self.max_len}."
+            )
 
         out = x + self.pe[:, : x.shape[1], :]
         if self.dropout:

--- a/pyaptamer/mcts/_algorithm.py
+++ b/pyaptamer/mcts/_algorithm.py
@@ -269,7 +269,8 @@ class MCTS(BaseObject):
         Returns
         -------
         dict
-            Dictionary containing the final candidate sequence (`candidate`) and its
+            Dictionary containing the reconstructed candidate sequence
+            (`candidate`), the raw encoded sequence (`sequence`), and its
             score (`score`).
         """
         self._reset()


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #350
Fixes #352
Fixes #353

#### What does this implement/fix? Explain your changes.

This PR fixes three minor but genuine bugs across different modules:

1. **`AptaNetPipeline.fit()` missing `return self`** (`aptanet/_pipeline.py`)
   The `fit()` method did not return `self`, breaking the sklearn estimator API convention. This prevents method chaining and usage in meta-estimators like `GridSearchCV`.

2. **`MCTS.run()` docstring incomplete** (`mcts/_algorithm.py`)
   The docstring stated the return dict contains `candidate` and `score`, but the actual return also includes a `sequence` key. Updated the docstring to document all three keys.

3. **`PositionalEncoding.forward()` uses `assert` for validation** (`aptatrans/layers/_encoder.py`)
   The sequence length check used `assert`, which is stripped when Python runs with `-O`. Replaced with an explicit `ValueError` so the check always runs.

#### What should a reviewer concentrate their feedback on?
- Whether the `return self` addition is correct for the sklearn API contract
- Whether the MCTS docstring accurately describes the three return keys
- Whether `ValueError` is the right exception type for the PositionalEncoding check

#### Did you add any tests for the change?
No new tests — these are a one-line fix, a docstring correction, and an assert-to-raise replacement.

#### Any other comments?
None.

#### PR checklist
- [x] The PR title starts with [BUG]
- [x] Used pre-commit hooks