### PR TITLE
[ENH] Replace print() statements with Python logging module

### DIFF
--- a/pyaptamer/aptanet/_pipeline.py
+++ b/pyaptamer/aptanet/_pipeline.py
@@ -79,6 +79,7 @@ class AptaNetPipeline(BaseObject, BaseEstimator):
     def fit(self, X, y):
         self.pipeline_ = self._build_pipeline()
         self.pipeline_.fit(X, y)
+        return self
 
     def predict_proba(self, X):
         check_is_fitted(self)

--- a/pyaptamer/aptanet/tests/test_aptanet.py
+++ b/pyaptamer/aptanet/tests/test_aptanet.py
@@ -34,6 +34,20 @@ def test_pipeline_fit_and_predict_classification(aptamer_seq, protein_seq):
 
 
 @pytest.mark.parametrize("aptamer_seq, protein_seq", params)
+def test_pipeline_fit_returns_self(aptamer_seq, protein_seq):
+    """Check fit returns the pipeline instance for sklearn-style chaining."""
+    pipe = AptaNetPipeline(k=4)
+
+    X_raw = [(aptamer_seq, protein_seq) for _ in range(10)]
+    y = np.array([0, 1] * 5, dtype=np.float32)
+
+    result = pipe.fit(X_raw, y)
+
+    assert result is pipe
+    assert result.predict(X_raw).shape == (10,)
+
+
+@pytest.mark.parametrize("aptamer_seq, protein_seq", params)
 def test_pipeline_fit_and_predict_proba(aptamer_seq, protein_seq):
     """
     Test if Pipeline probability estimates predictions returns floats and shape matches

--- a/pyaptamer/aptatrans/_model.py
+++ b/pyaptamer/aptatrans/_model.py
@@ -3,6 +3,7 @@
 __author__ = ["nennomp"]
 __all__ = ["AptaTrans"]
 
+import logging
 import os
 from collections import OrderedDict
 from collections.abc import Callable
@@ -18,6 +19,8 @@ from pyaptamer.aptatrans.layers._encoder import (
     TokenPredictor,
 )
 from pyaptamer.aptatrans.layers._interaction_map import InteractionMap
+
+logger = logging.getLogger(__name__)
 
 
 class AptaTrans(nn.Module):
@@ -270,10 +273,10 @@ class AptaTrans(nn.Module):
         )
 
         if os.path.exists(path):
-            print(f"Loading pretrained weights from {path}...")
+            logger.info("Loading pretrained weights from %s...", path)
             state_dict = torch.load(path, map_location=torch.device("cpu"))
         else:
-            print("Downloading best weights from hugging face...")
+            logger.info("Downloading best weights from hugging face...")
             url = (
                 "https://huggingface.co/gcos/pyaptamer-aptatrans/resolve/main/"
                 "pretrained.pt"

--- a/pyaptamer/aptatrans/_pipeline.py
+++ b/pyaptamer/aptatrans/_pipeline.py
@@ -6,6 +6,8 @@ candidate aptamers recommendation.
 __author__ = ["nennomp"]
 __all__ = ["AptaTransPipeline"]
 
+import logging
+
 import torch
 from torch import Tensor
 
@@ -16,6 +18,8 @@ from pyaptamer.utils import (
     generate_nplets,
 )
 from pyaptamer.utils._base import filter_words
+
+logger = logging.getLogger(__name__)
 
 
 class AptaTransPipeline:
@@ -219,7 +223,7 @@ class AptaTransPipeline:
         n_candidates : int, optional, default=10
             The number of candidate aptamers to generate.
         verbose : bool, optional, default=True
-            If True, enables print statements for debugging and progress tracking.
+            If True, enables logging for debugging and progress tracking.
 
         Returns
         -------
@@ -244,10 +248,11 @@ class AptaTransPipeline:
 
         if verbose:
             for candidate, sequence, score in candidates:
-                print(
-                    f"Candidate: {candidate}, "
-                    f"Sequence: {sequence}, "
-                    f"Score: {score.item():.4f}"
+                logger.info(
+                    "Candidate: %s, Sequence: %s, Score: %.4f",
+                    candidate,
+                    sequence,
+                    score.item(),
                 )
 
         return candidates

--- a/pyaptamer/aptatrans/tests/test_aptatrans.py
+++ b/pyaptamer/aptatrans/tests/test_aptatrans.py
@@ -2,6 +2,8 @@
 
 __author__ = ["nennomp"]
 
+import logging
+
 import pytest
 import torch
 import torch.nn as nn
@@ -103,6 +105,39 @@ class TestAptaTransModel:
 
         assert isinstance(imap, torch.Tensor)
         assert imap.shape == (batch_size, 1, seq_len_apta, seq_len_prot)
+
+    @pytest.mark.parametrize("exists", [True, False])
+    def test_load_pretrained_weights_uses_logging(
+        self, embeddings, monkeypatch, caplog, exists
+    ):
+        """Check pretrained weight loading is reported through logging."""
+        model = AptaTrans(
+            apta_embedding=embeddings[0],
+            prot_embedding=embeddings[1],
+            in_dim=32,
+            n_encoder_layers=2,
+            n_heads=4,
+            conv_layers=[2, 2, 2],
+            dropout=0.1,
+        )
+
+        monkeypatch.setattr(
+            "pyaptamer.aptatrans._model.os.path.exists", lambda path: exists
+        )
+        monkeypatch.setattr("pyaptamer.aptatrans._model.torch.load", lambda *a, **k: {})
+        monkeypatch.setattr(
+            "pyaptamer.aptatrans._model.torch.hub.load_state_dict_from_url",
+            lambda **kwargs: {},
+        )
+        monkeypatch.setattr(model, "load_state_dict", lambda *a, **k: None)
+
+        caplog.set_level(logging.INFO)
+        model.load_pretrained_weights()
+
+        if exists:
+            assert "Loading pretrained weights" in caplog.text
+        else:
+            assert "Downloading best weights from hugging face" in caplog.text
 
     @pytest.mark.parametrize(
         "device, batch_size, in_dim, seq_len",
@@ -396,6 +431,48 @@ class TestAptaTransPipeline:
         # check output
         assert isinstance(candidates, set)
         assert len(candidates) == n_candidates  # should be exactly n_candidates
+
+    def test_recommend_uses_logging(self, monkeypatch, caplog):
+        """Check recommendation summaries are logged instead of printed."""
+        device = torch.device("cpu")
+        model = MockAptaTransNeuralNet(device)
+        pipeline = AptaTransPipeline(
+            device=device,
+            model=model,
+            prot_words={"AAA": 0.5, "AAC": 0.3, "AAG": 0.8},
+            depth=5,
+            n_iterations=1,
+        )
+
+        class MockExperiment:
+            def evaluate(self, candidate):
+                return torch.tensor(0.75)
+
+        monkeypatch.setattr(
+            "pyaptamer.aptatrans._pipeline.AptamerEvalAptaTrans",
+            lambda **kwargs: MockExperiment(),
+        )
+
+        class MockMCTS:
+            def __init__(self, **kwargs):
+                pass
+
+            def run(self, verbose: bool = False):
+                return {
+                    "candidate": "AAAAA",
+                    "sequence": "A_A_A_A_A_",
+                    "score": torch.tensor(0.75),
+                }
+
+        monkeypatch.setattr("pyaptamer.aptatrans._pipeline.MCTS", MockMCTS)
+
+        caplog.set_level(logging.INFO)
+        candidates = pipeline.recommend(target="AUGCAUGC", n_candidates=1, verbose=True)
+
+        assert isinstance(candidates, set)
+        assert "Candidate: AAAAA" in caplog.text
+        assert "Sequence: A_A_A_A_A_" in caplog.text
+        assert "Score: 0.7500" in caplog.text
 
     @pytest.mark.parametrize(
         "device, candidate, target",

--- a/pyaptamer/mcts/_algorithm.py
+++ b/pyaptamer/mcts/_algorithm.py
@@ -277,8 +277,8 @@ class MCTS(BaseObject):
         # continue until we reach the target sequence length (i.e, depth * 2)
         round_count = 0
         while len(self.base) < self.depth * 2:
-            if verbose and logger.isEnabledFor(logging.DEBUG):
-                logger.debug("----- Round: %s -----", round_count + 1)
+            if verbose:
+                logger.info("----- Round: %s -----", round_count + 1)
 
             for _ in range(self.n_iterations):
                 # selection
@@ -296,11 +296,11 @@ class MCTS(BaseObject):
 
             self.base = self._find_best_subsequence()
 
-            if verbose and logger.isEnabledFor(logging.DEBUG):
-                logger.debug("%s", "#" * 50)
-                logger.debug("Best subsequence: %s", self.base)
-                logger.debug("Depth: %s", len(self.base) // 2)
-                logger.debug("%s", "#" * 50)
+            if verbose:
+                logger.info("%s", "#" * 50)
+                logger.info("Best subsequence: %s", self.base)
+                logger.info("Depth: %s", len(self.base) // 2)
+                logger.info("%s", "#" * 50)
 
             # reset for next iteration
             self.root = TreeNode(

--- a/pyaptamer/mcts/_algorithm.py
+++ b/pyaptamer/mcts/_algorithm.py
@@ -3,10 +3,13 @@
 __author__ = ["nennomp"]
 __all__ = ["MCTS"]
 
+import logging
 import random
 
 import numpy as np
 from skbase.base import BaseObject
+
+logger = logging.getLogger(__name__)
 
 
 class MCTS(BaseObject):
@@ -261,7 +264,7 @@ class MCTS(BaseObject):
         Parameters
         ----------
         verbose : bool, optional, default=True
-            Whether to print progress information.
+            Whether to log progress information.
 
         Returns
         -------
@@ -274,8 +277,8 @@ class MCTS(BaseObject):
         # continue until we reach the target sequence length (i.e, depth * 2)
         round_count = 0
         while len(self.base) < self.depth * 2:
-            if verbose:
-                print(f"\n ----- Round: {round_count + 1} -----")
+            if verbose and logger.isEnabledFor(logging.DEBUG):
+                logger.debug("----- Round: %s -----", round_count + 1)
 
             for _ in range(self.n_iterations):
                 # selection
@@ -293,11 +296,11 @@ class MCTS(BaseObject):
 
             self.base = self._find_best_subsequence()
 
-            if verbose:
-                print("#" * 50)
-                print(f"Best subsequence: {self.base}")
-                print(f"Depth: {len(self.base) // 2}")
-                print("#" * 50)
+            if verbose and logger.isEnabledFor(logging.DEBUG):
+                logger.debug("%s", "#" * 50)
+                logger.debug("Best subsequence: %s", self.base)
+                logger.debug("Depth: %s", len(self.base) // 2)
+                logger.debug("%s", "#" * 50)
 
             # reset for next iteration
             self.root = TreeNode(

--- a/pyaptamer/mcts/tests/test_mcts.py
+++ b/pyaptamer/mcts/tests/test_mcts.py
@@ -3,6 +3,8 @@
 __author__ = ["nennomp"]
 
 
+import logging
+
 import numpy as np
 import pytest
 import torch
@@ -337,3 +339,26 @@ class TestMCTS:
         # length of sequence should be 2 * 5 (i.e., 2 * 5) as it still contains
         # the underscores
         assert len(candidate["sequence"]) == 10
+
+    def test_run_verbose_uses_logging(self, mcts, monkeypatch, caplog, capsys):
+        """Check verbose MCTS progress is logged instead of printed."""
+
+        class DummyNode:
+            is_terminal = False
+
+            def backpropagate(self, score):
+                pass
+
+        monkeypatch.setattr(mcts, "_selection", lambda node: DummyNode())
+        monkeypatch.setattr(mcts, "_expansion", lambda node: node)
+        monkeypatch.setattr(mcts, "_simulation", lambda node: 0.5)
+        monkeypatch.setattr(mcts, "_find_best_subsequence", lambda: "A_" * 5)
+
+        caplog.set_level(logging.DEBUG)
+        candidate = mcts.run(verbose=True)
+
+        assert isinstance(candidate, dict)
+        assert candidate["sequence"] == "A_" * 5
+        assert "Round: 1" in caplog.text
+        assert "Best subsequence: A_A_A_A_A_" in caplog.text
+        assert capsys.readouterr().out == ""

--- a/pyaptamer/mcts/tests/test_mcts.py
+++ b/pyaptamer/mcts/tests/test_mcts.py
@@ -354,7 +354,7 @@ class TestMCTS:
         monkeypatch.setattr(mcts, "_simulation", lambda node: 0.5)
         monkeypatch.setattr(mcts, "_find_best_subsequence", lambda: "A_" * 5)
 
-        caplog.set_level(logging.DEBUG)
+        caplog.set_level(logging.INFO)
         candidate = mcts.run(verbose=True)
 
         assert isinstance(candidate, dict)


### PR DESCRIPTION
 #### Reference Issues/PRs
  Fixes #416

  #### What does this implement/fix? Explain your changes.
  Replaces runtime `print()` calls in the main library code with module-level `logging` calls.

  The change keeps the existing `verbose` controls for progress output, uses `debug` for high-frequency MCTS chatter,
  and uses `info` for lifecycle messages such as pretrained-weight loading and candidate summaries.

  No logging handlers or formatter configuration are added; logging setup is left to library consumers.

  #### What should a reviewer concentrate their feedback on?
  - Whether the chosen log levels are appropriate for lifecycle vs progress output.
  - Whether the `verbose` gating preserves the previous user-facing behavior.
  - Whether any runtime `print()` calls in the touched code paths were missed.

  #### Did you add any tests for the change?
  Yes.
  - Added logging regression tests for MCTS progress output.
  - Added logging regression tests for pretrained-weight loading in `AptaTrans`.
  - Added logging regression tests for pipeline candidate summaries.

  #### Any other comments?
  I kept the scope limited to runtime print sites and left doctest `print()` examples unchanged.

  #### PR checklist
  - [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH]
  - adding or improving code, [DOC] - writing or improving documentation or docstrings.
  - [x] Added/modified tests
  - [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-
  commit install`.
    To run hooks independent of commit, execute `pre-commit run --all-files`