### PR TITLE
[ENH] Add return type annotations to all dataset loader functions

### DIFF
--- a/pyaptamer/datasets/_loaders/_1brq.py
+++ b/pyaptamer/datasets/_loaders/_1brq.py
@@ -1,10 +1,16 @@
+from __future__ import annotations
+
 __author__ = "satvshr"
 __all__ = ["load_1brq"]
 
 import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pyaptamer.data.loader import MoleculeLoader
 
 
-def load_1brq():
+def load_1brq() -> MoleculeLoader:
     """Load the 1brq molecule as a MoleculeLoader.
 
     Returns

--- a/pyaptamer/datasets/_loaders/_1gnh.py
+++ b/pyaptamer/datasets/_loaders/_1gnh.py
@@ -1,10 +1,18 @@
+from __future__ import annotations
+
 __author__ = ["satvshr", "fkiraly"]
 __all__ = ["load_1gnh"]
 
 import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from Bio.PDB.Structure import Structure
+
+    from pyaptamer.data.loader import MoleculeLoader
 
 
-def load_1gnh():
+def load_1gnh() -> MoleculeLoader:
     """Load the 1GNH molecule as a MoleculeLoader.
 
     Returns
@@ -20,7 +28,7 @@ def load_1gnh():
 
 
 # This function is provided only to test struct_to_aaseq.
-def _load_1gnh_structure(pdb_path=None):
+def _load_1gnh_structure(pdb_path: str | None = None) -> Structure:
     """
     Load the 1gnh molecule from a PDB file using Biopython.
 

--- a/pyaptamer/datasets/_loaders/_5nu7.py
+++ b/pyaptamer/datasets/_loaders/_5nu7.py
@@ -1,10 +1,16 @@
+from __future__ import annotations
+
 __author__ = "satvshr"
 __all__ = ["load_5nu7"]
 
 import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pyaptamer.data.loader import MoleculeLoader
 
 
-def load_5nu7():
+def load_5nu7() -> MoleculeLoader:
     """Load the 5nu7 molecule as a MoleculeLoader.
 
     Returns

--- a/pyaptamer/datasets/_loaders/_aptacom_loader.py
+++ b/pyaptamer/datasets/_loaders/_aptacom_loader.py
@@ -1,7 +1,11 @@
+from __future__ import annotations
+
 # file: aptacom_loader.py
 
 __author__ = "rpgv"
 __all__ = ["load_aptacom_full", "load_aptacom_x_y"]
+
+import pandas as pd
 
 from pyaptamer.datasets._loaders._hf_to_dataset_loader import load_hf_to_dataset
 
@@ -42,7 +46,9 @@ filter_map = {
 }
 
 
-def _filter_columns(df, columns=None):
+def _filter_columns(
+    df: pd.DataFrame, columns: list[str] | None = None
+) -> pd.DataFrame:
     """
     Select a subset of columns from a pandas DataFrame.
 
@@ -65,7 +71,7 @@ def _filter_columns(df, columns=None):
     return df
 
 
-def prepare_x_y(df):
+def prepare_x_y(df: pd.DataFrame) -> pd.DataFrame:
     """
     Prepare dataset by selecting required columns and dropping rows with missing values.
 
@@ -94,7 +100,7 @@ def prepare_x_y(df):
     return df
 
 
-def load_aptacom_full(select_columns=None):
+def load_aptacom_full(select_columns: list[str] | None = None) -> pd.DataFrame:
     """
     Load the AptaCom dataset from Hugging Face, with optional column selection.
 
@@ -129,7 +135,9 @@ def load_aptacom_full(select_columns=None):
     return dataset
 
 
-def load_aptacom_x_y(return_X_y=False):
+def load_aptacom_x_y(
+    return_X_y: bool = False,
+) -> pd.DataFrame | tuple[pd.DataFrame, pd.DataFrame]:
     """
     Load the AptaCom dataset prepared for model training.
 

--- a/pyaptamer/datasets/_loaders/_hf_to_dataset_loader.py
+++ b/pyaptamer/datasets/_loaders/_hf_to_dataset_loader.py
@@ -1,16 +1,22 @@
+from __future__ import annotations
+
 __author__ = "satvshr"
 __all__ = ["load_hf_to_dataset"]
 
 import os
+from typing import TYPE_CHECKING
 
 import requests
 from datasets import load_dataset
+
+if TYPE_CHECKING:
+    from datasets import Dataset, DatasetDict
 
 # File formats not natively supported by `datasets.load_dataset`
 FILE_FORMATS = ["fasta", "pdb"]
 
 
-def _download_to_cwd(url):
+def _download_to_cwd(url: str) -> str:
     """Download URL into ./hf_datasets/ preserving the filename."""
     os.makedirs("hf_datasets", exist_ok=True)
 
@@ -27,7 +33,9 @@ def _download_to_cwd(url):
     return local_path
 
 
-def load_hf_to_dataset(path, download_locally=False, **kwargs):
+def load_hf_to_dataset(
+    path: str, download_locally: bool = False, **kwargs
+) -> Dataset | DatasetDict:
     """
     Load any Hugging Face dataset or file into a `datasets.Dataset`.
 

--- a/pyaptamer/datasets/_loaders/_li2014.py
+++ b/pyaptamer/datasets/_loaders/_li2014.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 __author__ = "satvshr"
 __all__ = ["load_li2014"]
 import os
@@ -5,7 +7,7 @@ import os
 import pandas as pd
 
 
-def load_li2014(split=None):
+def load_li2014(split: str | None = None) -> tuple[pd.DataFrame, pd.DataFrame]:
     """
     Load the Li 2014 aptamer–protein interaction dataset.
 

--- a/pyaptamer/datasets/_loaders/_online_databank.py
+++ b/pyaptamer/datasets/_loaders/_online_databank.py
@@ -1,12 +1,19 @@
+from __future__ import annotations
+
 __author__ = "satvshr"
 __all__ = ["load_from_rcsb"]
+
+from typing import TYPE_CHECKING
 
 from Bio.PDB import PDBList
 
 from pyaptamer.utils import pdb_to_struct
 
+if TYPE_CHECKING:
+    from Bio.PDB.Structure import Structure
 
-def load_from_rcsb(pdb_id, overwrite=False):
+
+def load_from_rcsb(pdb_id: str, overwrite: bool = False) -> Structure:
     """
     Download a PDB file from the RCSB Protein Data Bank and parse it into a `Structure`.
     Files are created in the current working directory.

--- a/pyaptamer/datasets/_loaders/_pfoa.py
+++ b/pyaptamer/datasets/_loaders/_pfoa.py
@@ -1,10 +1,16 @@
+from __future__ import annotations
+
 __author__ = ["satvshr", "fkiraly"]
 __all__ = ["load_pfoa"]
 
 import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pyaptamer.data.loader import MoleculeLoader
 
 
-def load_pfoa():
+def load_pfoa() -> MoleculeLoader:
     """Load the PFOA molecule as a MoleculeLoader.
 
     Returns


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #475

#### What does this implement/fix? Explain your changes.

Adds explicit return type annotations to all public (and private) loader functions across `pyaptamer/datasets/_loaders/`. This improves IDE support, makes the API self-documenting, and catches type errors statically without changing any runtime behaviour.

**Files changed:**

| File | Functions annotated |
|------|-------------------|
| `_1brq.py` | `load_1brq() -> MoleculeLoader` |
| `_1gnh.py` | `load_1gnh() -> MoleculeLoader`, `_load_1gnh_structure() -> Structure` |
| `_5nu7.py` | `load_5nu7() -> MoleculeLoader` |
| `_pfoa.py` | `load_pfoa() -> MoleculeLoader` |
| `_li2014.py` | `load_li2014() -> tuple[pd.DataFrame, pd.DataFrame]` |
| `_aptacom_loader.py` | `_filter_columns()`, `prepare_x_y()`, `load_aptacom_full()`, `load_aptacom_x_y()` — all `-> pd.DataFrame` or union |
| `_online_databank.py` | `load_from_rcsb() -> Structure` |
| `_hf_to_dataset_loader.py` | `_download_to_cwd() -> str`, `load_hf_to_dataset() -> Dataset \| DatasetDict` |

**Implementation notes:**
- `from __future__ import annotations` added to each file so annotations are evaluated lazily (strings at runtime) — no import cost.
- `TYPE_CHECKING` guards used for `MoleculeLoader`, `Bio.PDB.Structure`, and `datasets.Dataset/DatasetDict` since these are either lazily imported inside functions or heavy third-party types — zero runtime overhead.
- Parameter annotations also added where previously missing (e.g. `pdb_id: str`, `overwrite: bool`, `split: str | None`).

#### What should a reviewer concentrate their feedback on?
- Whether `Dataset | DatasetDict` is the right union for `load_hf_to_dataset` (given the auto-unwrap logic)
- Whether `pandas` should be a hard import in `_aptacom_loader.py` or kept under `TYPE_CHECKING`

#### Did you add any tests for the change?
No new tests needed — pure annotation change. All 12 existing dataset loader tests pass.

#### PR checklist
- [x] The PR title starts with [ENH]
- [x] Used pre-commit hooks