### PR TITLE
[DOC] fix typo "fro" → "for" in AptaTransLightning module docstring

### DIFF
--- a/pyaptamer/aptatrans/_model_lightning.py
+++ b/pyaptamer/aptatrans/_model_lightning.py
@@ -1,4 +1,4 @@
-"""AptaTrans' deep neural network wrapper fro Lightning."""
+"""AptaTrans' deep neural network wrapper for Lightning."""
 
 __author__ = ["nennomp"]
 __all__ = ["AptaTransLightning", "AptaTransEncoderLightning"]


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #390 
#### What does this implement/fix? Explain your changes.
Corrects a single-character typo in the module-level docstring of `pyaptamer/aptatrans/_model_lightning.py` (line 1): `"fro"` → `"for"`.

#### What should a reviewer concentrate their feedback on?
Documentation-only change — no logic is modified.

#### Did you add any tests for the change?
- [ ] No — documentation-only fix, no tests required.

#### Any other comments?
None.

#### PR checklist
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks.
