### PR TITLE
fix: sklearn compat for validate_data import (issue #365)

### DIFF
--- a/pyaptamer/aptanet/_feature_classifier.py
+++ b/pyaptamer/aptanet/_feature_classifier.py
@@ -9,7 +9,11 @@ from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
 from sklearn.feature_selection import SelectFromModel
 from sklearn.pipeline import Pipeline
 from sklearn.utils.multiclass import type_of_target
-from sklearn.utils.validation import check_is_fitted, validate_data
+from sklearn.utils.validation import check_is_fitted
+try:
+    from sklearn.utils.validation import validate_data
+except ImportError:
+    from sklearn_compat.utils.validation import validate_data
 from torch import optim
 
 from pyaptamer.aptanet._aptanet_nn import AptaNetMLP

--- a/pyaptamer/aptanet/tests/test_aptanet.py
+++ b/pyaptamer/aptanet/tests/test_aptanet.py
@@ -81,3 +81,26 @@ def test_sklearn_compatible_estimator(estimator, check):
     Run scikit-learn's compatibility checks on the AptaNetClassifier.
     """
     check(estimator)
+
+
+def test_validate_data_importable():
+    """Regression test for issue #365.
+
+    ``validate_data`` was added as a standalone function only in scikit-learn
+    1.6. On older versions the module must fall back to ``sklearn_compat``.
+    If the compatibility shim is removed this import will raise ImportError
+    on sklearn < 1.6.
+    """
+    import importlib
+
+    import pyaptamer.aptanet._feature_classifier as mod
+
+    try:
+        importlib.reload(mod)
+    except ImportError as exc:
+        pytest.fail(
+            f"_feature_classifier failed to import (issue #365 regression): {exc}"
+        )
+
+    assert hasattr(mod, "AptaNetClassifier")
+    assert hasattr(mod, "AptaNetRegressor")


### PR DESCRIPTION
`validate_data` was introduced as a module-level function in scikit-learn 1.6,
but `pyproject.toml` declares support for `scikit-learn>=1.3.0,<1.8.0`, meaning
users on 1.3–1.5 cannot use the library at all.

## Fix

Added a `try/except` fallback in `_feature_classifier.py` that imports
`validate_data` from `sklearn_compat` when the sklearn version does not expose
it as a standalone function. `sklearn_compat` is already an indirect dependency
of the project (via `imbalanced-learn`).

## Changes

- `pyaptamer/aptanet/_feature_classifier.py` — replaced bare import with
  version-safe try/except shim
- `pyaptamer/aptanet/tests/test_aptanet.py` — added regression test
  `test_validate_data_importable` to guard against future regressions

## Testing

All 106 tests pass.