### PR TITLE
[BUG] fix load_pretrained_weights() to use absolute path instead of CWD-dependent os.path.relpath()

### DIFF
--- a/pyaptamer/aptatrans/_model.py
+++ b/pyaptamer/aptatrans/_model.py
@@ -265,9 +265,7 @@ class AptaTrans(nn.Module):
 
         If the weights are not found locally, they will be downloaded from hugging face.
         """
-        path = os.path.relpath(
-            os.path.join(os.path.dirname(__file__), ".", "weights", "pretrained.pt")
-        )
+        path = os.path.join(os.path.dirname(__file__), "weights", "pretrained.pt")
 
         if os.path.exists(path):
             print(f"Loading pretrained weights from {path}...")


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #458 
#### What does this implement/fix? Explain your changes.
`load_pretrained_weights()` wrapped a correct `os.path.dirname(__file__)`-based absolute path inside `os.path.relpath()` (line 268). This made the weights path relative to the caller's CWD - if called from any directory other than the project root (like a notebook in a subdirectory), `os.path.exists(path)` returns `False` even when the weights file exists locally. This triggered unnecessary HuggingFace downloads and potentially saved the file to the wrong directory via `model_dir`.

**Fix:** Removed the `os.path.relpath()` wrapper and the redundant `"."` path segment. The absolute path generated by `os.path.dirname(__file__)` is already fully portable and CWD-independent.

| Before | After |
|--------|-------|
| `os.path.relpath(os.path.join(os.path.dirname(__file__), ".", "weights", "pretrained.pt"))` | `os.path.join(os.path.dirname(__file__), "weights", "pretrained.pt")` |

#### What should a reviewer concentrate their feedback on?
Confirming that the absolute path resolves correctly to the `weights/` directory next to `_model.py`.

#### Did you add any tests for the change?
- [ ] No tests added - path resolution fix only.
#### Any other comments?
None.

#### PR checklist
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
- [ ] - [ ] Added/modified tests
- [ ] - [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks.