### PR TITLE
[BUG] fix two malformed ValueError messages in PSeAAC.__init__: add missing spaces

### DIFF
--- a/pyaptamer/pseaac/_pseaac_general.py
+++ b/pyaptamer/pseaac/_pseaac_general.py
@@ -127,7 +127,7 @@ class PSeAAC:
 
         if group_props is not None and custom_groups is not None:
             raise ValueError(
-                "Specify only one of `group_props` or `custom_groups`,not both."
+                "Specify only one of `group_props` or `custom_groups`, not both."
             )
 
         self.np_matrix = aa_props(
@@ -148,7 +148,7 @@ class PSeAAC:
         else:
             if self._n_cols % group_props != 0:
                 raise ValueError(
-                    f"Number of properties ({self._n_cols}) must be divisible by"
+                    f"Number of properties ({self._n_cols}) must be divisible by "
                     f"group_props ({group_props})."
                 )
             self.prop_groups = [


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #424

#### What does this implement/fix? Explain your changes.
Fixes two `ValueError` messages in `pyaptamer/pseaac/_pseaac_general.py` that produce garbled output at runtime:

| File | Line | Before | After |
|------|------|--------|-------|
| `_pseaac_general.py` | 130 | `...custom_groups`,not both.` | `...custom_groups`, not both.` |
| `_pseaac_general.py` | 151 | `...must be divisible by"` + `"group_props...` | `...must be divisible by "` + `"group_props...` |

Both changes are single-character additions (one space each). No behavioural, API, or import change.

#### What should a reviewer concentrate their feedback on?
That the corrected messages read naturally and clearly.

#### Did you add any tests for the change?
- [ ] No — error message text only; no logic change.

#### Any other comments?
None.

#### PR checklist
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
- [ ] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks.
