### PR TITLE
[BUG] Return self from AptaNetPipeline.fit

### DIFF
--- a/pyaptamer/aptanet/_pipeline.py
+++ b/pyaptamer/aptanet/_pipeline.py
@@ -79,6 +79,7 @@ class AptaNetPipeline(BaseObject, BaseEstimator):
     def fit(self, X, y):
         self.pipeline_ = self._build_pipeline()
         self.pipeline_.fit(X, y)
+        return self
 
     def predict_proba(self, X):
         check_is_fitted(self)

--- a/pyaptamer/aptanet/tests/test_aptanet.py
+++ b/pyaptamer/aptanet/tests/test_aptanet.py
@@ -34,6 +34,22 @@ def test_pipeline_fit_and_predict_classification(aptamer_seq, protein_seq):
 
 
 @pytest.mark.parametrize("aptamer_seq, protein_seq", params)
+def test_pipeline_fit_returns_self(aptamer_seq, protein_seq):
+    """
+    Test that fit returns the estimator instance for sklearn-style chaining.
+    """
+    pipe = AptaNetPipeline()
+
+    X_raw = [(aptamer_seq, protein_seq) for _ in range(40)]
+    y = np.array([0] * 20 + [1] * 20, dtype=np.float32)
+
+    result = pipe.fit(X_raw, y)
+
+    assert result is pipe
+    assert result.predict(X_raw).shape == (40,)
+
+
+@pytest.mark.parametrize("aptamer_seq, protein_seq", params)
 def test_pipeline_fit_and_predict_proba(aptamer_seq, protein_seq):
     """
     Test if Pipeline probability estimates predictions returns floats and shape matches


### PR DESCRIPTION
 #### Reference Issues/PRs
  Fixes #448

  #### What does this implement/fix? Explain your changes.
  `AptaNetPipeline.fit()` now returns `self` after fitting so it follows scikit-learn estimator conventions and supports
  method chaining.

  - chained usage like `fit(...).predict(...)` works

  #### What should a reviewer concentrate their feedback on?
  - The API behavior change in `AptaNetPipeline.fit()`
  - The new regression test coverage

  #### Did you add any tests for the change?
  Yes. Added a regression test in `pyaptamer/aptanet/tests/test_aptanet.py`.

  #### Any other comments?
  Verified with:
  - `python -m pytest pyaptamer/aptanet/tests/test_aptanet.py`

  Result: `106 passed, 2 skipped`

  #### PR checklist
  - [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]
  - [x] Added/modified tests
  - [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks