### PR TITLE
[BUG] Fix infinite loop in AptaTransPipeline.recommend()

### DIFF
--- a/pyaptamer/aptatrans/_pipeline.py
+++ b/pyaptamer/aptatrans/_pipeline.py
@@ -238,11 +238,16 @@ class AptaTransPipeline:
 
         # generate aptamer candidates
         candidates = {}
-        while len(candidates) < n_candidates:
+        max_attempts = 100
+        attempts = 0
+        while len(candidates) < n_candidates and attempts < max_attempts:
             result = mcts.run(verbose=verbose)
             candidate, sequence, score = tuple(result.values())
             if candidate not in candidates:
                 candidates[candidate] = (candidate, sequence, score.item())
+            attempts += 1
+        if len(candidates) < n_candidates:
+            raise ValueError("Could not generate enough unique candidates")
 
         if verbose:
             for candidate, sequence, score in candidates.values():


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #364

#### What does this implement/fix? Explain your changes.
This PR fixes a potential infinite loop in AptaTransPipeline.recommend() when duplicate candidates are repeatedly generated.

A max_attempts limit has been added to ensure the loop terminates safely. If the required number of unique candidates cannot be generated, a ValueError is raised.

#### What should a reviewer concentrate their feedback on?
- Correctness of the loop termination logic
- Whether max_attempts is an appropriate safeguard

#### Did you add any tests for the change?
No new tests were added.

#### Any other comments?
This implementation uses a max_attempts safeguard to prevent infinite loops.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].