### PR TITLE
fix(rna2vec): always append padded sequence when all triplets are unknown

### DIFF
--- a/pyaptamer/utils/_rna.py
+++ b/pyaptamer/utils/_rna.py
@@ -151,24 +151,22 @@ def rna2vec(
             triplets.get(sequence[i : i + 3], 0) for i in range(len(sequence) - 2)
         ]
 
-        # skip sequences that convert to an empty list
-        if any(converted):
-            # truncate if too long
-            if max_sequence_length is not None and len(converted) > max_sequence_length:
-                converted = converted[:max_sequence_length]
+        # truncate if too long
+        if max_sequence_length is not None and len(converted) > max_sequence_length:
+            converted = converted[:max_sequence_length]
 
-            # pad if too short
-            if max_sequence_length is not None:
-                pad_length = max_sequence_length - len(converted)
-                padded_sequence = np.pad(
-                    array=converted,
-                    pad_width=(0, pad_length),
-                    constant_values=0,
-                )
-            else:
-                padded_sequence = np.array(converted)
+        # pad if too short
+        if max_sequence_length is not None:
+            pad_length = max_sequence_length - len(converted)
+            padded_sequence = np.pad(
+                array=converted,
+                pad_width=(0, pad_length),
+                constant_values=0,
+            )
+        else:
+            padded_sequence = np.array(converted)
 
-            result.append(padded_sequence)
+        result.append(padded_sequence)
 
     return np.array(result)
 


### PR DESCRIPTION
Fixes #372 
## Summary

Remove the if any(converted): guard in rna2vec which caused sequences with all-zero values to be dropped.

This ensures the output always preserves the same number of rows as the input.

**Before:**
```python
rna2vec(["NNN", "AAAC"], sequence_type="rna", max_sequence_length=4).shape
# (1, 4)  <- "NNN" was silently dropped
```

**After:**
```python
rna2vec(["NNN", "AAAC"], sequence_type="rna", max_sequence_length=4).shape
# (2, 4)  <- all-zero row for "NNN", correct row for "AAAC"
```