### PR TITLE
[BUG] Clarify MCTS simulation length invariant

### DIFF
--- a/pyaptamer/mcts/_algorithm.py
+++ b/pyaptamer/mcts/_algorithm.py
@@ -223,8 +223,12 @@ class MCTS(BaseObject):
         # prepend the `self.base` sequence
         sequence = self.base + sequence
 
+        # `sequence` stores encoded nucleotide pairs, so two characters represent
+        # one nucleotide.
+        current_length = len(sequence) // 2
+
         # fill the rest of the sequence with random possible values
-        remaining_length = self.depth - (len(sequence) // 2)
+        remaining_length = self.depth - current_length
         for _ in range(remaining_length):
             sequence += random.choice(self.states)
 

--- a/pyaptamer/mcts/tests/test_mcts.py
+++ b/pyaptamer/mcts/tests/test_mcts.py
@@ -309,6 +309,29 @@ class TestMCTS:
         _ = mcts._simulation(node=node)
         assert True
 
+    def test_simulation_preserves_depth_invariant(self, mcts, monkeypatch):
+        """Check simulation always evaluates a sequence with the expected length."""
+        mcts.base = "A_C_"
+        node = mcts.root.create_child(val="G_")
+
+        captured = {}
+
+        def mock_evaluate(sequence):
+            captured["sequence"] = sequence
+            return 0.5
+
+        monkeypatch.setattr(mcts.experiment, "evaluate", mock_evaluate)
+        monkeypatch.setattr(
+            "pyaptamer.mcts._algorithm.random.choice", lambda states: "A_"
+        )
+
+        score = mcts._simulation(node=node)
+
+        assert score == 0.5
+        assert captured["sequence"] == "A_C_G_A_A_"
+        assert len(captured["sequence"]) == mcts.depth * 2
+        assert len(captured["sequence"]) // 2 == mcts.depth
+
     def test_find_best_subsequence(self, mcts):
         """Check whether the best subsequence is returned based on UCT scores."""
         node = mcts.root.create_child(val="A_")


### PR DESCRIPTION
#### Reference Issues/PRs
  Fixes #449

  #### What does this implement/fix? Explain your changes.
  This PR clarifies the sequence-length invariant in `MCTS._simulation()` without changing behavior.

  The calculation that determines how many random states to append is now split into an explicit `current_length`
  intermediate value, making it clear that `len(sequence) // 2` counts encoded nucleotide pairs.

  #### What should a reviewer concentrate their feedback on?
  - Whether the renamed intermediate variable makes the invariant easier to understand.
  - Whether the regression test correctly protects the expected simulation length behavior.

  #### Did you add any tests for the change?
  Yes.
  - Added a regression test that captures the sequence passed to `experiment.evaluate()`.
  - The test asserts that the evaluated encoded sequence has the expected total length and that the decoded nucleotide
  count matches `self.depth`.

  #### Any other comments?
  This is a behavior-preserving refactor with a focused regression test. It is intended to make the invariant harder to
  misread in future edits.

  #### PR checklist
  - [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
  - [x] Added/modified tests
  - [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks.