### PR TITLE
[BUG] fix load_from_rcsb to return MoleculeLoader instead of raw Structure

### DIFF
--- a/pyaptamer/datasets/_loaders/_online_databank.py
+++ b/pyaptamer/datasets/_loaders/_online_databank.py
@@ -8,7 +8,8 @@ from Bio.PDB import PDBList
 
 def load_from_rcsb(pdb_id, overwrite=False):
     """
-    Download a PDB file from the RCSB Protein Data Bank and parse it into a `MoleculeLoader`.
+    Download a PDB file from the RCSB Protein Data Bank
+    and parse it into a `MoleculeLoader`.
     Files are created in the current working directory.
 
     Parameters

--- a/pyaptamer/datasets/_loaders/_online_databank.py
+++ b/pyaptamer/datasets/_loaders/_online_databank.py
@@ -8,8 +8,7 @@ from Bio.PDB import PDBList
 
 def load_from_rcsb(pdb_id, overwrite=False):
     """
-    Download a PDB file from the RCSB Protein Data Bank and return it as a
-    `MoleculeLoader` for use with `.to_df_seq()` and other APIs.
+    Download a PDB file from the RCSB Protein Data Bank and parse it into a `MoleculeLoader`.
     Files are created in the current working directory.
 
     Parameters
@@ -21,7 +20,7 @@ def load_from_rcsb(pdb_id, overwrite=False):
         If True, overwrite existing files. Default is False.
     Returns
     -------
-    mol : MoleculeLoader
+    MoleculeLoader
         A `MoleculeLoader` object for the downloaded structure.
     """
     from pyaptamer.data.loader import MoleculeLoader

--- a/pyaptamer/datasets/_loaders/_online_databank.py
+++ b/pyaptamer/datasets/_loaders/_online_databank.py
@@ -1,16 +1,15 @@
 __author__ = "satvshr"
 __all__ = ["load_from_rcsb"]
 
-from pathlib import Path
+import os
 
 from Bio.PDB import PDBList
-
-from pyaptamer.data.loader import MoleculeLoader
 
 
 def load_from_rcsb(pdb_id, overwrite=False):
     """
-    Download a PDB file from the RCSB Protein Data Bank and load it as a MoleculeLoader.
+    Download a PDB file from the RCSB Protein Data Bank and return it as a
+    `MoleculeLoader` for use with `.to_df_seq()` and other APIs.
     Files are created in the current working directory.
 
     Parameters
@@ -22,19 +21,23 @@ def load_from_rcsb(pdb_id, overwrite=False):
         If True, overwrite existing files. Default is False.
     Returns
     -------
-    loader : MoleculeLoader
-        A MoleculeLoader object representing the downloaded molecule.
+    mol : MoleculeLoader
+        A `MoleculeLoader` object for the downloaded structure.
     """
+    from pyaptamer.data.loader import MoleculeLoader
+
     pdbl = PDBList()
-    pdb_file_path = Path(
-        pdbl.retrieve_pdb_file(pdb_id, file_format="pdb", overwrite=overwrite)
+    pdb_file_path = pdbl.retrieve_pdb_file(
+        pdb_id, file_format="pdb", overwrite=overwrite
     )
 
     # BioPython saves PDB files with .ent extension; rename to .pdb
     # so MoleculeLoader can recognize the file type
-    if pdb_file_path.suffix == ".ent":
-        pdb_path = pdb_file_path.with_suffix(".pdb")
-        pdb_file_path.replace(pdb_path)
+    root, ext = os.path.splitext(pdb_file_path)
+    if ext == ".ent":
+        pdb_path = root + ".pdb"
+        if overwrite or not os.path.exists(pdb_path):
+            os.rename(pdb_file_path, pdb_path)
         pdb_file_path = pdb_path
 
     return MoleculeLoader(pdb_file_path)

--- a/pyaptamer/datasets/_loaders/_online_databank.py
+++ b/pyaptamer/datasets/_loaders/_online_databank.py
@@ -1,14 +1,16 @@
 __author__ = "satvshr"
 __all__ = ["load_from_rcsb"]
 
+from pathlib import Path
+
 from Bio.PDB import PDBList
 
-from pyaptamer.utils import pdb_to_struct
+from pyaptamer.data.loader import MoleculeLoader
 
 
 def load_from_rcsb(pdb_id, overwrite=False):
     """
-    Download a PDB file from the RCSB Protein Data Bank and parse it into a `Structure`.
+    Download a PDB file from the RCSB Protein Data Bank and load it as a MoleculeLoader.
     Files are created in the current working directory.
 
     Parameters
@@ -20,14 +22,19 @@ def load_from_rcsb(pdb_id, overwrite=False):
         If True, overwrite existing files. Default is False.
     Returns
     -------
-    structure : Bio.PDB.Structure.Structure
-        A Biopython Structure object.
+    loader : MoleculeLoader
+        A MoleculeLoader object representing the downloaded molecule.
     """
     pdbl = PDBList()
-    pdb_file_path = pdbl.retrieve_pdb_file(
-        pdb_id, file_format="pdb", overwrite=overwrite
+    pdb_file_path = Path(
+        pdbl.retrieve_pdb_file(pdb_id, file_format="pdb", overwrite=overwrite)
     )
 
-    structure = pdb_to_struct(pdb_file_path)
+    # BioPython saves PDB files with .ent extension; rename to .pdb
+    # so MoleculeLoader can recognize the file type
+    if pdb_file_path.suffix == ".ent":
+        pdb_path = pdb_file_path.with_suffix(".pdb")
+        pdb_file_path.replace(pdb_path)
+        pdb_file_path = pdb_path
 
-    return structure
+    return MoleculeLoader(pdb_file_path)

--- a/pyaptamer/datasets/tests/test_online_loader.py
+++ b/pyaptamer/datasets/tests/test_online_loader.py
@@ -20,9 +20,7 @@ def test_download_structure(pdb_id):
     )
 
     # Ensure the pdb file was downloaded to the expected path
-    assert os.path.exists(loader.path), (
-        f"PDB file not found at {loader.path}"
-    )
+    assert os.path.exists(loader.path), f"PDB file not found at {loader.path}"
 
     df_seq = loader.to_df_seq()
     assert not df_seq.empty, "Expected to_df_seq() to return a non-empty DataFrame"

--- a/pyaptamer/datasets/tests/test_online_loader.py
+++ b/pyaptamer/datasets/tests/test_online_loader.py
@@ -1,8 +1,8 @@
 __author__ = "satvshr"
 
 import pytest
-from Bio.PDB.Structure import Structure
 
+from pyaptamer.data.loader import MoleculeLoader
 from pyaptamer.datasets import load_from_rcsb
 
 
@@ -12,7 +12,7 @@ def test_download_structure(pdb_id):
     The download_structure function works correctly
     for valid PDB IDs.
     """
-    structure = load_from_rcsb(pdb_id)
-    assert isinstance(structure, Structure), (
-        f"Expected a Bio.PDB.Structure.Structure, got {type(structure)}"
+    loader = load_from_rcsb(pdb_id)
+    assert isinstance(loader, MoleculeLoader), (
+        f"Expected a MoleculeLoader, got {type(loader)}"
     )

--- a/pyaptamer/datasets/tests/test_online_loader.py
+++ b/pyaptamer/datasets/tests/test_online_loader.py
@@ -16,3 +16,6 @@ def test_download_structure(pdb_id):
     assert isinstance(loader, MoleculeLoader), (
         f"Expected a MoleculeLoader, got {type(loader)}"
     )
+
+    df_seq = loader.to_df_seq()
+    assert not df_seq.empty, "Expected to_df_seq() to return a non-empty DataFrame"

--- a/pyaptamer/datasets/tests/test_online_loader.py
+++ b/pyaptamer/datasets/tests/test_online_loader.py
@@ -1,5 +1,7 @@
 __author__ = "satvshr"
 
+import os
+
 import pytest
 
 from pyaptamer.data.loader import MoleculeLoader
@@ -15,6 +17,11 @@ def test_download_structure(pdb_id):
     loader = load_from_rcsb(pdb_id)
     assert isinstance(loader, MoleculeLoader), (
         f"Expected a MoleculeLoader, got {type(loader)}"
+    )
+
+    # Ensure the pdb file was downloaded to the expected path
+    assert os.path.exists(loader.path), (
+        f"PDB file not found at {loader.path}"
     )
 
     df_seq = loader.to_df_seq()


### PR DESCRIPTION
**Reference Issues/PRs**
#393

**What does this implement/fix? Explain your changes.**
`load_from_rcsb()` was returning a raw BioPython `Structure` object while every other loader (`load_1gnh`, `load_1brq`, `load_5nu7`, `load_pfoa`) returns `MoleculeLoader`. This meant you couldn't call `.to_df_seq()` on proteins loaded from RCSB. Changed it to return `MoleculeLoader` like the rest. Also handles the `.ent` to `.pdb` rename since BioPython downloads with `.ent` extension.

**What should a reviewer concentrate their feedback on?**
The `.ent` to `.pdb` rename — open to a better approach if there is one.

**Did you add any tests for the change?**
Updated `test_online_loader.py` to check for `MoleculeLoader` instead of `Structure`.

**Any other comments?**
None

- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.