### PR TITLE
[BUG] Fix duplicated words in AptaTrans docstring and comment

### DIFF
--- a/pyaptamer/aptatrans/_model.py
+++ b/pyaptamer/aptatrans/_model.py
@@ -220,7 +220,7 @@ class AptaTrans(nn.Module):
 
         encoder_module = nn.ModuleList([embedding, pos_encoding, encoder])
 
-        # pass the the encoder a padding mask to ignore zero-padded tokens
+        # pass the encoder a padding mask to ignore zero-padded tokens
         encoder_module.forward = lambda x: encoder(
             pos_encoding(embedding(x)),
             src_key_padding_mask=(x == 0),  # padding mask

--- a/pyaptamer/aptatrans/_pipeline.py
+++ b/pyaptamer/aptatrans/_pipeline.py
@@ -1,5 +1,5 @@
 """
-AptaTrans' complete pipeline for for aptamer-protein interaction prediction and
+AptaTrans' complete pipeline for aptamer-protein interaction prediction and
 candidate aptamers recommendation.
 """
 


### PR DESCRIPTION


#### Reference Issues/PRs

Fixes #397 

Follows the same pattern as the previously merged MCTS docstring cleanup (commit `70e63e6`).

#### What does this implement/fix? Explain your changes.

Removes two stray word duplications in `pyaptamer/aptatrans/`:

| File | Line | Before | After |
| --- | --- | --- | --- |
| `pyaptamer/aptatrans/_pipeline.py` | 2 | `AptaTrans' complete pipeline for for aptamer-protein interaction prediction and` | `AptaTrans' complete pipeline for aptamer-protein interaction prediction and` |
| `pyaptamer/aptatrans/_model.py` | 223 | `# pass the the encoder a padding mask to ignore zero-padded tokens` | `# pass the encoder a padding mask to ignore zero-padded tokens` |

Both changes are text-only (one word deletion each). There is no behavioural, API, or import change.

A repo-wide scan for common duplicated-word patterns (`for for`, `the the`, `and and`, `of of`, `in in`, `to to`, `is is`, `with with`, `that that`, `as as`) confirmed these are the only remaining occurrences under `pyaptamer/`.

#### What should a reviewer concentrate their feedback on?

- That the rewording still reads correctly in context (no semantic change intended).
- Whether the reviewer would prefer this split into two PRs (one per file). I bundled them because the scope is identical and the combined diff is two lines.

#### Did you add any tests for the change?

No tests added. The changes are in a module docstring and an inline comment; there is no runtime behaviour to assert. This follows the precedent of commit `70e63e6` (MCTS docstring fix), which was merged without tests for the same reason.

#### Any other comments?

Diff summary:

```
 pyaptamer/aptatrans/_model.py    | 2 +-
 pyaptamer/aptatrans/_pipeline.py | 2 +-
 2 files changed, 2 insertions(+), 2 deletions(-)
```

#### PR checklist

- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
- [ ] Added/modified tests — not applicable; docstring/comment-only change.
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. `pre-commit run --files pyaptamer/aptatrans/_pipeline.py pyaptamer/aptatrans/_model.py` passes (ruff-format, ruff, mixed-line-ending).
