### PR TITLE
[BUG] Fix y_masked cloned from x instead of y in MaskedDataset.__getitem__

### DIFF
--- a/pyaptamer/datasets/dataclasses/_masked.py
+++ b/pyaptamer/datasets/dataclasses/_masked.py
@@ -151,7 +151,7 @@ class MaskedDataset(Dataset):
         y = torch.tensor(self.y[index], dtype=torch.int64)
 
         x_masked = x.clone().detach()
-        y_masked = x.clone().detach()
+        y_masked = y.clone().detach()
 
         # non-padding positions (0 is padding)
         seq_len = torch.sum(x_masked > 0)

--- a/pyaptamer/datasets/tests/test_masked_dataset.py
+++ b/pyaptamer/datasets/tests/test_masked_dataset.py
@@ -1,0 +1,50 @@
+import numpy as np
+import pytest
+
+from pyaptamer.datasets.dataclasses import MaskedDataset
+
+
+@pytest.fixture
+def dataset():
+    x = [[1, 2, 3, 4, 0], [2, 1, 4, 3, 0]]
+    y = [[5, 6, 7, 8, 0], [6, 5, 8, 7, 0]]
+    return MaskedDataset(x, y, max_len=5, mask_idx=9, masked_rate=0.2)
+
+
+def test_getitem_returns_four_tensors(dataset):
+    x_masked, y_masked, x, y = dataset[0]
+    assert x_masked.shape == (5,)
+    assert y_masked.shape == (5,)
+    assert x.shape == (5,)
+    assert y.shape == (5,)
+
+
+def test_y_masked_derived_from_y_not_x(dataset):
+    """y_masked should contain values from y, not from x."""
+    x_masked, y_masked, x_orig, y_orig = dataset[0]
+    non_zero = y_masked[y_masked != 0]
+    for val in non_zero:
+        assert val.item() in y_orig.tolist()
+
+
+def test_original_tensors_match_input(dataset):
+    _, _, x, y = dataset[0]
+    np.testing.assert_array_equal(x.numpy(), [1, 2, 3, 4, 0])
+    np.testing.assert_array_equal(y.numpy(), [5, 6, 7, 8, 0])
+
+
+def test_length(dataset):
+    assert len(dataset) == 2
+
+
+def test_mismatched_lengths_raises():
+    with pytest.raises(ValueError, match="same length"):
+        MaskedDataset([[1, 2]], [[1, 2], [3, 4]], max_len=2, mask_idx=9)
+
+
+def test_rna_masking():
+    x = [[1, 2, 3, 4, 5]]
+    y = [[1, 2, 3, 4, 5]]
+    ds = MaskedDataset(x, y, max_len=5, mask_idx=9, masked_rate=0.5, is_rna=True)
+    x_masked, _, _, _ = ds[0]
+    assert (x_masked == 9).any()


### PR DESCRIPTION
<!--
Welcome to pyaptamer, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
Fixes #485 

#### What does this implement/fix? Explain your changes.
   
MaskedDataset.__getitem__ was cloning x instead of y when creating y_masked (line 154 of _masked.py). This caused the masked training target to contain input sequence values rather than target sequence values. The bug is invisible when x == y but corrupts masked language model     training when they differ.
                                                                                                                                                                                                                                                                                           
  Fix: changed y_masked = x.clone().detach() to y_masked = y.clone().detach().                                                                                                                                                                                                             
   


#### What should a reviewer concentrate their feedback on?

  - The one-line fix in _masked.py:154                                                                                                                                                                                                                                                     
  - The new test test_y_masked_derived_from_y_not_x which uses different x and y values to verify the fix


#### Did you add any tests for the change?
  Yes, added pyaptamer/datasets/tests/test_masked_dataset.py

#### Any other comments?
<!--
We value all user contributions, no matter how small or complex they are. If you have any questions, feel free to post
in the dev-chat channel on the pyaptamer discord channel in gc-os server https://discord.gg/7uKdHfdcJG. If we are slow to review (>7 working days), likewise feel free to ping us on discord. Thank you for your understanding during the review process.
-->

#### PR checklist


- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.


<!--
Thanks for contributing!
-->
