### PR TITLE
[BUG] Fix AptaNetPipeline.fit() missing return self

### DIFF
--- a/pyaptamer/aptanet/_pipeline.py
+++ b/pyaptamer/aptanet/_pipeline.py
@@ -79,6 +79,7 @@ class AptaNetPipeline(BaseObject, BaseEstimator):
     def fit(self, X, y):
         self.pipeline_ = self._build_pipeline()
         self.pipeline_.fit(X, y)
+        return self
 
     def predict_proba(self, X):
         check_is_fitted(self)


### PR DESCRIPTION
#### Reference Issues/PRs
Resolves #488, #467, and #448.

#### What does this implement/fix? Explain your changes.
Added the missing `return self` to the end of `AptaNetPipeline.fit()`. This ensures the pipeline strictly adheres to the scikit-learn estimator contract, fixing the bug where method chaining like `pipeline.fit(X, y).predict(X)` would throw an error because it previously returned `None`.

#### What should a reviewer concentrate their feedback on?
* N/A. Trivial fix.

#### Did you add any tests for the change?
- [x] Verified that the existing `sklearn_compatible_estimator` tests in `test_aptanet.py` now pass completely.
