### PR TITLE
[DOC] Complete unfilled placeholder in MoleculeLoader docstring

### DIFF
--- a/pyaptamer/data/loader.py
+++ b/pyaptamer/data/loader.py
@@ -16,7 +16,10 @@ class MoleculeLoader:
     ------------
     path : str, Path, or list thereof
         file location or list of file locations with molecule files
-        str can be any of the following... [fill in]
+        str can be any of the following:
+            - an absolute path, e.g. "/home/user/data/1gnh.pdb"
+            - a relative path, e.g. "../data/1brq.pdb"
+            - any string convertible to a Path object
 
         the following formats are currently supported:
 

--- a/pyaptamer/data/loader.py
+++ b/pyaptamer/data/loader.py
@@ -17,9 +17,9 @@ class MoleculeLoader:
     path : str, Path, or list thereof
         file location or list of file locations with molecule files
         str can be any of the following:
-            - an absolute path, e.g. "/home/user/data/1gnh.pdb"
-            - a relative path, e.g. "../data/1brq.pdb"
-            - any string convertible to a Path object
+            - an absolute path : ``"/home/user/data/1gnh.pdb"``
+            - a relative path  : ``"../data/1brq.pdb"``
+            - any string convertible to a ``pathlib.Path`` object
 
         the following formats are currently supported:
 


### PR DESCRIPTION
<!--
Welcome to pyaptamer, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs

Fixes #392 


#### What does this implement/fix? Explain your changes.
Completes the unfilled placeholder in the `MoleculeLoader` docstring in `pyaptamer/data/loader.py` by:
- Adding two concrete examples of string paths
- Adding clarification of rule that str paths must follow

#### Did you add any tests for the change?
No ,documentation-only change.

#### Any other comments?
-Documentation-only change (no logic or test changes needed).
-No new dependencies

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
- [ ] Added/modified tests
- [ ] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
  To run hooks independent of commit, execute `pre-commit run --all-files`

