### PR TITLE
[BUG] Fix typo in AptaTransPipeline error message: 'grater' -> 'greater'

### DIFF
--- a/pyaptamer/aptatrans/_pipeline.py
+++ b/pyaptamer/aptatrans/_pipeline.py
@@ -102,7 +102,7 @@ class AptaTransPipeline:
         """
         if depth < 3:
             raise ValueError(
-                f"Invalid depth value: {depth}. Must be grater or equal than 3."
+                f"Invalid depth value: {depth}. Must be greater than or equal to 3."
             )
 
         self.device = device


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #451.

#### What does this implement/fix? Explain your changes.

Fixes a typo in the `ValueError` message raised by `AptaTransPipeline.__init__()` when `depth < 3`.

- Before: `"Must be grater or equal than 3."`
- After: `"Must be greater than or equal to 3."`

Single character change in `pyaptamer/aptatrans/_pipeline.py:105`.

#### What should a reviewer concentrate their feedback on?

- Whether the corrected message wording is acceptable.

#### Did you add any tests for the change?

No new tests needed — this is a string-only fix with no behaviour change. Existing tests continue to pass.


#### PR checklist

- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
  To run hooks independent of commit, execute `pre-commit run --all-files`