### PR TITLE
[BUG] seq2vec silently drops unknown characters instead of mapping to index 0

### DIFF
--- a/pyaptamer/utils/_aptatrans_utils.py
+++ b/pyaptamer/utils/_aptatrans_utils.py
@@ -95,6 +95,16 @@ def seq2vec(
 
             # skip character if no match found
             if not matched:
+                output.append(0)
+                output_ss.append(0)
+
+                # if at `seq_max_len`, store and reset
+                if len(output) == seq_max_len:
+                    outputs.append(np.array(output))
+                    outputs_ss.append(np.array(output_ss))
+                    output = []
+                    output_ss = []
+
                 i += 1
 
         # add remaining output if not empty


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #381 
#### What does this implement/fix? Explain your changes.
Fixes a silent data corruption bug in `seq2vec` where unknown characters were completely dropped from sequences instead of being mapped to the `0` index token as documented. 

Changes implemented:
- Added `output.append(0)` and `output_ss.append(0)` inside the unmatched logic block.
- - Implemented the `seq_max_len` boundary check in the fallback block to ensure chunk resets are correctly maintained.
#### What should a reviewer concentrate their feedback on?
- N/A
#### Did you add any tests for the change?
- [ ] No - existing tests continue to pass. The fix is a specific logic adjustment inside the tokenizer.
#### Any other comments?
None.

#### PR checklist
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
- [ ] - [ ] Added/modified tests
- [ ] - [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks.