### PR TITLE
[BUG] Fix MaskedDataset y_masked initialized from x instead of y

### DIFF
--- a/pyaptamer/datasets/dataclasses/_masked.py
+++ b/pyaptamer/datasets/dataclasses/_masked.py
@@ -151,7 +151,7 @@ class MaskedDataset(Dataset):
         y = torch.tensor(self.y[index], dtype=torch.int64)
 
         x_masked = x.clone().detach()
-        y_masked = x.clone().detach()
+        y_masked = y.clone().detach()
 
         # non-padding positions (0 is padding)
         seq_len = torch.sum(x_masked > 0)

--- a/pyaptamer/datasets/tests/test_masked_dataset.py
+++ b/pyaptamer/datasets/tests/test_masked_dataset.py
@@ -1,0 +1,48 @@
+"""Tests for MaskedDataset."""
+
+import pytest
+
+from pyaptamer.datasets.dataclasses import MaskedDataset
+
+
+@pytest.fixture
+def basic_dataset():
+    """Create a basic MaskedDataset for testing."""
+    x = [[1, 2, 3, 4, 0], [2, 1, 4, 3, 0]]
+    y = [[1, 2, 3, 4, 0], [2, 1, 4, 3, 0]]
+    return MaskedDataset(x, y, max_len=5, mask_idx=5, masked_rate=0.2)
+
+
+def test_masked_dataset_length(basic_dataset):
+    """Check __len__ returns correct count."""
+    assert len(basic_dataset) == 2
+
+
+def test_masked_dataset_getitem_returns_four_tensors(basic_dataset):
+    """Check __getitem__ returns four tensors."""
+    result = basic_dataset[0]
+    assert len(result) == 4
+
+
+def test_masked_dataset_mismatched_lengths():
+    """Mismatched x and y lengths should raise."""
+    x = [[1, 2, 3]]
+    y = [[1, 2, 3], [4, 5, 6]]
+    with pytest.raises(ValueError, match="same length"):
+        MaskedDataset(x, y, max_len=3, mask_idx=5)
+
+
+def test_y_masked_initialized_from_y_not_x():
+    """Check y_masked is derived from y, not from x."""
+    x = [[1, 2, 3, 4, 0]]
+    y = [[5, 6, 7, 8, 0]]
+
+    dataset = MaskedDataset(x, y, max_len=5, mask_idx=9, masked_rate=0.5, is_rna=False)
+
+    _, y_masked, _, _ = dataset[0]
+
+    nonzero_mask = y_masked != 0
+    if nonzero_mask.any():
+        y_vals = set(y[0])
+        for val in y_masked[nonzero_mask].tolist():
+            assert val in y_vals


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes a previously unreported bug in `MaskedDataset.__getitem__()`.

#### What does this implement/fix? Explain your changes.
`MaskedDataset.__getitem__()` in `pyaptamer/datasets/dataclasses/_masked.py` initializes `y_masked` by cloning `x` instead of `y`:

Before (line 156):
```python
x_masked = x.clone().detach()
y_masked = x.clone().detach()  # bug: should be y
```

After:
```python
x_masked = x.clone().detach()
y_masked = y.clone().detach()
```

When `x != y`, the masked target returned for loss computation contains values from the input sequence instead of the actual target sequence. The return docstring says it returns "target sequence with non-masked positions set to 0", but it was returning the input sequence with non-masked positions zeroed.

In typical MLM usage `x == y` so the bug is masked, but the class API explicitly accepts different `x` and `y` arrays via its constructor.

#### What should a reviewer concentrate their feedback on?
- Whether the fix correctly initializes `y_masked` from `y`
- Whether the regression test adequately covers the divergent x/y case

#### Did you add any tests for the change?
Yes. Added `pyaptamer/datasets/tests/test_masked_dataset.py` with 4 tests:
- `test_masked_dataset_length` — basic `__len__` check
- `test_masked_dataset_getitem_returns_four_tensors` — output shape
- `test_masked_dataset_mismatched_lengths` — `ValueError` on mismatched x/y
- `test_y_masked_initialized_from_y_not_x` — regression test for this specific bug

#### Any other comments?
Local validation:
- `pytest pyaptamer/datasets/tests/test_masked_dataset.py` — 4 passed
- `pre-commit run --files pyaptamer/datasets/dataclasses/_masked.py pyaptamer/datasets/tests/test_masked_dataset.py` — all passed

#### PR checklist
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks.
```