### PR TITLE
[BUG] fix AptaNetPipeline.fit to return self, fixing sklearn method chaining

### DIFF
--- a/pyaptamer/aptanet/_pipeline.py
+++ b/pyaptamer/aptanet/_pipeline.py
@@ -79,6 +79,7 @@ class AptaNetPipeline(BaseObject, BaseEstimator):
     def fit(self, X, y):
         self.pipeline_ = self._build_pipeline()
         self.pipeline_.fit(X, y)
+        return self
 
     def predict_proba(self, X):
         check_is_fitted(self)

--- a/pyaptamer/aptanet/_pipeline.py
+++ b/pyaptamer/aptanet/_pipeline.py
@@ -59,6 +59,7 @@ class AptaNetPipeline(BaseObject, BaseEstimator):
     >>> y_train = np.array([0] * 20 + [1] * 20, dtype=np.float32)
     >>> X_test_pairs = [(aptamer_seq, protein_seq) for _ in range(10)]
     >>> pipe.fit(X_train_pairs, y_train)  # doctest: +ELLIPSIS
+    AptaNetPipeline(...)
     >>> preds = pipe.predict(X_test_pairs)
     >>> proba = pipe.predict_proba(X_test_pairs)
     """

--- a/pyaptamer/experiments/_aptamer_aptanet.py
+++ b/pyaptamer/experiments/_aptamer_aptanet.py
@@ -27,7 +27,8 @@ class AptamerEvalAptaNet(BaseAptamerEval):
     >>> pairs = [(aptamer_seq, protein_seq) for _ in range(5)]
     >>> labels = np.array([0] * 5, dtype=np.float32)
     >>> pipeline = AptaNetPipeline()
-    >>> pipeline.fit(pairs, labels)
+    >>> pipeline.fit(pairs, labels)  # doctest: +ELLIPSIS
+    AptaNetPipeline(...)
     >>> target = "ACDEFACDEFACDEFACDEFACDEFACDEFACDEFACDEF"
     >>> experiment = AptamerEvalAptaNet(target, pipeline)
     >>> aptamer_candidate = "AUGGC"


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #467

#### What does this implement/fix? Explain your changes.
`AptaNetPipeline` inherits from `sklearn.base.BaseEstimator`, which strictly mandates that `fit()` must return `self`. Previously, `fit()` returned `None`. 

This PR simply adds `return self` to `AptaNetPipeline.fit()`. 

Without this fix, method chaining (e.g. `pipeline.fit(X, y).predict(X)`) crashes with an `AttributeError`, and wrapping this pipeline in standard wrappers (like hyperparameter grid search or cross-validation) fails when the utility expects the fitted estimator back.

#### What should a reviewer concentrate their feedback on?
That the estimator API contract is now fully satisfied.

#### Did you add any tests for the change?
- [ ] No explicit tests added since it's a standard API compliance fix.

#### PR checklist
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
- [ ] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks.
