### PR TITLE
[BUG] fix benchmarking metric semantics: support score based scorers (ROC AUC/PR AUC)

### DIFF
--- a/pyaptamer/benchmarking/_base.py
+++ b/pyaptamer/benchmarking/_base.py
@@ -1,6 +1,8 @@
 __author__ = "satvshr"
 __all__ = ["Benchmarking"]
 
+import warnings
+
 import numpy as np
 import pandas as pd
 from sklearn.metrics import make_scorer
@@ -22,8 +24,16 @@ class Benchmarking:
     ----------
     estimators : list[estimator] | estimator
         List of sklearn-like estimators implementing `fit` and `predict`.
-    metrics : list[callable] | callable
-        List of callables with signature `(y_true, y_pred) -> float`.
+    metrics : list[callable | dict] | callable | dict
+        Metrics to evaluate. Supported forms:
+        - callable with signature `(y_true, y_pred) -> float` (legacy behavior)
+        - dict with keys:
+            - `metric` (required): callable scoring function
+            - `name` (optional): custom metric name in output index
+            - `response_method` (optional): one of
+              {"predict", "predict_proba", "decision_function"}
+            - `greater_is_better` (optional): bool forwarded to `make_scorer`
+            - `kwargs` (optional): dict of extra kwargs for metric callable
     X : array-like
         Feature matrix.
     y : array-like
@@ -81,18 +91,114 @@ class Benchmarking:
         self.cv = cv
         self.results = None
 
+    @staticmethod
+    def _metric_name(metric):
+        """Return a stable display name for a metric callable."""
+        return (
+            metric.__name__
+            if hasattr(metric, "__name__")
+            else metric.__class__.__name__
+        )
+
+    def _normalize_metric_spec(self, metric_spec):
+        """Normalize metric spec into scorer-compatible metadata."""
+        if callable(metric_spec):
+            return {
+                "name": self._metric_name(metric_spec),
+                "metric": metric_spec,
+                "response_method": None,
+                "greater_is_better": None,
+                "kwargs": {},
+            }
+
+        if not isinstance(metric_spec, dict):
+            raise ValueError("Each metric should be a callable or a dict metric spec.")
+
+        metric = metric_spec.get("metric")
+        if not callable(metric):
+            raise ValueError("Metric spec requires a callable under key 'metric'.")
+
+        response_method = metric_spec.get("response_method")
+        if response_method is not None and response_method not in {
+            "predict",
+            "predict_proba",
+            "decision_function",
+        }:
+            raise ValueError(
+                "Metric spec key 'response_method' must be one of "
+                "{'predict', 'predict_proba', 'decision_function'}."
+            )
+
+        kwargs = metric_spec.get("kwargs", {})
+        if kwargs is None:
+            kwargs = {}
+        if not isinstance(kwargs, dict):
+            raise ValueError("Metric spec key 'kwargs' must be a dictionary.")
+
+        greater_is_better = metric_spec.get("greater_is_better")
+        if greater_is_better is not None and not isinstance(greater_is_better, bool):
+            raise ValueError("Metric spec key 'greater_is_better' must be boolean.")
+
+        return {
+            "name": metric_spec.get("name", self._metric_name(metric)),
+            "metric": metric,
+            "response_method": response_method,
+            "greater_is_better": greater_is_better,
+            "kwargs": kwargs,
+        }
+
+    def _build_scorer(
+        self, metric, response_method=None, greater_is_better=None, kwargs=None
+    ):
+        """Build sklearn scorer with version-compatible response handling."""
+        kwargs = kwargs or {}
+        scorer_kwargs = dict(kwargs)
+        if greater_is_better is not None:
+            scorer_kwargs["greater_is_better"] = greater_is_better
+
+        if response_method is None or response_method == "predict":
+            return make_scorer(metric, **scorer_kwargs)
+
+        try:
+            return make_scorer(metric, response_method=response_method, **scorer_kwargs)
+        except TypeError:
+            # sklearn<1.4 compatibility path
+            if response_method == "predict_proba":
+                return make_scorer(metric, needs_proba=True, **scorer_kwargs)
+            if response_method == "decision_function":
+                return make_scorer(metric, needs_threshold=True, **scorer_kwargs)
+            raise
+
     def _to_scorers(self, metrics):
         """Convert metric callables to a dict of scorers."""
         scorers = {}
-        for metric in metrics:
-            if not callable(metric):
-                raise ValueError("Each metric should be a callable.")
-            name = (
-                metric.__name__
-                if hasattr(metric, "__name__")
-                else metric.__class__.__name__
+        known_score_metrics = {
+            "roc_auc_score",
+            "average_precision_score",
+            "log_loss",
+            "brier_score_loss",
+        }
+
+        for metric_spec in metrics:
+            spec = self._normalize_metric_spec(metric_spec)
+
+            if (
+                spec["response_method"] is None
+                and self._metric_name(spec["metric"]) in known_score_metrics
+            ):
+                warnings.warn(
+                    f"Metric '{spec['name']}' typically expects continuous scores. "
+                    "Consider setting response_method='predict_proba' or "
+                    "'decision_function' in the metric spec.",
+                    stacklevel=2,
+                )
+
+            scorers[spec["name"]] = self._build_scorer(
+                spec["metric"],
+                response_method=spec["response_method"],
+                greater_is_better=spec["greater_is_better"],
+                kwargs=spec["kwargs"],
             )
-            scorers[name] = make_scorer(metric)
         return scorers
 
     def _to_df(self, results):

--- a/pyaptamer/benchmarking/tests/test_benchmarking.py
+++ b/pyaptamer/benchmarking/tests/test_benchmarking.py
@@ -1,7 +1,9 @@
 import numpy as np
 import pytest
-from sklearn.metrics import accuracy_score, mean_squared_error
-from sklearn.model_selection import PredefinedSplit
+from sklearn.datasets import make_classification
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import accuracy_score, mean_squared_error, roc_auc_score
+from sklearn.model_selection import PredefinedSplit, cross_validate
 
 from pyaptamer.aptanet import AptaNetPipeline, AptaNetRegressor
 from pyaptamer.benchmarking._base import Benchmarking
@@ -68,3 +70,65 @@ def test_benchmarking_with_predefined_split_regression(aptamer_seq, protein_seq)
     assert "train" in summary.columns
     assert "test" in summary.columns
     assert (reg.__class__.__name__, "mean_squared_error") in summary.index
+
+
+def test_benchmarking_roc_auc_matches_sklearn_reference():
+    """ROC-AUC should use score outputs when response_method is provided."""
+    X, y = make_classification(
+        n_samples=120,
+        n_features=10,
+        n_informative=6,
+        n_redundant=2,
+        random_state=7,
+    )
+    clf = LogisticRegression(max_iter=200, random_state=7)
+
+    bench = Benchmarking(
+        estimators=[clf],
+        metrics=[
+            {
+                "metric": roc_auc_score,
+                "response_method": "predict_proba",
+            }
+        ],
+        X=X,
+        y=y,
+        cv=5,
+    )
+    summary = bench.run()
+    benchmark_auc = summary.loc[(clf.__class__.__name__, "roc_auc_score"), "test"]
+
+    reference = cross_validate(
+        clf,
+        X,
+        y,
+        cv=5,
+        scoring={"roc_auc": "roc_auc"},
+        return_train_score=True,
+    )
+    sklearn_auc = float(np.mean(reference["test_roc_auc"]))
+
+    assert benchmark_auc == pytest.approx(sklearn_auc, abs=1e-10)
+
+
+def test_benchmarking_warns_for_score_metric_without_response_method():
+    """Warn when a score-based metric is passed without response_method."""
+    X, y = make_classification(
+        n_samples=80,
+        n_features=8,
+        n_informative=5,
+        n_redundant=1,
+        random_state=3,
+    )
+    clf = LogisticRegression(max_iter=200, random_state=3)
+
+    bench = Benchmarking(
+        estimators=[clf],
+        metrics=[roc_auc_score],
+        X=X,
+        y=y,
+        cv=3,
+    )
+
+    with pytest.warns(UserWarning, match="typically expects continuous scores"):
+        bench.run()


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes benchmarking scorer semantics inconsistency.

---

#### What does this implement/fix? Explain your changes.

This PR corrects and extends the benchmarking metric semantics to ensure consistent, explicit, and sklearn-compatible evaluation across the benchmarking layer.

From reviewing the repository architecture, the `pyaptamer/benchmarking` module operates as the evaluation bridge between model pipelines (e.g., AptaNet/AptaTrans pipelines in the application layer) and metric computation. It standardizes how predictions produced by estimators are transformed into comparable evaluation signals.

### Problem

The existing implementation assumed `(y_true, y_pred)` semantics for all metrics, which breaks for score-based metrics (e.g., ROC-AUC, log-loss) that require probability estimates or decision scores. This could silently produce incorrect evaluations depending on the estimator and metric combination.

### Solution

This PR introduces a backward-compatible extension of the metric API while preserving existing behavior.

#### 1. Extended Metric Specification
- `metrics` now supports:
  - legacy callables (unchanged)
  - structured metric specs (`dict`) with:
    - `metric` (callable, required)
    - `name` (optional)
    - `response_method` (`predict`, `predict_proba`, `decision_function`)
    - `greater_is_better` (optional)
    - `kwargs` (optional)

This aligns the benchmarking interface with sklearn’s scorer abstraction while keeping the API flexible for future extensions.

#### 2. Normalization & Validation Layer
- Added `_normalize_metric_spec(...)`
- Ensures early validation of malformed specs with explicit errors
- Provides a uniform internal representation for downstream scorer construction

#### 3. Scorer Construction (sklearn-compatible)
- Added `_build_scorer(...)`
- Dynamically constructs scorers using the specified `response_method`
- Includes fallback handling for sklearn compatibility:
  - `predict_proba` → `needs_proba=True`
  - `decision_function` → `needs_threshold=True`

This ensures consistent behavior with `cross_validate` and avoids implicit assumptions about estimator outputs.

#### 4. Guardrails for Score-Based Metrics
- Added warnings in `_to_scorers(...)` when score-based metrics (e.g., `roc_auc_score`, `average_precision_score`, `log_loss`, `brier_score_loss`) are used without specifying `response_method`
- Prevents silent misuse with hard labels and surfaces correct usage patterns to the user

Importantly, this change is localized to the benchmarking layer and does not affect model implementations or pipeline orchestration logic.

---

#### What should a reviewer concentrate their feedback on?

- Correctness and robustness of scorer construction logic across different estimator capabilities
- Alignment with sklearn scorer semantics and edge cases (e.g., missing `predict_proba`)
- Validation logic in `_normalize_metric_spec(...)`
- Whether the warning strategy appropriately balances safety vs. verbosity
- Any unintended interaction with pipeline outputs from AptaNet/AptaTrans workflows

---

#### Did you add any tests for the change?

Yes.

Added/updated tests in `pyaptamer/benchmarking/tests/test_benchmarking.py`:

- `test_benchmarking_roc_auc_matches_sklearn_reference`
  - Verifies that ROC-AUC computed via Benchmarking (with `response_method="predict_proba"`) matches sklearn’s `cross_validate(..., scoring="roc_auc")`
  - Ensures semantic equivalence with sklearn’s reference implementation

- `test_benchmarking_warns_for_score_metric_without_response_method`
  - Confirms that appropriate warnings are raised when score-based metrics are used with legacy callable semantics

These tests validate both correctness and regression safety.

---

#### Any other comments?

- Pre-commit hooks (ruff, formatting, line endings) have been applied and verified
- Changes are backward-compatible with existing metric usage
- The update strengthens the evaluation layer without impacting:
  - domain/algorithm layer (AptaNet, AptaTrans, MCTS)
  - data layer (datasets/loaders)
  - pipeline orchestration
- Full test suite passes locally in a properly configured environment (dependency note: `skbase` required)

Happy to refine further or extend support for additional metric patterns if needed.

---

#### PR checklist

- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks.