### PR TITLE
[BUG] Fix: Implement 80/10/10 token permutations in MaskedDataset

### DIFF
--- a/pyaptamer/datasets/dataclasses/_masked.py
+++ b/pyaptamer/datasets/dataclasses/_masked.py
@@ -67,6 +67,7 @@ class MaskedDataset(Dataset):
         mask_idx: int,
         masked_rate: float = 0.15,
         is_rna: bool = False,
+        vocab_size: int | None = None,
     ) -> None:
         super().__init__()
 
@@ -81,6 +82,7 @@ class MaskedDataset(Dataset):
         self.mask_idx = mask_idx
         self.masked_rate = masked_rate
         self.is_rna = is_rna
+        self.vocab_size = vocab_size
 
         self.box = np.array(list(range(max_len)))
         self.len = len(self.x)
@@ -123,14 +125,6 @@ class MaskedDataset(Dataset):
         """
         return self.len
 
-    # TODO: For now this method applies masking as originally intended in AptaTrans
-    # code. However, there may some errors:
-    # (1.) 80% of the positions are masked but the remaining 20% are not masked at all.
-    # In BERT, the remaining 20% are replaced with random tokens or 10% replaced with
-    # random tokens and 10% left unchanged.
-    # (2.) The masking has two sample phases, one with `self.masked_rate` and one with
-    # hardcoded `0.8 * self.masked_rate`. This means that the actual masking rate
-    # becomes `0.8 * self.masked_rate` which seems confusing and possibly not intended.
     def __getitem__(self, index: int) -> tuple[Tensor, Tensor, Tensor, Tensor]:
         """
         Get a single masked sequence sample.
@@ -165,11 +159,26 @@ class MaskedDataset(Dataset):
             pos for pos in valid_positions if pos not in mask_positions
         ]
 
-        # apply masking
-        actual_mask_positions = random.sample(
-            mask_positions, int(len(mask_positions) * 0.8)
-        )
+        # apply masking (80% MASK, 10% random token, 10% unchanged)
+        random.shuffle(mask_positions)
+        n_mask = int(len(mask_positions) * 0.8)
+        n_rand = int(len(mask_positions) * 0.1)
+
+        actual_mask_positions = mask_positions[:n_mask]
+        rand_positions = mask_positions[n_mask : n_mask + n_rand]
+
+        # 80% to mask token
         x_masked[actual_mask_positions] = self.mask_idx
+
+        # 10% to random token
+        if len(rand_positions) > 0:
+            v_size = (
+                self.vocab_size if self.vocab_size is not None else (self.mask_idx - 1)
+            )
+            # sample from valid indices (typically 1 to v_size, 0 is padding)
+            x_masked[rand_positions] = torch.randint(
+                1, max(2, v_size + 1), (len(rand_positions),)
+            )
 
         # for RNA, also mask adjacent nucleotides for base pairing
         if self.is_rna:


### PR DESCRIPTION

#### Reference Issues/PRs
Fixes #473


#### What does this implement/fix? Explain your changes.
This PR resolves an open `# TODO` inside `pyaptamer/datasets/dataclasses/_masked.py` where the token sampling logic failed to correctly render random permutations when creating masked NLP tensors.

Currently, the model natively slices 15% of tokens in the dataset and masks exactly 80% to `self.mask_idx`, but leaves the remaining 20% completely unmodified. In alignment with standard BERT architecture, this PR injects a random number distribution (via `torch.randint`) directly bounded across the vocabulary matrix (`vocab_size`) mapping exactly 10% to random inputs, strictly leaving only 10% unmodified. 

Additionally, it extracts `<vocab_size>` into the constructor signature to reliably fetch accurate random collision indices dynamically instead of risking tensor overflows.

#### What should a reviewer concentrate their feedback on?
- The newly implemented extraction of `vocab_size` within the `__init__` constructor of `MaskedDataset` and verifying `mask_idx - 1` operates safely as a fallback locally.
- The `random.shuffle()` distribution handling bounds within the 15% array subset correctly splitting lengths into accurate `x_masked[actual_mask_positions]` alignments computationally.

#### Did you add any tests for the change?
No new formal module test files were necessary, however, local `pytest` iterations were verified directly against `test_hf_to_dataset.py` mapping to guarantee no breaking structural signatures.

#### Any other comments?
N/A

#### PR checklist

- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
- [ ] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
  To run hooks independent of commit, execute `pre-commit run --all-files`
