### PR TITLE
[BUG]: Fix `rna2vec` silent data loss for short sequences

### DIFF
--- a/pyaptamer/utils/_rna.py
+++ b/pyaptamer/utils/_rna.py
@@ -151,24 +151,20 @@ def rna2vec(
             triplets.get(sequence[i : i + 3], 0) for i in range(len(sequence) - 2)
         ]
 
-        # skip sequences that convert to an empty list
-        if any(converted):
-            # truncate if too long
-            if max_sequence_length is not None and len(converted) > max_sequence_length:
-                converted = converted[:max_sequence_length]
+        # truncate if too long
+        if len(converted) > max_sequence_length:
+            converted = converted[:max_sequence_length]
 
-            # pad if too short
-            if max_sequence_length is not None:
-                pad_length = max_sequence_length - len(converted)
-                padded_sequence = np.pad(
-                    array=converted,
-                    pad_width=(0, pad_length),
-                    constant_values=0,
-                )
-            else:
-                padded_sequence = np.array(converted)
+        # pad to max_sequence_length (sequences too short to form any triplet
+        # produce an empty converted list and become an all-zero row)
+        pad_length = max_sequence_length - len(converted)
+        padded_sequence = np.pad(
+            array=converted,
+            pad_width=(0, pad_length),
+            constant_values=0,
+        )
 
-            result.append(padded_sequence)
+        result.append(padded_sequence)
 
     return np.array(result)
 

--- a/pyaptamer/utils/tests/test_rna.py
+++ b/pyaptamer/utils/tests/test_rna.py
@@ -147,24 +147,23 @@ def test_rna2vec_edge_cases():
     result = rna2vec(["AAACGU"], sequence_type="rna", max_sequence_length=4)
     assert result.shape[1] == 4  # should truncate to 4 triplets
 
-    # empty sequence
-    result = rna2vec([""], sequence_type="rna")
-    assert len(result) == 0
+    # sequences too short to form a triplet must still produce one zero row each,
+    # preserving the shape contract (len(sequence_list), max_sequence_length)
+    for short_seq in ["", "A", "AA"]:
+        result = rna2vec([short_seq], sequence_type="rna", max_sequence_length=275)
+        assert result.shape == (1, 275), f"shape contract broken for {short_seq!r}"
+        assert np.all(result == 0), f"short sequence {short_seq!r} must be all-zero row"
 
-    # single character sequence (can't form triplet)
-    result = rna2vec(["A"], sequence_type="rna")
-    assert len(result) == 0
-
-    # double character sequence (can't form triplet)
-    result = rna2vec(["AA"], sequence_type="rna")
-    assert len(result) == 0
+    # mixed list: one valid, one short — shape must be (2, 275)
+    result = rna2vec(["ACGU", "A"], sequence_type="rna", max_sequence_length=275)
+    assert result.shape == (2, 275)
+    assert np.all(result[1] == 0)  # short sequence is the all-zero row
 
     # test with secondary structure sequences - edge cases
-    result = rna2vec(["S"], sequence_type="ss")
-    assert len(result) == 0
-
-    result = rna2vec(["SS"], sequence_type="ss")
-    assert len(result) == 0
+    for short_seq in ["S", "SS"]:
+        result = rna2vec([short_seq], sequence_type="ss", max_sequence_length=275)
+        assert result.shape == (1, 275), f"shape contract broken for {short_seq!r}"
+        assert np.all(result == 0), f"short sequence {short_seq!r} must be all-zero row"
 
 
 def test_rna2vec_default_parameters():


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #415 

#### What does this implement/fix? Explain your changes.
`rna2vec()` in `pyaptamer/utils/_rna.py` used if any(converted): to guard the append, which silently dropped any sequence shorter than 3 characters. For sequences of length `0`, `1`, or `2`, `range(len(sequence) - 2)` produces an empty list, `any([])` is False, and the sequence is never added to the result. 

Therfor , this ***violates*** the documented return shape contract of `(len(sequence_list), max_sequence_length`) — callers receive fewer rows than inputs with no error or warning, causing cryptc shape mismatches downstream in `AptamerEvalAptaTrans.`

***The fix removes the conditional guard entirely***. Every input sequence now unconditionally appends one padded row. Sequences too short to form any triplet produce `converted = []`, which zero-pads to `max_sequence_length`, preserving the shape contract.

#### PR checklist
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks.

**pytest pass**
* individuals
<img width="1464" height="130" alt="Image" src="https://github.com/user-attachments/assets/8bd9808a-7088-4a7b-9d87-bd61e641f52c" />

* all
<img width="1919" height="134" alt="image" src="https://github.com/user-attachments/assets/71c13809-9b5e-4928-866a-ad02774bdbc6" />


**pre-commits pass**
<img width="1914" height="113" alt="Image" src="https://github.com/user-attachments/assets/47ea075c-14ea-422a-b2d2-88d7bce5e4d1" />