### PR TITLE
[DOC] fix encode_rna docstring: correct domain (RNA not protein) and grammar

### DIFF
--- a/pyaptamer/utils/_rna.py
+++ b/pyaptamer/utils/_rna.py
@@ -182,16 +182,16 @@ def encode_rna(
 ):
     """Encode RNA sequences into their numerical representations.
 
-    This function tokenizes protein sequences using a greedy longest-match approach,
-    where longer amino acid patterns are preferred over shorter ones. Sequences are
-    either trunacted or zero-padded to `max_len` tokens.
+    This function tokenizes RNA sequences using a greedy longest-match approach,
+    where longer nucleotide patterns are preferred over shorter ones. Sequences are
+    either truncated or zero-padded to `max_len` tokens.
 
     Parameters
     ----------
     sequences : list[str]
         List of RNA sequences to be encoded.
     words : dict[str, int]
-        A dictionary mappings RNA 3-mers to unique indices.
+        A dictionary mapping RNA k-mers to unique indices.
     max_len : int
         Maximum length of each encoded sequence. Sequences will be truncated
         or padded to this length.


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #383 
#### What does this implement/fix? Explain your changes.
Fixes two docstring errors in `encode_rna` in `pyaptamer/utils/_rna.py`:

1. **Wrong domain reference**: The summary incorrectly stated `"This function tokenizes protein sequences... where longer amino acid patterns are preferred"`. Corrected to `"RNA sequences"` and `"nucleotide patterns"` to accurately reflect the function's actual purpose.
2. 2. **Grammatical error**: Changed `"A dictionary mappings RNA 3-mers"` to `"A dictionary mapping RNA k-mers"`. Also fixed `"trunacted"` -> `"truncated"` in the same block.
#### What should a reviewer concentrate their feedback on?
The change is documentation-only -- no logic is modified.

#### Did you add any tests for the change?
- [ ] No -- documentation-only fix, no tests required.
#### Any other comments?
None.

#### PR checklist
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
- [ ] - [ ] Added/modified tests
- [ ] - [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks.