### PR TITLE
[ENH] Improve Benchmarking API: reusability, metric support, and estimator handling

### DIFF
--- a/examples/benchmarking_tutorial.ipynb
+++ b/examples/benchmarking_tutorial.ipynb
@@ -157,19 +157,14 @@
    "source": [
     "# Example estimator\n",
     "aptanet_estimator = AptaNetPipeline(k=4)\n",
-    "\n",
     "# Define a 5-fold CV strategy\n",
     "cv = KFold(n_splits=5, shuffle=True, random_state=42)\n",
-    "\n",
     "# Run benchmarking with CV\n",
     "bench = Benchmarking(\n",
     "    estimators=[aptanet_estimator],\n",
     "    metrics=[accuracy_score],\n",
-    "    X=X,\n",
-    "    y=y,\n",
-    "    cv=cv,\n",
     ")\n",
-    "results_cv = bench.run()\n",
+    "results_cv = bench.run(X=X, y=y, cv=cv)\n",
     "print(results_cv)"
    ]
   },
@@ -215,16 +210,12 @@
     "test_fold = np.ones(len(y)) * -1\n",
     "test_fold[-10:] = 0\n",
     "cv = PredefinedSplit(test_fold)\n",
-    "\n",
     "# Run benchmarking with fixed split\n",
     "bench_fixed = Benchmarking(\n",
     "    estimators=[aptanet_estimator],\n",
     "    metrics=[accuracy_score],\n",
-    "    X=X,\n",
-    "    y=y,\n",
-    "    cv=cv,\n",
     ")\n",
-    "results_fixed = bench_fixed.run()\n",
+    "results_fixed = bench_fixed.run(X=X, y=y, cv=cv)\n",
     "print(results_fixed)"
    ]
   },

--- a/pyaptamer/benchmarking/_base.py
+++ b/pyaptamer/benchmarking/_base.py
@@ -73,33 +73,62 @@ class Benchmarking:
     >>> summary = bench.run()  # doctest: +SKIP
     """
 
-    def __init__(self, estimators, metrics, X, y, cv=None):
+    def __init__(self, estimators, metrics):
         self.estimators = estimators if isinstance(estimators, list) else [estimators]
         self.metrics = metrics if isinstance(metrics, list) else [metrics]
-        self.X = X
-        self.y = y
-        self.cv = cv
         self.results = None
 
     def _to_scorers(self, metrics):
-        """Convert metric callables to a dict of scorers."""
+        """Convert metrics to a dict of scorers."""
+        from sklearn.metrics import get_scorer
+
         scorers = {}
         for metric in metrics:
-            if not callable(metric):
-                raise ValueError("Each metric should be a callable.")
-            name = (
-                metric.__name__
-                if hasattr(metric, "__name__")
-                else metric.__class__.__name__
-            )
-            scorers[name] = make_scorer(metric)
+            if isinstance(metric, str):
+                scorers[metric] = get_scorer(metric)
+            elif callable(metric):
+                name = (
+                    metric.__name__
+                    if hasattr(metric, "__name__")
+                    else metric.__class__.__name__
+                )
+                scorers[name] = make_scorer(metric)
+            else:
+                raise ValueError(f"Metric {metric} should be a callable or a string.")
         return scorers
+
+    def _get_estimator_names(self):
+        """Get or generate unique names for estimators."""
+        names = []
+        estimators = []
+
+        for item in self.estimators:
+            if isinstance(item, tuple) and len(item) == 2:
+                names.append(item[0])
+                estimators.append(item[1])
+            else:
+                names.append(item.__class__.__name__)
+                estimators.append(item)
+
+        # Handle duplicates by adding suffixes
+        final_names = []
+        counts = {}
+        for name in names:
+            if name not in counts:
+                counts[name] = 0
+                final_names.append(name)
+            else:
+                counts[name] += 1
+                final_names.append(f"{name}_{counts[name]}")
+
+        return list(zip(final_names, estimators, strict=False))
 
     def _to_df(self, results):
         """Convert nested results to a unified DataFrame."""
         records = []
         index = []
 
+        # Ensure consistent order by iterating over the results in processing order
         for est_name, est_scores in results.items():
             for metric_name, scores in est_scores.items():
                 records.append(scores)
@@ -108,34 +137,33 @@ class Benchmarking:
         index = pd.MultiIndex.from_tuples(index, names=["estimator", "metric"])
         return pd.DataFrame(records, index=index, columns=["train", "test"])
 
-    def run(self):
+    def run(self, X, y, cv=None):
         """
         Train each estimator and evaluate with cross-validation.
+
+        Parameters
+        ----------
+        X : array-like
+            Feature matrix.
+        y : array-like
+            Target vector.
+        cv : int, CV splitter, or None, default=None
+            Cross-validation strategy. If `None`, defaults to 5-fold CV.
 
         Returns
         -------
         results : pd.DataFrame
-
-            - Index: pandas.MultiIndex with two levels (names shown in parentheses)
-                - level 0 "estimator": estimator name
-                - level 1 "metric": evaluator name
-            - Columns: ["train", "test"] (both floats)
-            - Cell values: mean scores (float) computed across CV folds:
-                - "train" = mean of cross_validate(...)[f"train_{metric}"]
-                - "test"  = mean of cross_validate(...)[f"test_{metric}"]
-
         """
         self.scorers_ = self._to_scorers(self.metrics)
+        named_estimators = self._get_estimator_names()
         results = {}
 
-        for estimator in self.estimators:
-            est_name = estimator.__class__.__name__
-
+        for est_name, estimator in named_estimators:
             cv_results = cross_validate(
                 estimator,
-                self.X,
-                self.y,
-                cv=self.cv,
+                X,
+                y,
+                cv=cv,
                 scoring=self.scorers_,
                 return_train_score=True,
             )

--- a/pyaptamer/benchmarking/tests/test_benchmarking.py
+++ b/pyaptamer/benchmarking/tests/test_benchmarking.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from sklearn.metrics import accuracy_score, mean_squared_error
+from sklearn.metrics import accuracy_score
 from sklearn.model_selection import PredefinedSplit
 
 from pyaptamer.aptanet import AptaNetPipeline, AptaNetRegressor
@@ -31,11 +31,8 @@ def test_benchmarking_with_predefined_split_classification(aptamer_seq, protein_
     bench = Benchmarking(
         estimators=[clf],
         metrics=[accuracy_score],
-        X=X_raw,
-        y=y,
-        cv=cv,
     )
-    summary = bench.run()
+    summary = bench.run(X=X_raw, y=y, cv=cv)
 
     assert "train" in summary.columns
     assert "test" in summary.columns
@@ -58,13 +55,52 @@ def test_benchmarking_with_predefined_split_regression(aptamer_seq, protein_seq)
 
     bench = Benchmarking(
         estimators=[reg],
-        metrics=[mean_squared_error],
-        X=X_raw,
-        y=y,
-        cv=cv,
+        metrics=["neg_mean_squared_error"],
     )
-    summary = bench.run()
+    summary = bench.run(X=X_raw, y=y, cv=cv)
 
     assert "train" in summary.columns
     assert "test" in summary.columns
-    assert (reg.__class__.__name__, "mean_squared_error") in summary.index
+    assert (reg.__class__.__name__, "neg_mean_squared_error") in summary.index
+
+
+def test_benchmarking_unique_names():
+    """
+    Test that duplicate estimator classes get unique names.
+    """
+    aptamer_seq = "AGCTTAGCGTACAGCTTAAAAGGGTTTCCCCTGCCCGCGTAC"
+    protein_seq = "ACDEFGHIKLMNPQRSTVWYACDEFGHIKLMNPQRSTVWY"
+    X_raw = [(aptamer_seq, protein_seq) for _ in range(20)]
+    y = np.array([0] * 10 + [1] * 10, dtype=np.float32)
+
+    clf1 = AptaNetPipeline(k=3)
+    clf2 = AptaNetPipeline(k=4)
+
+    bench = Benchmarking(
+        estimators=[clf1, clf2],
+        metrics=["accuracy"],
+    )
+    summary = bench.run(X=X_raw, y=y, cv=2)
+
+    assert "AptaNetPipeline" in summary.index.get_level_values(0)
+    assert "AptaNetPipeline_1" in summary.index.get_level_values(0)
+
+
+def test_benchmarking_named_estimators():
+    """
+    Test that user-provided names for estimators are used.
+    """
+    aptamer_seq = "AGCTTAGCGTACAGCTTAAAAGGGTTTCCCCTGCCCGCGTAC"
+    protein_seq = "ACDEFGHIKLMNPQRSTVWYACDEFGHIKLMNPQRSTVWY"
+    X_raw = [(aptamer_seq, protein_seq) for _ in range(20)]
+    y = np.array([0] * 10 + [1] * 10, dtype=np.float32)
+
+    clf = AptaNetPipeline(k=3)
+
+    bench = Benchmarking(
+        estimators=[("MyModel", clf)],
+        metrics=["accuracy"],
+    )
+    summary = bench.run(X=X_raw, y=y, cv=2)
+
+    assert "MyModel" in summary.index.get_level_values(0)


### PR DESCRIPTION
#### Reference Issues/PRs
Closes #444  
Related to #297

---

#### What does this implement/fix? Explain your changes.

This PR improves the Benchmarking API to make it more reusable, robust, and aligned with standard machine learning workflows.

Key changes include:

- Refactored the API to move `X`, `y`, and `cv` from `__init__` to the `run()` method, allowing reuse of the same benchmarking configuration across different datasets and evaluation strategies.
- Added support for string-based metric names (e.g., "accuracy", "f1"), improving compatibility with scikit-learn.
- Improved estimator naming logic to prevent result overwriting when benchmarking multiple instances of the same estimator class (building on #297).
- Updated and extended the test suite to reflect the new API and validate the added functionality.
- Updated the benchmarking tutorial notebook to ensure consistency with the new interface.

These changes improve flexibility, reproducibility, and usability of the benchmarking pipeline.

---

#### What should a reviewer concentrate their feedback on?

- API design changes, especially moving data inputs to the `run()` method
- Estimator naming logic and handling of duplicate class names
- Compatibility with existing workflows and backward compatibility considerations

---

#### Did you add any tests for the change?

Yes. Existing tests were updated to match the new API, and additional tests were added to verify:
- string-based metric support
- correct handling of duplicate estimator names

All tests pass successfully.

---

#### Any other comments?

The estimator naming issue addressed here is related to #297. This PR extends the fix by improving the overall API design and usability.

---

#### PR checklist

- [x] The PR title starts with [ENH]
- [x] Added/modified tests
- [x] Used pre-commit hooks and ensured all checks pass