### PR TITLE
[ENH] Add explicit return type hints to dataset loaders

### DIFF
--- a/pyaptamer/datasets/_loaders/_1brq.py
+++ b/pyaptamer/datasets/_loaders/_1brq.py
@@ -4,7 +4,7 @@ __all__ = ["load_1brq"]
 import os
 
 
-def load_1brq():
+def load_1brq() -> "MoleculeLoader":
     """Load the 1brq molecule as a MoleculeLoader.
 
     Returns

--- a/pyaptamer/datasets/_loaders/_1gnh.py
+++ b/pyaptamer/datasets/_loaders/_1gnh.py
@@ -4,7 +4,7 @@ __all__ = ["load_1gnh"]
 import os
 
 
-def load_1gnh():
+def load_1gnh() -> "MoleculeLoader":
     """Load the 1GNH molecule as a MoleculeLoader.
 
     Returns


### PR DESCRIPTION
Resolves #475 

**Overview**
Added explicit `-> "MoleculeLoader"` return type annotations to the dataset loader functions (`load_1brq` and `load_1gnh`).

This is a small API improvement to make return types clearer and help with IDE autocomplete. No changes to runtime behavior.

**Checklist**
- [x] Code passes `ruff`
- [x] Kept the change minimal and focused