### PR TITLE
[BUG] Fix _load_1gnh_structure ignoring the pdb_path parameter

### DIFF
--- a/pyaptamer/datasets/_loaders/_1gnh.py
+++ b/pyaptamer/datasets/_loaders/_1gnh.py
@@ -37,7 +37,8 @@ def _load_1gnh_structure(pdb_path=None):
     """
     from Bio.PDB import PDBParser
 
-    pdb_path = os.path.join(os.path.dirname(__file__), "..", "data", "1gnh.pdb")
+    if pdb_path is None:
+        pdb_path = os.path.join(os.path.dirname(__file__), "..", "data", "1gnh.pdb")
 
     parser = PDBParser(QUIET=True)
     structure = parser.get_structure("1gnh", pdb_path)

--- a/pyaptamer/utils/tests/test_struct_to_aaseq.py
+++ b/pyaptamer/utils/tests/test_struct_to_aaseq.py
@@ -1,6 +1,9 @@
 __author__ = "satvshr"
 
+import os
+
 import pandas as pd
+import pytest
 
 from pyaptamer.datasets._loaders._1gnh import _load_1gnh_structure
 from pyaptamer.utils._struct_to_aaseq import struct_to_aaseq
@@ -43,3 +46,31 @@ def test_struct_to_aaseq():
     assert seq_list == df["sequence"].tolist(), (
         "List sequences must match DataFrame 'sequence' column"
     )
+
+
+def test_load_1gnh_structure_with_explicit_path():
+    """Test that _load_1gnh_structure uses a caller-supplied pdb_path.
+
+    Before the fix, the pdb_path argument was silently overwritten by a
+    hardcoded default, so a wrong path would never raise an error. After the
+    fix, passing a non-existent path must propagate an exception, proving that
+    the argument is actually forwarded to the parser.
+    """
+    bad_path = os.path.join(os.path.dirname(__file__), "nonexistent_file.pdb")
+    with pytest.raises(FileNotFoundError):
+        _load_1gnh_structure(pdb_path=bad_path)
+
+
+def test_load_1gnh_structure_default_path_unchanged():
+    """Test that _load_1gnh_structure still works correctly with default pdb_path.
+
+    Calling without arguments must continue to load the bundled 1gnh.pdb file
+    and return a valid Biopython Structure object.
+    """
+    from Bio.PDB.Structure import Structure
+
+    structure = _load_1gnh_structure()
+    assert isinstance(structure, Structure), (
+        "Default call should return a Biopython Structure"
+    )
+    assert structure.get_id() == "1gnh", "Structure ID should be '1gnh'"


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #404.

#### What does this implement/fix? Explain your changes.

`_load_1gnh_structure(pdb_path=None)` in `pyaptamer/datasets/_loaders/_1gnh.py` accepted a `pdb_path` argument but unconditionally overwrote it on the next line with the hardcoded default path:

```python
# Before (buggy): always overwrites the argument
pdb_path = os.path.join(os.path.dirname(__file__), "..", "data", "1gnh.pdb")
```

Any caller-supplied path was silently ignored — even a non-existent path raised no error, because the function never used the parameter.

The fix wraps the default assignment in an `if pdb_path is None` guard:

```python
# After (fixed): only falls back when no path is given
if pdb_path is None:
    pdb_path = os.path.join(os.path.dirname(__file__), "..", "data", "1gnh.pdb")
```

#### What should a reviewer concentrate their feedback on?

- The one-line guard in `_1gnh.py` is the entire functional change.
- The two new tests in `test_struct_to_aaseq.py` verify both the fix
  (bad path → `FileNotFoundError`) and the regression guard (default
  path still works).

#### Did you add any tests for the change?

Yes — two tests were added to `pyaptamer/utils/tests/test_struct_to_aaseq.py`:

- `test_load_1gnh_structure_with_explicit_path`: supplies a non-existent
  path and asserts `FileNotFoundError` is raised, proving the argument is
  forwarded to the parser.
- `test_load_1gnh_structure_default_path_unchanged`: calls without
  arguments and verifies the bundled `1gnh.pdb` is still loaded correctly.

All three tests in the file pass locally.

#### Any other comments?

A previous attempt at this fix (PR #357) was abandoned without being merged. This PR provides the same minimal one-line change with added test coverage.

#### PR checklist

- [x] The PR title starts with [BUG]
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks.