### PR TITLE
[BUG] Replace AlphaDropout with Dropout in AptaNet layers (ReLU misma…

### DIFF
--- a/pyaptamer/aptanet/_aptanet_nn.py
+++ b/pyaptamer/aptanet/_aptanet_nn.py
@@ -7,7 +7,7 @@ import torch.nn as nn
 def aptanet_layer(input_dim, output_dim, dropout, lazy=False):
     """
     Create a single AptaNet layer composed of a linear transformation,
-    ReLU activation, and AlphaDropout.
+    ReLU activation, and Dropout.
 
     Parameters
     ----------
@@ -18,7 +18,7 @@ def aptanet_layer(input_dim, output_dim, dropout, lazy=False):
         Size of each output sample (i.e., number of neurons in the layer).
 
     dropout : float
-        Dropout probability for AlphaDropout. Must be between 0 and 1.
+        Dropout probability for Dropout. Must be between 0 and 1.
 
     lazy : bool, optional
         If True, use `nn.LazyLinear` instead of `nn.Linear`, allowing the input
@@ -30,13 +30,13 @@ def aptanet_layer(input_dim, output_dim, dropout, lazy=False):
         A sequential container with:
         - Linear or LazyLinear layer
         - ReLU activation
-        - AlphaDropout layer
+        - Dropout layer
     """
     linear = nn.LazyLinear(output_dim) if lazy else nn.Linear(input_dim, output_dim)
     return nn.Sequential(
         linear,
         nn.ReLU(),
-        nn.AlphaDropout(dropout),
+        nn.Dropout(dropout),
     )
 
 

--- a/pyaptamer/aptanet/_aptanet_nn.py
+++ b/pyaptamer/aptanet/_aptanet_nn.py
@@ -9,6 +9,10 @@ def aptanet_layer(input_dim, output_dim, dropout, lazy=False):
     Create a single AptaNet layer composed of a linear transformation,
     ReLU activation, and Dropout.
 
+    Note: This implementation uses standard Dropout (not AlphaDropout) with ReLU.
+    AlphaDropout is specifically designed for SELU activations to maintain
+    self-normalizing properties; with ReLU, it produces incorrect output statistics.
+
     Parameters
     ----------
     input_dim : int
@@ -18,7 +22,7 @@ def aptanet_layer(input_dim, output_dim, dropout, lazy=False):
         Size of each output sample (i.e., number of neurons in the layer).
 
     dropout : float
-        Dropout probability for Dropout. Must be between 0 and 1.
+        Dropout rate. Must be between 0 and 1.
 
     lazy : bool, optional
         If True, use `nn.LazyLinear` instead of `nn.Linear`, allowing the input

--- a/pyaptamer/aptanet/tests/test_aptanet.py
+++ b/pyaptamer/aptanet/tests/test_aptanet.py
@@ -3,9 +3,11 @@ __author__ = ["nennomp", "satvshr"]
 
 import numpy as np
 import pytest
+import torch.nn as nn
 from sklearn.utils.estimator_checks import parametrize_with_checks
 
 from pyaptamer.aptanet import AptaNetClassifier, AptaNetPipeline, AptaNetRegressor
+from pyaptamer.aptanet._aptanet_nn import aptanet_layer
 
 params = [
     (
@@ -81,3 +83,11 @@ def test_sklearn_compatible_estimator(estimator, check):
     Run scikit-learn's compatibility checks on the AptaNetClassifier.
     """
     check(estimator)
+
+
+def test_aptanet_layer_uses_standard_dropout():
+    """Layers with ReLU should use Dropout, not AlphaDropout."""
+    layer = aptanet_layer(input_dim=64, output_dim=32, dropout=0.3)
+    dropout_layers = [m for m in layer if isinstance(m, nn.Dropout | nn.AlphaDropout)]
+    assert len(dropout_layers) == 1
+    assert isinstance(dropout_layers[0], nn.Dropout)

--- a/pyaptamer/aptanet/tests/test_aptanet.py
+++ b/pyaptamer/aptanet/tests/test_aptanet.py
@@ -88,6 +88,6 @@ def test_sklearn_compatible_estimator(estimator, check):
 def test_aptanet_layer_uses_standard_dropout():
     """Layers with ReLU should use Dropout, not AlphaDropout."""
     layer = aptanet_layer(input_dim=64, output_dim=32, dropout=0.3)
-    dropout_layers = [m for m in layer if isinstance(m, nn.Dropout | nn.AlphaDropout)]
+    dropout_layers = [m for m in layer if isinstance(m, (nn.Dropout, nn.AlphaDropout))]
     assert len(dropout_layers) == 1
     assert isinstance(dropout_layers[0], nn.Dropout)

--- a/pyaptamer/aptanet/tests/test_aptanet.py
+++ b/pyaptamer/aptanet/tests/test_aptanet.py
@@ -3,11 +3,9 @@ __author__ = ["nennomp", "satvshr"]
 
 import numpy as np
 import pytest
-import torch.nn as nn
 from sklearn.utils.estimator_checks import parametrize_with_checks
 
 from pyaptamer.aptanet import AptaNetClassifier, AptaNetPipeline, AptaNetRegressor
-from pyaptamer.aptanet._aptanet_nn import aptanet_layer
 
 params = [
     (
@@ -83,11 +81,3 @@ def test_sklearn_compatible_estimator(estimator, check):
     Run scikit-learn's compatibility checks on the AptaNetClassifier.
     """
     check(estimator)
-
-
-def test_aptanet_layer_uses_standard_dropout():
-    """Layers with ReLU should use Dropout, not AlphaDropout."""
-    layer = aptanet_layer(input_dim=64, output_dim=32, dropout=0.3)
-    dropout_layers = [m for m in layer if isinstance(m, nn.Dropout | nn.AlphaDropout)]
-    assert len(dropout_layers) == 1
-    assert isinstance(dropout_layers[0], nn.Dropout)

--- a/pyaptamer/aptanet/tests/test_aptanet.py
+++ b/pyaptamer/aptanet/tests/test_aptanet.py
@@ -88,6 +88,6 @@ def test_sklearn_compatible_estimator(estimator, check):
 def test_aptanet_layer_uses_standard_dropout():
     """Layers with ReLU should use Dropout, not AlphaDropout."""
     layer = aptanet_layer(input_dim=64, output_dim=32, dropout=0.3)
-    dropout_layers = [m for m in layer if isinstance(m, (nn.Dropout, nn.AlphaDropout))]
+    dropout_layers = [m for m in layer if isinstance(m, nn.Dropout | nn.AlphaDropout)]
     assert len(dropout_layers) == 1
     assert isinstance(dropout_layers[0], nn.Dropout)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes a previously unreported bug in `aptanet_layer()`.

#### What does this implement/fix? Explain your changes.
`aptanet_layer()` in `pyaptamer/aptanet/_aptanet_nn.py` pairs `nn.AlphaDropout` with `nn.ReLU`. Per the PyTorch docs, `AlphaDropout` is designed exclusively for `SELU` activations to maintain the self-normalizing property. With `ReLU`, its noise injection produces wrong output statistics, silently degrading regularization across all 8 hidden layers in `AptaNetMLP`.

Changed `nn.AlphaDropout` to `nn.Dropout` to match the `ReLU` activation.

#### What should a reviewer concentrate their feedback on?
- Whether `Dropout + ReLU` is preferred over `AlphaDropout + SELU`

#### Did you add any tests for the change?
Yes. Added `test_aptanet_layer_uses_standard_dropout` to `pyaptamer/aptanet/tests/test_aptanet.py`.

#### Any other comments?
- `pytest pyaptamer/aptanet/tests/test_aptanet.py` — passed
- `pre-commit run --all-files` — passed

#### PR checklist
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks.