### PR TITLE
[FIX] Add input validation to pairs_to_features

### DIFF
--- a/pyaptamer/utils/__init__.py
+++ b/pyaptamer/utils/__init__.py
@@ -5,6 +5,7 @@ __all__ = [
     "dna2rna",
     "encode_rna",
     "generate_nplets",
+    "compute_protein_words",
     "rna2vec",
     "pdb_to_struct",
     "struct_to_aaseq",
@@ -16,6 +17,7 @@ from pyaptamer.utils._aa_str_to_letter import aa_str_to_letter
 from pyaptamer.utils._pdb_to_aaseq import pdb_to_aaseq
 from pyaptamer.utils._pdb_to_seq_uniprot import pdb_to_seq_uniprot
 from pyaptamer.utils._pdb_to_struct import pdb_to_struct
+from pyaptamer.utils._protein_words import compute_protein_words
 from pyaptamer.utils._rna import (
     dna2rna,
     encode_rna,

--- a/pyaptamer/utils/_aptanet_utils.py
+++ b/pyaptamer/utils/_aptanet_utils.py
@@ -59,8 +59,10 @@ def generate_kmer_vecs(aptamer_sequence, k=4):
 
 def pairs_to_features(X, k=4):
     """
-    Convert a list of (aptamer_sequence, protein_sequence) pairs into feature vectors.
-    Also supports a pandas DataFrame with 'aptamer' and 'protein' columns.
+    Convert aptamer-protein pairs into concatenated numeric feature vectors.
+
+    Accepts either an iterable of ``(aptamer_sequence, protein_sequence)`` pairs
+    or a pandas DataFrame with ``aptamer`` and ``protein`` columns.
 
     This function generates feature vectors for each (aptamer, protein) pair using:
 
@@ -69,9 +71,9 @@ def pairs_to_features(X, k=4):
 
     Parameters
     ----------
-    X : list of tuple of str or pandas.DataFrame
-        A list where each element is a tuple `(aptamer_sequence, protein_sequence)`,
-        or a DataFrame containing 'aptamer' and 'protein' columns.
+    X : iterable of tuple[str, str] or pandas.DataFrame
+        Sequence pairs as ``(aptamer, protein)`` tuples, or a DataFrame containing
+        ``aptamer`` and ``protein`` columns.
 
     k : int, optional
         The k-mer size used to generate the k-mer vector from the aptamer sequence.
@@ -82,18 +84,49 @@ def pairs_to_features(X, k=4):
     np.ndarray
         A 2D NumPy array where each row corresponds to the concatenated feature vector
         for a given (aptamer, protein) pair.
+
+    Raises
+    ------
+    ValueError
+        If input is empty, DataFrame columns are missing, pair structure is invalid,
+        sequence entries are not strings, or sequences are empty.
+
+    Notes
+    -----
+    Aptamer and protein sequences are normalized to uppercase before feature
+    extraction.
     """
     pseaac = AptaNetPSeAAC()
     feats = []
 
     if isinstance(X, pd.DataFrame):
-        pairs = zip(X["aptamer"], X["protein"], strict=False)
+        if "aptamer" not in X.columns or "protein" not in X.columns:
+            raise ValueError("DataFrame must contain 'aptamer' and 'protein'")
+        pairs = list(zip(X["aptamer"], X["protein"]))
     else:
-        pairs = X
+        pairs = list(X)
 
-    for aptamer_seq, protein_seq in pairs:
+    if not pairs:
+        raise ValueError("Empty input")
+
+    for pair in pairs:
+        if not isinstance(pair, (list, tuple)) or len(pair) != 2:
+            raise ValueError("Each element must be (aptamer, protein)")
+
+        aptamer_seq, protein_seq = pair
+
+        if not isinstance(aptamer_seq, str) or not isinstance(protein_seq, str):
+            raise ValueError("Sequences must be strings")
+
+        if not aptamer_seq or not protein_seq:
+            raise ValueError("Sequences cannot be empty")
+
+        aptamer_seq = aptamer_seq.upper()
+        protein_seq = protein_seq.upper()
+
         kmer = generate_kmer_vecs(aptamer_seq, k=k)
         pseaac_vec = np.asarray(pseaac.transform(protein_seq))
+
         feats.append(np.concatenate([kmer, pseaac_vec]))
 
     # Ensure float32 for PyTorch compatibility

--- a/pyaptamer/utils/_aptanet_utils.py
+++ b/pyaptamer/utils/_aptanet_utils.py
@@ -102,7 +102,7 @@ def pairs_to_features(X, k=4):
     if isinstance(X, pd.DataFrame):
         if "aptamer" not in X.columns or "protein" not in X.columns:
             raise ValueError("DataFrame must contain 'aptamer' and 'protein'")
-        pairs = list(zip(X["aptamer"], X["protein"]))
+        pairs = list(zip(X["aptamer"], X["protein"], strict=False))
     else:
         pairs = list(X)
 
@@ -110,7 +110,7 @@ def pairs_to_features(X, k=4):
         raise ValueError("Empty input")
 
     for pair in pairs:
-        if not isinstance(pair, (list, tuple)) or len(pair) != 2:
+        if not isinstance(pair, (list | tuple)) or len(pair) != 2:
             raise ValueError("Each element must be (aptamer, protein)")
 
         aptamer_seq, protein_seq = pair

--- a/pyaptamer/utils/_protein_words.py
+++ b/pyaptamer/utils/_protein_words.py
@@ -1,4 +1,3 @@
-
 """Protein word extraction utilities.
 
 Core behavior mirrors the AptaTrans vocabulary pre-processing pattern:
@@ -8,7 +7,9 @@ Core behavior mirrors the AptaTrans vocabulary pre-processing pattern:
 """
 
 from collections import Counter
+
 from pyaptamer.utils._base import filter_words
+
 
 def compute_protein_words(
     protein_sequences,

--- a/pyaptamer/utils/_protein_words.py
+++ b/pyaptamer/utils/_protein_words.py
@@ -1,0 +1,75 @@
+
+"""Protein word extraction utilities.
+
+Core behavior mirrors the AptaTrans vocabulary pre-processing pattern:
+1) collect overlapping substrings for k in [min_k, max_k],
+2) optionally keep only above-average-frequency words,
+3) map surviving words to compact integer ids via ``filter_words``.
+"""
+
+from collections import Counter
+from pyaptamer.utils._base import filter_words
+
+def compute_protein_words(
+    protein_sequences,
+    min_k: int = 1,
+    max_k: int = 3,
+    apply_frequency_filter: bool = True,
+):
+    """Build a protein-word vocabulary from raw sequences.
+
+    Parameters
+    ----------
+    protein_sequences : iterable[str]
+        Protein sequences.
+    min_k : int, optional, default=1
+        Minimum word length.
+    max_k : int, optional, default=3
+        Maximum word length.
+    apply_frequency_filter : bool, optional, default=True
+        If True, keeps only words with frequency above the mean and renumbers
+        the surviving words into consecutive integer ids.
+
+    Returns
+    -------
+    dict
+        If ``apply_frequency_filter`` is True, returns only the words whose
+        frequency is above the average frequency, mapped to integer ids.
+        The original frequencies are discarded for the filtered output.
+        Otherwise, returns raw counts as ``dict[str, int]`` (word -> frequency).
+
+    Notes
+    -----
+    The returned id mapping is stable with respect to insertion order of
+    counted words (Python 3.7+ dict ordering), after applying the mean filter.
+    """
+    if min_k < 1 or max_k < min_k:
+        raise ValueError("Expected 1 <= min_k <= max_k.")
+
+    word_counts = Counter()
+
+    for seq in protein_sequences:
+        # Be permissive with upstream inputs: ignore missing entries.
+        if seq is None:
+            continue
+
+        # Normalize simple formatting noise and case before counting words.
+        sequence = str(seq).strip().upper()
+        if not sequence:
+            continue
+
+        seq_len = len(sequence)
+        for k in range(min_k, max_k + 1):
+            # No k-mer can be extracted when sequence is shorter than k.
+            if seq_len < k:
+                continue
+
+            # Overlapping substrings, e.g. MKLAVT -> MKL, KLA, LAV, AVT for k=3.
+            for start in range(seq_len - k + 1):
+                word_counts[sequence[start : start + k]] += 1
+
+    if not apply_frequency_filter:
+        return dict(word_counts)
+
+    # filter_words expects frequency values and returns word->id mapping.
+    return filter_words({word: float(freq) for word, freq in word_counts.items()})

--- a/pyaptamer/utils/tests/test_protein_words.py
+++ b/pyaptamer/utils/tests/test_protein_words.py
@@ -1,0 +1,111 @@
+"""Pytest coverage for protein word extraction utilities."""
+
+import pytest
+
+from pyaptamer.utils import compute_protein_words
+from pyaptamer.utils._protein_words import compute_protein_words as module_compute_protein_words
+
+# Run each test against both import surfaces:
+# - public package API (`pyaptamer.utils`)
+# - direct module API (`pyaptamer.utils.protein_words`)
+
+
+@pytest.mark.parametrize("func", [compute_protein_words, module_compute_protein_words])
+def test_public_and_module_imports_work(func):
+    """The helper should be available from both public and module import paths."""
+    result = func(["MKL"], min_k=1, max_k=3, apply_frequency_filter=False)
+
+    assert result == {
+        "M": 1,
+        "K": 1,
+        "L": 1,
+        "MK": 1,
+        "KL": 1,
+        "MKL": 1,
+    }
+
+
+@pytest.mark.parametrize("func", [compute_protein_words, module_compute_protein_words])
+def test_overlapping_k3_windows(func):
+    """k=3 must use overlapping windows, not chunked windows."""
+    result = func(["MKLAVT"], min_k=3, max_k=3, apply_frequency_filter=False)
+
+    assert result == {"MKL": 1, "KLA": 1, "LAV": 1, "AVT": 1}
+
+
+@pytest.mark.parametrize("func", [compute_protein_words, module_compute_protein_words])
+def test_mixed_k_1_to_3_uses_all_overlapping_substrings(func):
+    """k=1..3 should include all overlapping substrings up to length 3."""
+    result = func(["MKL"], min_k=1, max_k=3, apply_frequency_filter=False)
+
+    assert result == {
+        "M": 1,
+        "K": 1,
+        "L": 1,
+        "MK": 1,
+        "KL": 1,
+        "MKL": 1,
+    }
+
+
+@pytest.mark.parametrize("func", [compute_protein_words, module_compute_protein_words])
+def test_frequency_filter_removes_below_average_words_and_renumbers(func):
+    """Filtering should discard below-average words and renumber survivors."""
+    result = func(["AAAB"], min_k=1, max_k=1, apply_frequency_filter=True)
+
+    assert result == {"A": 1}
+    # Filtered output is an id mapping, not raw frequencies.
+    assert all(isinstance(value, int) for value in result.values())
+
+
+@pytest.mark.parametrize("func", [compute_protein_words, module_compute_protein_words])
+def test_frequency_filter_with_all_equal_frequencies_returns_empty(func):
+    """Strictly above-average filtering should drop words tied at the mean."""
+    result = func(["AB"], min_k=1, max_k=1, apply_frequency_filter=True)
+
+    assert result == {}
+
+
+@pytest.mark.parametrize("func", [compute_protein_words, module_compute_protein_words])
+def test_skips_empty_none_and_whitespace_inputs(func):
+    """None and blank entries should be ignored without errors."""
+    result = func([None, "", "   ", " mk "], min_k=1, max_k=1, apply_frequency_filter=False)
+
+    assert result == {"M": 1, "K": 1}
+
+
+@pytest.mark.parametrize("func", [compute_protein_words, module_compute_protein_words])
+def test_accepts_any_iterable_of_sequences(func):
+    """The input can be any iterable, not just a list."""
+    sequences = (seq for seq in ["AAA", "AAB"])
+    result = func(sequences, min_k=1, max_k=1, apply_frequency_filter=False)
+
+    assert result == {"A": 5, "B": 1}
+
+
+@pytest.mark.parametrize(
+    "min_k,max_k",
+    [(0, 3), (2, 1), (-1, 2)],
+)
+@pytest.mark.parametrize("func", [compute_protein_words, module_compute_protein_words])
+def test_invalid_k_bounds_raise_value_error(func, min_k, max_k):
+    """Invalid k bounds should fail fast."""
+    with pytest.raises(ValueError, match="Expected 1 <= min_k <= max_k"):
+        func(["MKL"], min_k=min_k, max_k=max_k)
+
+
+@pytest.mark.parametrize("func", [compute_protein_words, module_compute_protein_words])
+def test_sequences_shorter_than_k_are_skipped(func):
+    """Sequences shorter than k should contribute nothing."""
+    result = func(["AA", "A"], min_k=3, max_k=3, apply_frequency_filter=False)
+
+    assert result == {}
+
+
+@pytest.mark.parametrize("func", [compute_protein_words, module_compute_protein_words])
+def test_filtering_matches_shared_mean_rule(func):
+    """The filtered output should keep only words with frequency above the mean."""
+    result = func(["AABBCC", "AAABBB"], min_k=1, max_k=1, apply_frequency_filter=True)
+
+    # Counts are A=5, B=5, C=2 -> mean = 4, so A and B survive.
+    assert result == {"A": 1, "B": 2}


### PR DESCRIPTION
## Summary
Adds input validation to `pairs_to_features`.

## Changes
- Validate empty input
- Validate tuple structure
- Validate input types
- Validate DataFrame columns
- Normalize sequence case

## Why
Prevents unclear runtime errors and improves robustness.

Closes #<408>