### PR TITLE
[BUG] Fix _load_1gnh_structure ignoring pdb_path parameter

### DIFF
--- a/pyaptamer/datasets/_loaders/_1gnh.py
+++ b/pyaptamer/datasets/_loaders/_1gnh.py
@@ -37,7 +37,8 @@ def _load_1gnh_structure(pdb_path=None):
     """
     from Bio.PDB import PDBParser
 
-    pdb_path = os.path.join(os.path.dirname(__file__), "..", "data", "1gnh.pdb")
+    if pdb_path is None:
+        pdb_path = os.path.join(os.path.dirname(__file__), "..", "data", "1gnh.pdb")
 
     parser = PDBParser(QUIET=True)
     structure = parser.get_structure("1gnh", pdb_path)

--- a/pyaptamer/utils/tests/test_struct_to_aaseq.py
+++ b/pyaptamer/utils/tests/test_struct_to_aaseq.py
@@ -1,5 +1,7 @@
 __author__ = "satvshr"
 
+import os
+
 import pandas as pd
 
 from pyaptamer.datasets._loaders._1gnh import _load_1gnh_structure
@@ -43,3 +45,18 @@ def test_struct_to_aaseq():
     assert seq_list == df["sequence"].tolist(), (
         "List sequences must match DataFrame 'sequence' column"
     )
+
+
+def test_load_1gnh_structure_respects_custom_pdb_path():
+    """Check that _load_1gnh_structure uses pdb_path when provided."""
+    default_path = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        "..",
+        "..",
+        "datasets",
+        "data",
+        "1gnh.pdb",
+    )
+    structure = _load_1gnh_structure(pdb_path=default_path)
+    assert structure is not None
+    assert structure.id == "1gnh"


### PR DESCRIPTION

#### Reference Issues/PRs
Fixes a previously unreported bug in `_load_1gnh_structure()`.

#### What does this implement/fix? Explain your changes.
`_load_1gnh_structure(pdb_path=None)` in `pyaptamer/datasets/_loaders/_1gnh.py` unconditionally overwrites `pdb_path` with the hardcoded default path, silently ignoring any custom path passed by the caller:

Before:
```python
pdb_path = os.path.join(os.path.dirname(__file__), "..", "data", "1gnh.pdb")
```

After:
```python
if pdb_path is None:
    pdb_path = os.path.join(os.path.dirname(__file__), "..", "data", "1gnh.pdb")
```

The docstring says "if not provided, uses the default path", implying a custom path should work.

#### What should a reviewer concentrate their feedback on?
- Whether the `if pdb_path is None:` guard is placed correctly

#### Did you add any tests for the change?
Yes. Added `test_load_1gnh_structure_respects_custom_pdb_path` to `pyaptamer/utils/tests/test_struct_to_aaseq.py`.

#### Any other comments?
Local validation:
- `pytest pyaptamer/utils/tests/test_struct_to_aaseq.py` — 2 passed
- `pre-commit run --files pyaptamer/datasets/_loaders/_1gnh.py pyaptamer/utils/tests/test_struct_to_aaseq.py` — all passed

#### PR checklist
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks.