### PR TITLE
[BUG] Replace assert with ValueError in MCTS _reconstruct

### DIFF
--- a/pyaptamer/mcts/_algorithm.py
+++ b/pyaptamer/mcts/_algorithm.py
@@ -124,9 +124,10 @@ class MCTS(BaseObject):
         # if the sequence is not reconstructed yet, it should have an even length
         # because it should consist of pairs such as 'A_' and '_A' (i.e., nucleotide +
         # direction marker).
-        assert len(sequence) % 2 == 0, (
-            f"Encoded sequence must have even length, got {len(sequence)}."
-        )
+        if len(sequence) % 2 != 0:
+            raise ValueError(
+                f"Encoded sequence must have even length, got {len(sequence)}."
+            )
 
         # reconstruct
         result = ""

--- a/pyaptamer/mcts/tests/test_mcts.py
+++ b/pyaptamer/mcts/tests/test_mcts.py
@@ -269,6 +269,11 @@ class TestMCTS:
         # mixed prepend/append
         assert mcts._reconstruct("A_C__GU_") == "UCAG"
 
+    def test_reconstruct_odd_length_raises(self, mcts):
+        """Check that _reconstruct raises ValueError for odd-length encoded input."""
+        with pytest.raises(ValueError, match="even length"):
+            mcts._reconstruct("A_C")
+
     def test_selection_not_fully_expanded(self, mcts):
         """Check selection step when the node is not fully expanded."""
         # from root with no childrem, should return the root itself


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes a previously unreported bug in `MCTS._reconstruct()`.

#### What does this implement/fix? Explain your changes.
`_reconstruct()` in `pyaptamer/mcts/_algorithm.py` uses an `assert` to validate that the encoded sequence has even length. `assert` statements are stripped when running with `python -O`, silently removing this validation.

Replaced `assert` with a proper `ValueError` raise.

#### What should a reviewer concentrate their feedback on?
- Whether `ValueError` is the right exception type here

#### Did you add any tests for the change?
Yes. Added `test_reconstruct_odd_length_raises` to `pyaptamer/mcts/tests/test_mcts.py`.

#### Any other comments?
- `pytest pyaptamer/mcts/tests/test_mcts.py` — all passed
- `pre-commit run --all-files` — all passed

#### PR checklist
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks.