### PR TITLE
[BUG] Fix typos in APIDataset docstring

### DIFF
--- a/pyaptamer/datasets/dataclasses/_api.py
+++ b/pyaptamer/datasets/dataclasses/_api.py
@@ -68,7 +68,7 @@ class APIDataset(Dataset):
     ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
         """
         Prepare the data by augmenting aptamer sequences with their reverse complements
-        and transforming them to vector numericla representations.
+        and transforming them to vector numerical representations.
 
         Parameters
         ----------
@@ -77,9 +77,9 @@ class APIDataset(Dataset):
         x_prot : np.ndarray
             Protein sequences.
         y : np.ndarray
-            Laabels for the interactions.
-        split : bool
-            If True, the dataset will augment aptamer sequences by adding their reverse
+            Labels for the interactions.
+        split : str
+            If "train", the dataset will augment aptamer sequences by adding their reverse
             complements.
         """
         if split == "train":


### PR DESCRIPTION

**Title:** `[DOC] Fix typos in APIDataset docstring`

---

### Reference Issues/PRs

Fixes #367

### What does this implement/fix? Explain your changes.

Fixes multiple typos and documentation errors in the `APIDataset._prepare_data` method docstring located in `pyaptamer/datasets/dataclasses/_api.py`. 

Specifically:
- Fixed `"numericla"` → `"numerical"`
- Fixed `"Laabels"` → `"Labels"`
- Fixed the `split` parameter type annotation from `bool` → `str`, and updated its description to reflect the `"train"` / `"test"` string values rather than `True` / `False`.

### Changes

**Files changed:** `pyaptamer/datasets/dataclasses/_api.py` (4 lines modified)

### Any other comments?

- Documentation-only change (no logic or test changes needed)
- Verified the docstring renders correctly with numpydoc format
- No new dependencies or breaking changes
