### PR TITLE
[BUG] fix clean_protein_seq to use 'X' for unknown residues and add t…

### DIFF
--- a/pyaptamer/utils/_pseaac_utils.py
+++ b/pyaptamer/utils/_pseaac_utils.py
@@ -11,7 +11,7 @@ is used for efficient membership testing.
 Functions
 ---------
 clean_protein_seq(seq)
-    Replaces invalid amino acids with "N" and warn the user.
+    Replaces invalid amino acids with "X" and warns the user.
 """
 
 AMINO_ACIDS = list("ACDEFGHIKLMNPQRSTVWY")
@@ -19,7 +19,7 @@ AMINO_ACIDS = list("ACDEFGHIKLMNPQRSTVWY")
 
 def clean_protein_seq(seq):
     """
-    Replace invalid amino acids with "N" and warn the user.
+    Replaces invalid amino acids with "X" and warns the user.
 
     Parameters
     ----------
@@ -30,7 +30,7 @@ def clean_protein_seq(seq):
     -------
     str
         Cleaned protein sequence where all invalid characters have been replaced
-        with "N".
+        with "X".
     """
     import warnings
 
@@ -41,12 +41,12 @@ def clean_protein_seq(seq):
         if aa in AMINO_ACIDS:
             cleaned.append(aa)
         else:
-            cleaned.append("N")
+            cleaned.append("X")
             invalid_found = True
 
     if invalid_found:
         warnings.warn(
-            "Invalid amino acid(s) found in sequence. Replaced with 'N'.",
+           "Invalid amino acid(s) found in sequence. Replaced with 'X'.",
             UserWarning,
             stacklevel=2,
         )

--- a/pyaptamer/utils/_pseaac_utils.py
+++ b/pyaptamer/utils/_pseaac_utils.py
@@ -46,7 +46,7 @@ def clean_protein_seq(seq):
 
     if invalid_found:
         warnings.warn(
-           "Invalid amino acid(s) found in sequence. Replaced with 'X'.",
+            "Invalid amino acid(s) found in sequence. Replaced with 'X'.",
             UserWarning,
             stacklevel=2,
         )

--- a/pyaptamer/utils/tests/test_pseaac_utils.py
+++ b/pyaptamer/utils/tests/test_pseaac_utils.py
@@ -1,0 +1,20 @@
+import pytest
+from pyaptamer.utils._pseaac_utils import clean_protein_seq
+
+
+def test_clean_protein_seq_valid():
+    seq = "ACDEFGHIKLMNPQRSTVWY"
+    result = clean_protein_seq(seq)
+    assert result == seq
+
+
+def test_clean_protein_seq_invalid_replaced_with_X():
+    seq = "ABZ*"
+    result = clean_protein_seq(seq)
+    assert result == "AXXX"
+
+
+def test_clean_protein_seq_warns():
+    seq = "ABZ*"
+    with pytest.warns(UserWarning, match="Replaced with 'X'"):
+        clean_protein_seq(seq)

--- a/pyaptamer/utils/tests/test_pseaac_utils.py
+++ b/pyaptamer/utils/tests/test_pseaac_utils.py
@@ -1,4 +1,5 @@
 import pytest
+
 from pyaptamer.utils._pseaac_utils import clean_protein_seq
 
 
@@ -8,7 +9,7 @@ def test_clean_protein_seq_valid():
     assert result == seq
 
 
-def test_clean_protein_seq_invalid_replaced_with_X():
+def test_clean_protein_seq_invalid_replaced_with_x():
     seq = "ABZ*"
     result = clean_protein_seq(seq)
     assert result == "AXXX"


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #480

#### What does this implement/fix? Explain your changes.
This PR fixes an issue in `clean_protein_seq` where invalid or unknown amino acid residues were previously replaced with `"N"`.

However, `"N"` represents Asparagine, which is a valid amino acid. Replacing unknown residues with `"N"` can introduce incorrect biological meaning into the sequence.

This PR updates the behavior to replace unknown residues with `"X"`, which is the standard placeholder for unknown amino acids.

#### What changes were made?
- Replaced `"N"` with `"X"` for invalid residues
- Updated warning message accordingly
- Updated docstrings for consistency
- Added unit tests to verify correct behavior

#### What should a reviewer concentrate their feedback on?
- Correctness of replacement logic (`"X"` vs `"N"`)
- Consistency of docstrings and warning message
- Coverage of added tests

#### Did you add any tests for the change?
Yes. Tests were added to ensure:
- valid sequences remain unchanged
- invalid residues are replaced with `"X"`
- warnings are raised correctly

#### Any other comments?
All relevant tests pass locally. One unrelated test (`test_download_structure`) fails due to SSL/certificate issues during external data download, which is not affected by this change.

#### PR checklist
- [x] The PR title starts with [BUG]
- [x] Added/modified tests
- [ ] Used pre-commit hooks