### PR TITLE
[DOC] Fix PSeAAC docstring errors and malformed error messages

### DIFF
--- a/pyaptamer/pseaac/_pseaac_aptanet.py
+++ b/pyaptamer/pseaac/_pseaac_aptanet.py
@@ -89,8 +89,8 @@ class AptaNetPSeAAC:
 
     Example
     -------
-    >>> from pyaptamer.pseaac import PSeAAC
-    >>> pseaac = PSeAAC()
+    >>> from pyaptamer.pseaac import AptaNetPSeAAC
+    >>> pseaac = AptaNetPSeAAC()
     >>> features = pseaac.transform("ACDEFGHIKLMNPQRHIKLMNPQRSTVWHIKLMNPQRSTVWY")
     >>> print(features[:10])
     [0.006 0.006 0.006 0.006 0.006 0.006 0.018 0.018 0.018 0.018]

--- a/pyaptamer/pseaac/_pseaac_general.py
+++ b/pyaptamer/pseaac/_pseaac_general.py
@@ -127,7 +127,7 @@ class PSeAAC:
 
         if group_props is not None and custom_groups is not None:
             raise ValueError(
-                "Specify only one of `group_props` or `custom_groups`,not both."
+                "Specify only one of `group_props` or `custom_groups`, not both."
             )
 
         self.np_matrix = aa_props(
@@ -148,7 +148,7 @@ class PSeAAC:
         else:
             if self._n_cols % group_props != 0:
                 raise ValueError(
-                    f"Number of properties ({self._n_cols}) must be divisible by"
+                    f"Number of properties ({self._n_cols}) must be divisible by "
                     f"group_props ({group_props})."
                 )
             self.prop_groups = [
@@ -219,12 +219,6 @@ class PSeAAC:
         protein_sequence : str
             The input protein sequence consisting of valid amino acid characters
             (A, C, D, E, F, G, H, I, K, L, M, N, P, Q, R, S, T, V, W, Y).
-        lambda_val : int, default=30
-            The maximum distance between residues considered in the sequence-order
-            correlation (θ) calculations.
-        weight : float, default=0.15
-            The weight factor that balances the contribution of sequence-order
-            correlation features relative to amino acid composition features.
 
         Returns
         -------

--- a/pyaptamer/pseaac/tests/test_pseaac.py
+++ b/pyaptamer/pseaac/tests/test_pseaac.py
@@ -125,3 +125,15 @@ def test_pseaac_configurations(
     assert len(vec) == expected_len, (
         f"Expected vector length {expected_len}, but got {len(vec)}"
     )
+
+
+def test_pseaac_group_props_and_custom_groups_conflict():
+    """Both group_props and custom_groups cannot be specified at the same time."""
+    with pytest.raises(ValueError, match="not both"):
+        PSeAAC(group_props=3, custom_groups=[[0, 1, 2]])
+
+
+def test_pseaac_indivisible_group_props():
+    """Error message must be readable when group_props doesn't divide n_props."""
+    with pytest.raises(ValueError, match="divisible by group_props"):
+        PSeAAC(prop_indices=[0, 1, 2, 3, 4], group_props=3)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes previously unreported issues in the `pseaac` module.

#### What does this implement/fix? Explain your changes.
Four fixes:

1. `PSeAAC.transform()` docstring listed `lambda_val` and `weight` as parameters but the method only takes `protein_sequence`. Also had wrong default `0.15` vs actual `0.05`. Removed phantom params.
2. `AptaNetPSeAAC` docstring example imported `PSeAAC` instead of `AptaNetPSeAAC`. Fixed.
3. Missing space in f-string: `"divisible by" f"group_props"` → `"divisible bygroup_props"`. Added space.
4. Missing space: `"custom_groups`,not both."` → `", not both."`.

#### What should a reviewer concentrate their feedback on?
- Whether the `transform()` docstring is accurate after removing the phantom params

#### Did you add any tests for the change?
Yes. Added `test_pseaac_group_props_and_custom_groups_conflict` and `test_pseaac_indivisible_group_props` to `pyaptamer/pseaac/tests/test_pseaac.py`.

#### Any other comments?
- `pytest pyaptamer/pseaac/tests/test_pseaac.py` — 13 passed
- `pre-commit run --all-files` — all passed

#### PR checklist
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks.