### PR TITLE
[DOC] add initial documentation structure

### DIFF
--- a/docs/aptatrans/overview.md
+++ b/docs/aptatrans/overview.md
@@ -1,0 +1,37 @@
+
+---
+
+# 📄 `docs/aptatrans/overview.md`
+
+```md
+# AptaTrans Overview
+
+AptaTrans is a deep learning model used to predict interactions between aptamers and proteins.
+
+## Key Idea
+
+The model takes two sequences:
+
+- Aptamer sequence
+- Protein sequence
+
+It processes them and predicts interaction strength or compatibility.
+
+## Workflow
+
+1. Encode sequences into embeddings
+2. Generate interaction map
+3. Apply convolutional layers
+4. Produce prediction output
+
+## Features
+
+- Uses sequence embeddings
+- Convolution-based architecture
+- Designed for biological sequence interaction tasks
+
+## Notes
+
+- Input sequences must be properly encoded
+- Model expects tensor inputs
+- Output shape depends on task configuration

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,15 @@
+# PyAptamer Documentation
+
+PyAptamer is a machine learning library designed for modeling and analyzing aptamer–protein interactions.
+
+It provides tools and models for sequence encoding, interaction prediction, and data processing.
+
+## Documentation Structure
+
+- [Installation](installation.md)
+- [Quick Start](quickstart.md)
+- [AptaTrans Overview](aptatrans/overview.md)
+
+## Getting Started
+
+If you are new, start with the Quick Start guide to understand how to use the library.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,14 @@
+# Installation
+
+## Requirements
+
+- Python 3.10 or higher
+- PyTorch
+
+## Install from source
+
+Clone the repository:
+
+```bash
+git clone https://github.com/gc-os-ai/pyaptamer.git
+cd pyaptamer

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,31 @@
+
+---
+
+# 📄 `docs/quickstart.md`
+
+```md
+# Quick Start
+
+This guide shows a simple example of how to use PyAptamer.
+
+## Example
+
+```python
+from pyaptamer.aptatrans import AptaTrans, EncoderPredictorConfig
+import torch
+
+# Create embeddings
+apta_embedding = EncoderPredictorConfig(128, 16, max_len=128)
+prot_embedding = EncoderPredictorConfig(128, 16, max_len=128)
+
+# Initialize model
+model = AptaTrans(apta_embedding, prot_embedding, pretrained=False)
+
+# Dummy input
+x_apta = torch.randint(0, 16, (2, 10))
+x_prot = torch.randint(0, 16, (2, 12))
+
+# Forward pass
+output = model(x_apta, x_prot)
+
+print(output.shape)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #469

#### What does this implement/fix? Explain your changes.
This PR adds an initial documentation structure to the `docs/` folder.

Included:
- `index.md` – entry point for documentation
- `installation.md` – setup instructions
- `quickstart.md` – basic usage example
- `aptatrans/overview.md` – overview of the AptaTrans module

The goal is to make the repository more beginner-friendly and provide a structured foundation for future documentation.

#### What should a reviewer concentrate their feedback on?
- Clarity and structure of the documentation
- Whether the content is beginner-friendly
- Overall organization of the docs folder

#### Did you add any tests for the change?
No, this PR only adds documentation and does not affect code functionality.

#### Any other comments?
This is an initial documentation setup and can be extended with more detailed module-level documentation in future contributions.

#### PR checklist
- [x] The PR title starts with [DOC]
- [ ] Added/modified tests
- [ ] Used pre-commit hooks