### PR TITLE
[BUG] Fix dna2rna docstring parameter name mismatch

### DIFF
--- a/pyaptamer/utils/_rna.py
+++ b/pyaptamer/utils/_rna.py
@@ -22,7 +22,7 @@ def dna2rna(sequence: str) -> str:
 
     Parameters
     ----------
-    seq : str
+    sequence : str
         The DNA sequence to be converted.
 
     Returns


### PR DESCRIPTION




Fixes #400 

#### What does this implement/fix? Explain your changes.

The `dna2rna` function in `pyaptamer/utils/_rna.py` had a parameter-name mismatch between its signature and its NumPy-style docstring:

| Location | Before | After |
| --- | --- | --- |
| `_rna.py:15` (signature) | `def dna2rna(sequence: str) -> str:` | *(unchanged)* |
| `_rna.py:25` (docstring) | `seq : str` | `sequence : str` |

This is a one-line docstring edit. No behavioural, API, or import changes.

Why it matters:

- IDE hover hints and NumPy-style doc parsers (Sphinx / numpydoc) rely on the name in the `Parameters` section matching the argument. Before this fix, `sequence` was effectively undocumented and `seq` pointed to nothing.
- Brings `dna2rna` in line with sibling functions in the same module (`rna2vec`, `encode_rna`, `generate_nplets`), which all use docstring names matching their signatures.

#### What should a reviewer concentrate their feedback on?

- Whether to match by renaming the *argument* to `seq` instead (less consistent with sibling functions; would also be a public API change, so I opted to fix the docstring).
- An AST-based sweep of the whole `pyaptamer/` package confirmed this is the only genuine docstring/signature parameter-name mismatch. Other apparent mismatches flagged by a naive regex were false positives (e.g. `structure` under `Returns` sections).

#### Did you add any tests for the change?

No tests added — the change is in a docstring, no runtime behaviour to assert. Existing tests continue to pass:

```
pyaptamer/utils/tests/ ... 30 passed in 4.54s
```

#### Any other comments?

Diff summary:

```
 pyaptamer/utils/_rna.py | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

Follow-up observation (not part of this PR): `encode_rna` in the same file has a separate content issue — its description mentions "protein sequences" and "amino acid patterns" although the function operates on RNA. Happy to open a follow-up PR for that if desired.

#### PR checklist

- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
- [ ] Added/modified tests — not applicable; docstring-only change.
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. `pre-commit run --files pyaptamer/utils/_rna.py` passes (ruff-format, ruff, mixed-line-ending).
