### PR TITLE
[BUG] fix GreedyEncoder.__init__ max_len type annotation and default value

### DIFF
--- a/pyaptamer/trafos/encode/_greedy.py
+++ b/pyaptamer/trafos/encode/_greedy.py
@@ -60,7 +60,7 @@ class GreedyEncoder(BaseTransform):
     def __init__(
         self,
         words: dict[str, int],
-        max_len: int,
+        max_len: int | None = None,
         word_max_len: int = None,
     ):
         self.words = words


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #421

#### What does this implement/fix? Explain your changes.
Fixes two related inconsistencies in `pyaptamer/trafos/encode/_greedy.py`:

1. `__init__` declared `max_len: int` with no default, making it a required argument. However `get_test_params()` returns `param0` without `max_len`, causing a `TypeError` in any test harness that unpacks it.
2. `_transform` already handles `max_len=None` at lines 117 and 123 (auto-pad to longest sequence). The signature contradicted this intentional behaviour.

Fix: `max_len: int | None = None` — a one-character type update and a default value addition. No change to `_transform` logic.

#### What should a reviewer concentrate their feedback on?
The one-line signature change only. No logic is modified.

#### PR checklist
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
- [ ] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks.
