### PR TITLE
[BUG] Fix MCTS TreeNode initialized with phantom visit

### DIFF
--- a/pyaptamer/mcts/_algorithm.py
+++ b/pyaptamer/mcts/_algorithm.py
@@ -398,7 +398,7 @@ class TreeNode:
         self.is_terminal = is_terminal
         self.exploitation_score = exploitation_score
 
-        self.n_visits = 1
+        self.n_visits = 0
         self.children = {}
 
     def is_fully_expanded(self) -> bool:
@@ -426,7 +426,7 @@ class TreeNode:
         float
             The UCT score for this node.
         """
-        if self.parent is None:
+        if self.parent is None or self.n_visits == 0:
             return float("inf")
 
         # exploration term

--- a/pyaptamer/mcts/tests/test_mcts.py
+++ b/pyaptamer/mcts/tests/test_mcts.py
@@ -58,7 +58,7 @@ class TestTreeNode:
         assert node2.is_root is False
         assert node2.is_terminal is True
         assert node2.exploitation_score == 0.1
-        assert node2.n_visits == 1
+        assert node2.n_visits == 0
         assert len(node2.children) == 0
 
     def test_is_fully_expanded(self, root):
@@ -77,7 +77,7 @@ class TestTreeNode:
         # check whether the correct value is returned
         child.backpropagate(score=0.5)
         new_uct_score = child.uct_score()
-        assert new_uct_score == pytest.approx(0.6663, rel=1e-4)
+        assert new_uct_score == pytest.approx(0.5, rel=1e-4)
 
     def test_uct_score_parent_none(self, root):
         """Test UCT score calculation when parent is None, should return inf."""
@@ -157,9 +157,9 @@ class TestTreeNode:
         child2.backpropagate(score=10.0)
 
         # check that visits are updated
-        assert root.n_visits == 2
-        assert child1.n_visits == 2
-        assert child2.n_visits == 2
+        assert root.n_visits == 1
+        assert child1.n_visits == 1
+        assert child2.n_visits == 1
         # check that (exploitation) scores are updated
         assert root.exploitation_score == 0.0
         assert child1.exploitation_score == 10.0


### PR DESCRIPTION
#### Reference Issues/PRs
Resolves #483.

#### What does this implement/fix? Explain your changes.
Fixed a bug in the Monte Carlo Tree Search algorithm where `TreeNode` instances were being initialized with `self.n_visits = 1` instead of `0`. This phantom visit artificially skewed the UCT (Upper Confidence Bound) calculations during the initial exploration phase. 

Changes made:
- Updated `TreeNode.__init__` to start with 0 visits.
- Updated `uct_score()` to safely handle `self.n_visits == 0` by returning `inf` (ensuring unvisited nodes are strictly prioritized for exploration, per standard MCTS implementation).
- Corrected the expected values in the `test_mcts.py` test suite that were previously asserting against the skewed math.

#### What should a reviewer concentrate their feedback on?
* N/A

#### Did you add any tests for the change?
- [x] Verified existing MCTS tests pass with corrected assertions.
