### PR TITLE
[BUG] raise ValueError in APIDataset when y contains non-string labels to prevent silent all-zeros corruption

### DIFF
--- a/pyaptamer/datasets/dataclasses/_api.py
+++ b/pyaptamer/datasets/dataclasses/_api.py
@@ -99,6 +99,11 @@ class APIDataset(Dataset):
             words=self.prot_words,
             max_len=self.prot_max_len,
         )
+        if not np.isin(y, ["positive", "negative"]).all():
+            raise ValueError(
+                "Labels `y` must contain only 'positive' or 'negative' strings. "
+                f"Got unique values: {np.unique(y).tolist()}"
+            )
         y = torch.tensor((y == "positive").astype(int))
 
         return (x_apta, x_prot, y)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #426

#### What does this implement/fix? Explain your changes.
`APIDataset._prepare_data` converts labels at line 102 via `(y == "positive").astype(int)`.
When `y` contains integers instead of `"positive"/"negative"` strings, NumPy compares each integer to the string — all comparisons return `False` — producing a tensor of all-zeros silently, corrupting every training label with no error or warning.

This PR adds a one-guard validation check right before label conversion:

    if not np.isin(y, ["positive", "negative"]).all():
        raise ValueError(
            "Labels `y` must contain only 'positive' or 'negative' strings. "
            f"Got unique values: {np.unique(y).tolist()}"
        )

Users now get a clear, actionable error instead of a silently corrupted model.

#### What should a reviewer concentrate their feedback on?
The wording of the error message and whether the check placement (after augmentation, before conversion) is correct.

#### Did you add any tests for the change?
- [ ] No tests added — open to adding if the reviewer prefers.

#### Any other comments?
The class docstring already specifies strings-only for `y`. This fix enforces that contract at runtime.

#### PR checklist
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
- [ ] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks.
