### PR TITLE
[DOC] Fix typo and duplicated phrase in MCTS class docstring

### DIFF
--- a/pyaptamer/mcts/_algorithm.py
+++ b/pyaptamer/mcts/_algorithm.py
@@ -11,8 +11,8 @@ from skbase.base import BaseObject
 
 class MCTS(BaseObject):
     """
-    MCTS algorithm implementation for string optimization, specifically for aptamr
-    generation as described in aptamer generation as described in [1]_, originally
+    MCTS algorithm implementation for string optimization, specifically for aptamer
+    generation as described in [1]_, originally
     introduced in [2]_.
 
     Adapted from:


### PR DESCRIPTION
**Title:** `[DOC] Fix typo and duplicated phrase in MCTS class docstring`

---

### Reference Issues/PRs

Fixes #369 

### What does this implement/fix? Explain your changes.

Fixes a typo and a confusing duplicated phrase in the `MCTS` class docstring located in `pyaptamer/mcts/_algorithm.py`.

Specifically:
- Fixed `"aptamr"` → `"aptamer"`
- Removed the accidental repetition in the sentence: `"generation as described in aptamer generation as described in [1]_"` → `"generation as described in [1]_"`

### Changes

**Files changed:** `pyaptamer/mcts/_algorithm.py` (2 lines modified)

### Any other comments?

- Documentation-only change (no logic or test changes needed)
- Verified the docstring renders correctly with numpydoc format
- No new dependencies or breaking changes
