### PR TITLE
[BUG]: Validate `n_iterations` in MCTS

### DIFF
--- a/pyaptamer/mcts/_algorithm.py
+++ b/pyaptamer/mcts/_algorithm.py
@@ -74,6 +74,9 @@ class MCTS(BaseObject):
         n_iterations: int = 1000,
         experiment=None,
     ) -> None:
+        if n_iterations < 1:
+            raise ValueError(f"`n_iterations` must be >= 1, got {n_iterations}.")
+
         self.experiment = experiment
         self.depth = depth
         self.n_iterations = n_iterations

--- a/pyaptamer/mcts/_algorithm.py
+++ b/pyaptamer/mcts/_algorithm.py
@@ -24,11 +24,13 @@ class MCTS(BaseObject):
     ----------
     states : list[str], optional, default=None
         Possible values for the nodes. Underscores indicate whether the values are
-        supposed to be prepended or appended to the sequence.
+        supposed to be prepended or appended to the sequence. Must be non-empty and
+        contain unique entries.
     depth : int, optional, default=20
-        Maximum depth of the search tree, also the length of the generated sequences.
+        Maximum depth of the search tree, also the length of the generated
+        sequences. Must be >= 1.
     n_iterations : int, optional, default=1000
-        Number of iterations per round for the MCTS algorithm.
+        Number of iterations per round for the MCTS algorithm. Must be >= 1.
     experiment : BaseAptamerEval, optional, default=None
         An instance of an experiment class definingthe goal function for the algorithm.
 
@@ -74,17 +76,23 @@ class MCTS(BaseObject):
         n_iterations: int = 1000,
         experiment=None,
     ) -> None:
+        if depth < 1:
+            raise ValueError(f"`depth` must be >= 1, got {depth}.")
         if n_iterations < 1:
             raise ValueError(f"`n_iterations` must be >= 1, got {n_iterations}.")
+
+        if states is None:
+            states = ["A_", "C_", "G_", "U_", "_A", "_C", "_G", "_U"]
+        elif not states:
+            raise ValueError("`states` must contain at least one entry.")
+        elif len(states) != len(set(states)):
+            raise ValueError("`states` must contain unique entries.")
 
         self.experiment = experiment
         self.depth = depth
         self.n_iterations = n_iterations
 
         super().__init__()
-
-        if states is None:
-            states = ["A_", "C_", "G_", "U_", "_A", "_C", "_G", "_U"]
         self.states = states
 
         self.root = TreeNode(

--- a/pyaptamer/mcts/_algorithm.py
+++ b/pyaptamer/mcts/_algorithm.py
@@ -34,15 +34,6 @@ class MCTS(BaseObject):
     experiment : BaseAptamerEval, optional, default=None
         An instance of an experiment class definingthe goal function for the algorithm.
 
-    Raises
-    ------
-    ValueError
-        If ``depth`` is less than 1.
-    ValueError
-        If ``n_iterations`` is less than 1.
-    ValueError
-        If ``states`` contains duplicate entries.
-
     Attributes
     ----------
     root : TreeNode
@@ -85,6 +76,16 @@ class MCTS(BaseObject):
         n_iterations: int = 1000,
         experiment=None,
     ) -> None:
+        """
+        Raises
+        ------
+        ValueError
+            If `depth` is less than 1.
+        ValueError
+            If `n_iterations` is less than 1.
+        ValueError
+            If `states` contains duplicate entries.
+        """
         if depth < 1:
             raise ValueError(f"`depth` must be >= 1, got {depth}.")
         if n_iterations < 1:

--- a/pyaptamer/mcts/_algorithm.py
+++ b/pyaptamer/mcts/_algorithm.py
@@ -24,8 +24,8 @@ class MCTS(BaseObject):
     ----------
     states : list[str], optional, default=None
         Possible values for the nodes. Underscores indicate whether the values are
-        supposed to be prepended or appended to the sequence. Must be non-empty and
-        contain unique entries.
+        supposed to be prepended or appended to the sequence. If None or empty,
+        defaults to the standard RNA nucleotide states. Must contain unique entries.
     depth : int, optional, default=20
         Maximum depth of the search tree, also the length of the generated
         sequences. Must be >= 1.
@@ -33,6 +33,15 @@ class MCTS(BaseObject):
         Number of iterations per round for the MCTS algorithm. Must be >= 1.
     experiment : BaseAptamerEval, optional, default=None
         An instance of an experiment class definingthe goal function for the algorithm.
+
+    Raises
+    ------
+    ValueError
+        If ``depth`` is less than 1.
+    ValueError
+        If ``n_iterations`` is less than 1.
+    ValueError
+        If ``states`` contains duplicate entries.
 
     Attributes
     ----------
@@ -81,10 +90,8 @@ class MCTS(BaseObject):
         if n_iterations < 1:
             raise ValueError(f"`n_iterations` must be >= 1, got {n_iterations}.")
 
-        if states is None:
+        if not states:
             states = ["A_", "C_", "G_", "U_", "_A", "_C", "_G", "_U"]
-        elif not states:
-            raise ValueError("`states` must contain at least one entry.")
         elif len(states) != len(set(states)):
             raise ValueError("`states` must contain unique entries.")
 

--- a/pyaptamer/mcts/tests/test_mcts.py
+++ b/pyaptamer/mcts/tests/test_mcts.py
@@ -253,10 +253,11 @@ class TestMCTS:
         with pytest.raises(ValueError, match=r"`n_iterations` must be >= 1"):
             MCTS(n_iterations=n_iterations)
 
-    def test_init_empty_states(self):
-        """Check an empty search space is rejected early."""
-        with pytest.raises(ValueError, match=r"`states` must contain at least one"):
-            MCTS(states=[])
+    @pytest.mark.parametrize("states", [None, []])
+    def test_init_empty_or_none_states_defaults(self, states):
+        """Check that None or empty states default to the standard nucleotide set."""
+        mcts = MCTS(states=states)
+        assert mcts.states == ["A_", "C_", "G_", "U_", "_A", "_C", "_G", "_U"]
 
     def test_init_duplicate_states(self):
         """Check duplicate states are rejected early."""

--- a/pyaptamer/mcts/tests/test_mcts.py
+++ b/pyaptamer/mcts/tests/test_mcts.py
@@ -241,6 +241,12 @@ def mcts(request):
 class TestMCTS:
     """Tests for the MCTS() class."""
 
+    @pytest.mark.parametrize("n_iterations", [0, -1])
+    def test_init_invalid_iterations(self, n_iterations):
+        """Check invalid iteration counts are rejected early."""
+        with pytest.raises(ValueError, match=r"`n_iterations` must be >= 1"):
+            MCTS(n_iterations=n_iterations)
+
     def test_reset(self, mcts):
         """Check correct reset of the inner state."""
         # modify its inner state

--- a/pyaptamer/mcts/tests/test_mcts.py
+++ b/pyaptamer/mcts/tests/test_mcts.py
@@ -241,11 +241,27 @@ def mcts(request):
 class TestMCTS:
     """Tests for the MCTS() class."""
 
+    @pytest.mark.parametrize("depth", [0, -1])
+    def test_init_invalid_depth(self, depth):
+        """Check invalid depths are rejected early."""
+        with pytest.raises(ValueError, match=r"`depth` must be >= 1"):
+            MCTS(depth=depth)
+
     @pytest.mark.parametrize("n_iterations", [0, -1])
     def test_init_invalid_iterations(self, n_iterations):
         """Check invalid iteration counts are rejected early."""
         with pytest.raises(ValueError, match=r"`n_iterations` must be >= 1"):
             MCTS(n_iterations=n_iterations)
+
+    def test_init_empty_states(self):
+        """Check an empty search space is rejected early."""
+        with pytest.raises(ValueError, match=r"`states` must contain at least one"):
+            MCTS(states=[])
+
+    def test_init_duplicate_states(self):
+        """Check duplicate states are rejected early."""
+        with pytest.raises(ValueError, match=r"`states` must contain unique entries"):
+            MCTS(states=["A_", "A_"])
 
     def test_reset(self, mcts):
         """Check correct reset of the inner state."""


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #358

#### What does this implement/fix? Explain your changes.
1. Expanded constructor input validation in `MCTS.__init__`:
* Raises `ValueError` when:- **
a. `n_iterations < 1`.
b. `depth < 1`.
c. `states` is empty.
d. `states` contains duplicates.

4. Added focused regression tests in `test_mcts.py`:
* Verifies invalid:-
a. `n_iterations` values (`0`, `-1`) are rejected.
b. `depth` values (`0`, `-1`) are rejected.
c.  `states` inputs (empty and duplicate entries) are rejected.

```python
def __init__(self, ...) -> None:
    if depth < 1:
        raise ValueError(f"`depth` must be >= 1, got {depth}.")
    if n_iterations < 1:
        raise ValueError(f"`n_iterations` must be >= 1, got {n_iterations}.")

    if states is None:
        states = ["A_", "C_", "G_", "U_", "_A", "_C", "_G", "_U"]
    elif not states:
        raise ValueError("`states` must contain at least one entry.")
    elif len(states) != len(set(states)):
        raise ValueError("`states` must contain unique entries.")
```

#### What should a reviewer concentrate their feedback on?
- [ ] Please focus on whether validating `depth`, `n_iterations`, and `states` in `MCTS.__init__` is the right and consistent fix for preventing invalid runtime behavior (including the infinite-loop path in `run()` for `n_iterations <= 0`).
- [ ] Please check whether `ValueError` is the correct API behavior for these invalid constructor inputs.
- [ ] Please check that the added regression tests are focused and cover the relevant invalid cases without over-scoping.

#### Did you add any tests for the change?
yes

```python
@pytest.mark.parametrize("depth", [0, -1])
def test_init_invalid_depth(self, depth):
    ...

@pytest.mark.parametrize("n_iterations", [0, -1])
def test_init_invalid_iterations(self, n_iterations):
    ...

def test_init_empty_states(self):
    ...

def test_init_duplicate_states(self):
    ...
```

#### PR checklist
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] 
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. 

py-test
<img width="1912" height="165" alt="image" src="https://github.com/user-attachments/assets/a396765d-8f98-40f4-b108-73b39be7391d" />

notebooks diff
<img width="1919" height="121" alt="Screenshot 2026-04-11 004844" src="https://github.com/user-attachments/assets/541bf011-285f-4319-8389-634def1ac032" />

pre-commit
<img width="1907" height="199" alt="image" src="https://github.com/user-attachments/assets/41140756-df9d-4bd9-a7cc-5c7e8b5281e3" />

run-jupyter-notebooks
<img width="1914" height="300" alt="Image" src="https://github.com/user-attachments/assets/c92528ec-5a7b-4144-a155-77c90effe95b" />