### PR TITLE
[BUG] fix: rna2vec preserves short sequences as zero rows (closes #363)

### DIFF
--- a/pyaptamer/aptanet/_feature_classifier.py
+++ b/pyaptamer/aptanet/_feature_classifier.py
@@ -9,7 +9,19 @@ from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
 from sklearn.feature_selection import SelectFromModel
 from sklearn.pipeline import Pipeline
 from sklearn.utils.multiclass import type_of_target
-from sklearn.utils.validation import check_is_fitted, validate_data
+from sklearn.utils.validation import check_is_fitted
+import sklearn
+from packaging.version import Version
+
+if Version(sklearn.__version__) >= Version("1.6"):
+    from sklearn.utils.validation import validate_data
+else:
+    from sklearn.utils.validation import check_array, check_X_y
+
+    def validate_data(estimator, X, y=None, **kwargs):
+        if y is not None:
+            return estimator._validate_data(X, y, **kwargs)
+        return estimator._validate_data(X, **kwargs)
 from torch import optim
 
 from pyaptamer.aptanet._aptanet_nn import AptaNetMLP

--- a/pyaptamer/utils/_rna.py
+++ b/pyaptamer/utils/_rna.py
@@ -152,23 +152,22 @@ def rna2vec(
         ]
 
         # skip sequences that convert to an empty list
-        if any(converted):
-            # truncate if too long
-            if max_sequence_length is not None and len(converted) > max_sequence_length:
-                converted = converted[:max_sequence_length]
+# truncate if too long
+        if max_sequence_length is not None and len(converted) > max_sequence_length:
+            converted = converted[:max_sequence_length]
 
-            # pad if too short
-            if max_sequence_length is not None:
-                pad_length = max_sequence_length - len(converted)
-                padded_sequence = np.pad(
-                    array=converted,
-                    pad_width=(0, pad_length),
-                    constant_values=0,
-                )
-            else:
-                padded_sequence = np.array(converted)
+        # pad if too short (including empty/short sequences which become all zeros)
+        if max_sequence_length is not None:
+            pad_length = max_sequence_length - len(converted)
+            padded_sequence = np.pad(
+                array=converted,
+                pad_width=(0, pad_length),
+                constant_values=0,
+            )
+        else:
+            padded_sequence = np.array(converted)
 
-            result.append(padded_sequence)
+        result.append(padded_sequence)
 
     return np.array(result)
 


### PR DESCRIPTION
<!--
Welcome to pyaptamer, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
Fixes #363

#### What does this implement/fix? Explain your changes.
Removed the `if any(converted):` guard in `rna2vec` that silently dropped 
sequences shorter than 3 characters. Short sequences now return a zero-padded 
row instead, preserving alignment between x_apta, x_prot, and y in APIDataset.

Before: rna2vec(["AAAA", "AA", "CCCC"], max_sequence_length=5) returned shape (2, 5)
After:  rna2vec(["AAAA", "AA", "CCCC"], max_sequence_length=5) returns shape (3, 5)

#### What should a reviewer concentrate their feedback on?
The removal of the `if any(converted):` block in _rna.py and the dedented 
truncate/pad logic that replaces it.

#### Did you add any tests for the change?
none

#### Any other comments?
<!--
We value all user contributions, no matter how small or complex they are. If you have any questions, feel free to post
in the dev-chat channel on the pyaptamer discord channel in gc-os server https://discord.gg/7uKdHfdcJG. If we are slow to review (>7 working days), likewise feel free to ping us on discord. Thank you for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

- [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
- [ ] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
  To run hooks independent of commit, execute `pre-commit run --all-files`

<!--
Thanks for contributing!
