### PR TITLE
[BUG] Add missing  in AptaNetPipeline.fit()

### DIFF
--- a/pyaptamer/aptanet/_pipeline.py
+++ b/pyaptamer/aptanet/_pipeline.py
@@ -59,6 +59,7 @@ class AptaNetPipeline(BaseObject, BaseEstimator):
     >>> y_train = np.array([0] * 20 + [1] * 20, dtype=np.float32)
     >>> X_test_pairs = [(aptamer_seq, protein_seq) for _ in range(10)]
     >>> pipe.fit(X_train_pairs, y_train)  # doctest: +ELLIPSIS
+    AptaNetPipeline(...)
     >>> preds = pipe.predict(X_test_pairs)
     >>> proba = pipe.predict_proba(X_test_pairs)
     """
@@ -79,6 +80,7 @@ class AptaNetPipeline(BaseObject, BaseEstimator):
     def fit(self, X, y):
         self.pipeline_ = self._build_pipeline()
         self.pipeline_.fit(X, y)
+        return self
 
     def predict_proba(self, X):
         check_is_fitted(self)


### PR DESCRIPTION
<!--
Welcome to pyaptamer, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
Fixes: #488 

#### What does this implement/fix? Explain your changes.
 Added return self to AptaNetPipeline.fit() to follow scikit-learn's estimator convention. Both AptaNetClassifier.fit() and AptaNetRegressor.fit() already return self, this was the only one missing it. Also updated the doctest to expect the repr output.


#### What should a reviewer concentrate their feedback on?

  - The one-line fix in _pipeline.py:82                                                                                                                                  
  - The doctest update on line 62 to match the new return value


#### Did you add any tests for the change?
No

#### Any other comments?
None

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
- [ ] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
  To run hooks independent of commit, execute `pre-commit run --all-files`

<!--
Thanks for contributing!
-->
