### PR TITLE
[BUG] Fix recommend() infinite loop when MCTS returns duplicate candidates

### DIFF
--- a/pyaptamer/aptatrans/_pipeline.py
+++ b/pyaptamer/aptatrans/_pipeline.py
@@ -6,6 +6,8 @@ candidate aptamers recommendation.
 __author__ = ["nennomp"]
 __all__ = ["AptaTransPipeline"]
 
+import warnings
+
 import torch
 from torch import Tensor
 
@@ -203,14 +205,16 @@ class AptaTransPipeline:
         self,
         target: str,
         n_candidates: int = 10,
+        max_attempts: int | None = None,
         verbose: bool = True,
     ) -> set[tuple[str, str, float]]:
         """Recommend aptamer candidates for a given target protein.
 
         The Monte Carlo Tree Search (MCTS) algorithm is used to generate candidate
         aptamers. Then, AptaTrans' deep neural network is used as a scoring function to
-        evaluate the candidates, inside the Aptamer() experiment. The process stop when
-        `n_candidates` unique candidates are generated.
+        evaluate the candidates, inside the Aptamer() experiment. The process stops when
+        `n_candidates` unique candidates are generated, or `max_attempts` MCTS runs have
+        been exhausted.
 
         Parameters
         ----------
@@ -218,6 +222,13 @@ class AptaTransPipeline:
             The target protein sequence.
         n_candidates : int, optional, default=10
             The number of candidate aptamers to generate.
+        max_attempts : int or None, optional, default=None
+            Maximum number of MCTS runs before stopping. Prevents an infinite loop when
+            the search space is degenerate and MCTS keeps returning duplicate candidates.
+            If None, defaults to ``max(100, 10 * n_candidates)``. If the limit is
+            reached before collecting ``n_candidates`` unique candidates, a
+            ``UserWarning`` is issued and the partial results collected so far are
+            returned.
         verbose : bool, optional, default=True
             If True, enables print statements for debugging and progress tracking.
 
@@ -227,6 +238,9 @@ class AptaTransPipeline:
             A set of tuples containing reconstructed and unrecontructed candidate
             aptamer sequence, and the corresponding score.
         """
+        if max_attempts is None:
+            max_attempts = max(100, 10 * n_candidates)
+
         experiment = self._init_aptamer_experiment(target)
 
         # initialize MCTS with the experiment
@@ -238,11 +252,23 @@ class AptaTransPipeline:
 
         # generate aptamer candidates
         candidates = {}
-        while len(candidates) < n_candidates:
+        attempts = 0
+        while len(candidates) < n_candidates and attempts < max_attempts:
             result = mcts.run(verbose=verbose)
             candidate, sequence, score = tuple(result.values())
             if candidate not in candidates:
                 candidates[candidate] = (candidate, sequence, score.item())
+            attempts += 1
+
+        if len(candidates) < n_candidates:
+            warnings.warn(
+                f"recommend() reached max_attempts={max_attempts} before collecting "
+                f"{n_candidates} unique candidates. "
+                f"Returning {len(candidates)} candidate(s). "
+                "Consider increasing max_attempts or n_iterations.",
+                UserWarning,
+                stacklevel=2,
+            )
 
         if verbose:
             for candidate, sequence, score in candidates.values():

--- a/pyaptamer/aptatrans/tests/test_aptatrans.py
+++ b/pyaptamer/aptatrans/tests/test_aptatrans.py
@@ -397,6 +397,79 @@ class TestAptaTransPipeline:
         assert isinstance(candidates, set)
         assert len(candidates) == n_candidates  # should be exactly n_candidates
 
+    def test_recommend_warns_on_duplicate_candidates(self, monkeypatch):
+        """recommend() should warn and return partial results when max_attempts is
+        exhausted due to duplicate candidates, instead of looping forever."""
+        device = torch.device("cpu")
+        model = MockAptaTransNeuralNet(device)
+        prot_words = {"AUG": 0.8, "GCA": 0.6, "UGC": 0.4, "CUA": 0.2}
+        pipeline = AptaTransPipeline(device=device, model=model, prot_words=prot_words)
+
+        monkeypatch.setattr(
+            "pyaptamer.aptatrans._pipeline.AptamerEvalAptaTrans",
+            lambda **kwargs: type(
+                "MockExp", (), {"evaluate": lambda self, c: torch.tensor(0.5)}
+            )(),
+        )
+
+        class MockMCTSDuplicates:
+            def __init__(self, **kwargs):
+                pass
+
+            def run(self, verbose=False):
+                return {
+                    "candidate": "AAAA",
+                    "sequence": "seq_aaaa",
+                    "score": torch.tensor(0.1),
+                }
+
+        monkeypatch.setattr("pyaptamer.aptatrans._pipeline.MCTS", MockMCTSDuplicates)
+
+        with pytest.warns(UserWarning, match="max_attempts=5"):
+            result = pipeline.recommend(
+                target="AUGCAUGC", n_candidates=3, max_attempts=5
+            )
+
+        # only 1 unique candidate despite requesting 3
+        assert isinstance(result, set)
+        assert len(result) == 1
+
+    def test_recommend_max_attempts_default_scales_with_n_candidates(self, monkeypatch):
+        """Default max_attempts should be max(100, 10 * n_candidates)."""
+        device = torch.device("cpu")
+        model = MockAptaTransNeuralNet(device)
+        prot_words = {"AUG": 0.8, "GCA": 0.6, "UGC": 0.4, "CUA": 0.2}
+        pipeline = AptaTransPipeline(device=device, model=model, prot_words=prot_words)
+
+        monkeypatch.setattr(
+            "pyaptamer.aptatrans._pipeline.AptamerEvalAptaTrans",
+            lambda **kwargs: type(
+                "MockExp", (), {"evaluate": lambda self, c: torch.tensor(0.5)}
+            )(),
+        )
+
+        call_count = {"n": 0}
+
+        class MockMCTSCounting:
+            def __init__(self, **kwargs):
+                pass
+
+            def run(self, verbose=False):
+                call_count["n"] += 1
+                return {
+                    "candidate": "AAAA",
+                    "sequence": "seq_aaaa",
+                    "score": torch.tensor(0.1),
+                }
+
+        monkeypatch.setattr("pyaptamer.aptatrans._pipeline.MCTS", MockMCTSCounting)
+
+        # n_candidates=5 → default max_attempts = max(100, 50) = 100
+        with pytest.warns(UserWarning):
+            pipeline.recommend(target="AUGCAUGC", n_candidates=5)
+
+        assert call_count["n"] == 100
+
     @pytest.mark.parametrize(
         "device, candidate, target",
         [


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #364

#### What does this implement/fix? Explain your changes.

`AptaTransPipeline.recommend()` had an unbounded `while` loop that would never terminate if MCTS kept returning duplicate candidates (e.g. degenerate model or small search space).

This PR adds a `max_attempts` parameter to bound the number of MCTS runs:

- **Default:** `max(100, 10 * n_candidates)` — scales automatically with the requested output size
- **On limit hit:** issues a `UserWarning` with a clear message and returns whatever unique candidates were collected so far (non-breaking — existing callers are unaffected unless they hit the limit)

```python
# example: degenerate case now terminates safely
candidates = pipeline.recommend(target, n_candidates=5, max_attempts=50)
# UserWarning: recommend() reached max_attempts=50 before collecting 5 unique candidates...
```

#### What should a reviewer concentrate their feedback on?
- Whether `UserWarning` is the right warning class, or if `RuntimeWarning` is preferred
- Whether the default `max(100, 10 * n_candidates)` multiplier is sensible
- Whether returning partial results is preferred over raising an exception

#### Did you add any tests for the change?
Yes, 2 new tests:
- `test_recommend_warns_on_duplicate_candidates` — verifies `UserWarning` is issued and partial results returned when all MCTS runs return the same candidate
- `test_recommend_max_attempts_default_scales_with_n_candidates` — verifies default `max_attempts` scales as `max(100, 10 * n_candidates)` and loop terminates at exactly that count

All 4 `recommend`-related tests pass (including the 2 pre-existing ones).

#### PR checklist
- [x] The PR title starts with [BUG]
- [x] Used pre-commit hooks