### PR TITLE
[BUG] Fix AptaNetPipeline KeyError when using AptaCom DataFrame schema

### DIFF
--- a/pyaptamer/aptanet/tests/test_aptanet.py
+++ b/pyaptamer/aptanet/tests/test_aptanet.py
@@ -2,6 +2,7 @@ __author__ = ["nennomp", "satvshr"]
 
 
 import numpy as np
+import pandas as pd
 import pytest
 from sklearn.utils.estimator_checks import parametrize_with_checks
 
@@ -81,3 +82,25 @@ def test_sklearn_compatible_estimator(estimator, check):
     Run scikit-learn's compatibility checks on the AptaNetClassifier.
     """
     check(estimator)
+
+
+@pytest.mark.parametrize("aptamer_seq, protein_seq", params)
+def test_pipeline_fit_with_aptacom_dataframe(aptamer_seq, protein_seq):
+    """
+    Test if AptaNetPipeline fits on a DataFrame with 'aptamer_sequence' and 'target_sequence'.
+    This matches the schema returned by load_aptacom_x_y(return_X_y=True).
+    """
+    X = pd.DataFrame(
+        {
+            "aptamer_sequence": [aptamer_seq] * 8,
+            "target_sequence": [protein_seq] * 8,
+        }
+    )
+    y = np.array([0, 0, 0, 0, 1, 1, 1, 1], dtype=np.float32)
+
+    pipe = AptaNetPipeline(k=4)
+    # This should not raise KeyError or ValueError
+    pipe.fit(X, y)
+
+    preds = pipe.predict(X)
+    assert len(preds) == 8

--- a/pyaptamer/utils/_aptanet_utils.py
+++ b/pyaptamer/utils/_aptanet_utils.py
@@ -94,9 +94,18 @@ def pairs_to_features(X, k=4):
         elif "aptamer_sequence" in X.columns and "target_sequence" in X.columns:
             apt_col, prot_col = "aptamer_sequence", "target_sequence"
         else:
-            raise KeyError(
+            actual_columns = list(X.columns)
+            schema_one = {"aptamer", "protein"}
+            schema_two = {"aptamer_sequence", "target_sequence"}
+            missing_schema_one = sorted(schema_one - set(X.columns))
+            missing_schema_two = sorted(schema_two - set(X.columns))
+            raise ValueError(
                 "DataFrame must contain either ('aptamer', 'protein') "
-                "or ('aptamer_sequence', 'target_sequence') columns."
+                "or ('aptamer_sequence', 'target_sequence') columns. "
+                f"Found columns: {actual_columns}. "
+                f"Missing for ('aptamer', 'protein'): {missing_schema_one}. "
+                f"Missing for ('aptamer_sequence', 'target_sequence'): "
+                f"{missing_schema_two}."
             )
         pairs = zip(X[apt_col], X[prot_col], strict=False)
     else:

--- a/pyaptamer/utils/_aptanet_utils.py
+++ b/pyaptamer/utils/_aptanet_utils.py
@@ -60,7 +60,8 @@ def generate_kmer_vecs(aptamer_sequence, k=4):
 def pairs_to_features(X, k=4):
     """
     Convert a list of (aptamer_sequence, protein_sequence) pairs into feature vectors.
-    Also supports a pandas DataFrame with 'aptamer' and 'protein' columns.
+    Also supports a pandas DataFrame with ('aptamer', 'protein') or
+    ('aptamer_sequence', 'target_sequence') columns.
 
     This function generates feature vectors for each (aptamer, protein) pair using:
 
@@ -71,7 +72,8 @@ def pairs_to_features(X, k=4):
     ----------
     X : list of tuple of str or pandas.DataFrame
         A list where each element is a tuple `(aptamer_sequence, protein_sequence)`,
-        or a DataFrame containing 'aptamer' and 'protein' columns.
+        or a DataFrame containing either ('aptamer', 'protein') or
+        ('aptamer_sequence', 'target_sequence') columns.
 
     k : int, optional
         The k-mer size used to generate the k-mer vector from the aptamer sequence.
@@ -87,7 +89,16 @@ def pairs_to_features(X, k=4):
     feats = []
 
     if isinstance(X, pd.DataFrame):
-        pairs = zip(X["aptamer"], X["protein"], strict=False)
+        if "aptamer" in X.columns and "protein" in X.columns:
+            apt_col, prot_col = "aptamer", "protein"
+        elif "aptamer_sequence" in X.columns and "target_sequence" in X.columns:
+            apt_col, prot_col = "aptamer_sequence", "target_sequence"
+        else:
+            raise KeyError(
+                "DataFrame must contain either ('aptamer', 'protein') "
+                "or ('aptamer_sequence', 'target_sequence') columns."
+            )
+        pairs = zip(X[apt_col], X[prot_col], strict=False)
     else:
         pairs = X
 


### PR DESCRIPTION
Reference Issues/PRs
Fixes #310.

What does this implement/fix? Explain your changes.
Fixes KeyError: 'aptamer' in AptaNetPipeline.fit() when using AptaCom DataFrame (aptamer_sequence, target_sequence).

Changes:
Added support for both schemas in pairs_to_features:
aptamer / protein
aptamer_sequence / target_sequence
Improved error message if columns are missing
Updated docstrings

What should a reviewer concentrate their feedback on?
Column detection logic robustness
Docstring clarity
Error message usefulness

Did you add any tests for the change?
Manually verified using the issue’s reproduction script (no new tests added).

Any other comments?
Ensures smooth usage with load_aptacom_x_y(return_X_y=True).

PR checklist:
 Title follows format [BUG]
 Verified fix (manual test)
 Used pre-commit hooks