### PR TITLE
[BUG] MCTS: initialize TreeNode n_visits at 0 and guard UCT for unvisited nodes

### DIFF
--- a/pyaptamer/mcts/_algorithm.py
+++ b/pyaptamer/mcts/_algorithm.py
@@ -377,7 +377,7 @@ class TreeNode:
     >>> print(node.uct_score())
     inf
     >>> print(child.uct_score())  # doctest: +SKIP
-    np.float64(0.6663)
+    np.float64(0.5)
     """
 
     def __init__(
@@ -398,7 +398,7 @@ class TreeNode:
         self.is_terminal = is_terminal
         self.exploitation_score = exploitation_score
 
-        self.n_visits = 1
+        self.n_visits = 0
         self.children = {}
 
     def is_fully_expanded(self) -> bool:
@@ -427,6 +427,10 @@ class TreeNode:
             The UCT score for this node.
         """
         if self.parent is None:
+            return float("inf")
+
+        # unvisited nodes get infinite UCT to guarantee first exploration
+        if self.n_visits == 0:
             return float("inf")
 
         # exploration term

--- a/pyaptamer/mcts/_algorithm.py
+++ b/pyaptamer/mcts/_algorithm.py
@@ -426,11 +426,8 @@ class TreeNode:
         float
             The UCT score for this node.
         """
-        if self.parent is None:
-            return float("inf")
-
-        # unvisited nodes get infinite UCT to guarantee first exploration
-        if self.n_visits == 0:
+        # unvisited nodes (including root) get infinite UCT to guarantee exploration
+        if self.parent is None or self.n_visits == 0:
             return float("inf")
 
         # exploration term

--- a/pyaptamer/mcts/tests/test_mcts.py
+++ b/pyaptamer/mcts/tests/test_mcts.py
@@ -58,7 +58,7 @@ class TestTreeNode:
         assert node2.is_root is False
         assert node2.is_terminal is True
         assert node2.exploitation_score == 0.1
-        assert node2.n_visits == 1
+        assert node2.n_visits == 0
         assert len(node2.children) == 0
 
     def test_is_fully_expanded(self, root):
@@ -77,7 +77,15 @@ class TestTreeNode:
         # check whether the correct value is returned
         child.backpropagate(score=0.5)
         new_uct_score = child.uct_score()
-        assert new_uct_score == pytest.approx(0.6663, rel=1e-4)
+        # after 1 backprop: exploitation = 0.5/1 = 0.5,
+        # exploration = sqrt(log(1)/(2*1)) = 0
+        assert new_uct_score == pytest.approx(0.5, rel=1e-4)
+
+    def test_uct_score_unvisited(self, root, val):
+        """Test that an unvisited node returns inf to guarantee first exploration."""
+        child = root.create_child(val=val, is_terminal=True)
+        assert child.n_visits == 0
+        assert child.uct_score() == float("inf")
 
     def test_uct_score_parent_none(self, root):
         """Test UCT score calculation when parent is None, should return inf."""
@@ -157,9 +165,9 @@ class TestTreeNode:
         child2.backpropagate(score=10.0)
 
         # check that visits are updated
-        assert root.n_visits == 2
-        assert child1.n_visits == 2
-        assert child2.n_visits == 2
+        assert root.n_visits == 1
+        assert child1.n_visits == 1
+        assert child2.n_visits == 1
         # check that (exploitation) scores are updated
         assert root.exploitation_score == 0.0
         assert child1.exploitation_score == 10.0


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #483

#### What does this implement/fix? Explain your changes.

`TreeNode.n_visits` was initialised to `1`, giving every new node a phantom visit before any simulation reached it. After the first real `backpropagate()`, `n_visits` became `2` instead of `1`, diluting the exploitation term (`exploitation_score / n_visits`) by ~50% on the first update and biasing UCT toward exploration more than the standard formula intends.

Changes:
- Set `TreeNode.n_visits = 0` in `__init__` (was `1`).
- `uct_score()` now returns `float("inf")` when `n_visits == 0` (standard MCTS behaviour to guarantee first exploration of each child).
- Updated existing tests to reflect the correct visit counts and UCT value.
- Added `test_uct_score_unvisited` to cover the new `inf` guard.

Reproducer from the issue now behaves correctly:

```python
from pyaptamer.mcts._algorithm import TreeNode

child = TreeNode().create_child(val="A_", is_terminal=True)
print(child.uct_score())                          # inf (was a real number)
child.backpropagate(score=0.5)
print(child.n_visits)                             # 1   (was 2)
print(child.exploitation_score / child.n_visits)  # 0.5 (was 0.25)
```

#### What should a reviewer concentrate their feedback on?

- Whether returning `inf` for unvisited nodes in `uct_score()` is the preferred style, vs. handling the unvisited case at the selection site.
- Whether the updated expected values in the existing tests look correct.

#### Did you add any tests for the change?

Yes. Added `test_uct_score_unvisited` (asserts `uct_score == inf` for a freshly created child). Updated `test_init`, `test_uct_score`, and `test_backpropagate` to reflect the new visit counts and UCT value. All 43 tests in `pyaptamer/mcts/tests/test_mcts.py` pass, and the module doctests pass.

#### Any other comments?

The current behaviour appears to be inherited from the original AptaTrans reference implementation ([PNUMLB/AptaTrans/mcts.py](https://github.com/PNUMLB/AptaTrans/blob/master/mcts.py)), which also has `self.visits = 1`.

#### PR checklist

- [x] The PR title starts with `[BUG]`.
- [x] Added/modified tests.
- [x] Used pre-commit hooks when committing.