### PR TITLE
[BUG] Make AptaTrans pretrained weights path CWD-independent

### DIFF
--- a/pyaptamer/aptatrans/_model.py
+++ b/pyaptamer/aptatrans/_model.py
@@ -265,9 +265,7 @@ class AptaTrans(nn.Module):
 
         If the weights are not found locally, they will be downloaded from hugging face.
         """
-        path = os.path.relpath(
-            os.path.join(os.path.dirname(__file__), ".", "weights", "pretrained.pt")
-        )
+        path = os.path.join(os.path.dirname(__file__), "weights", "pretrained.pt")
 
         if os.path.exists(path):
             print(f"Loading pretrained weights from {path}...")

--- a/pyaptamer/aptatrans/tests/test_aptatrans.py
+++ b/pyaptamer/aptatrans/tests/test_aptatrans.py
@@ -2,10 +2,13 @@
 
 __author__ = ["nennomp"]
 
+from pathlib import Path
+
 import pytest
 import torch
 import torch.nn as nn
 
+import pyaptamer.aptatrans._model as aptatrans_model
 from pyaptamer.aptatrans import AptaTrans, AptaTransPipeline, EncoderPredictorConfig
 
 
@@ -158,6 +161,100 @@ class TestAptaTransModel:
         # output should be in [0, 1] (sigmoid activation)
         assert torch.all(output >= 0.0) and torch.all(output <= 1.0)
         assert not torch.allclose(output[0], output[1], atol=1e-5)
+
+    def test_load_pretrained_weights_uses_absolute_local_path(
+        self, embeddings, tmp_path, monkeypatch
+    ):
+        """Pretrained weights path should not depend on the current cwd."""
+        model = AptaTrans(
+            apta_embedding=embeddings[0],
+            prot_embedding=embeddings[1],
+            pretrained=False,
+        )
+
+        monkeypatch.chdir(tmp_path)
+
+        captured = {}
+
+        def fake_exists(path):
+            assert Path(path).is_absolute()
+            assert path.endswith("pretrained.pt")
+            return True
+
+        def fake_torch_load(path, map_location):
+            assert Path(path).is_absolute()
+            captured["path"] = path
+            captured["map_location"] = map_location
+            return {"dummy": torch.tensor(1.0)}
+
+        def fake_load_state_dict(self, state_dict, strict=True):
+            captured["state_dict"] = state_dict
+            captured["strict"] = strict
+
+        monkeypatch.setattr(aptatrans_model.os.path, "exists", fake_exists)
+        monkeypatch.setattr(aptatrans_model.torch, "load", fake_torch_load)
+        monkeypatch.setattr(AptaTrans, "load_state_dict", fake_load_state_dict)
+        monkeypatch.setattr(
+            aptatrans_model.torch.hub,
+            "load_state_dict_from_url",
+            lambda *args, **kwargs: pytest.fail(
+                "Remote download should not be used when local weights exist"
+            ),
+        )
+
+        model.load_pretrained_weights()
+
+        assert Path(captured["path"]).is_absolute()
+        assert captured["strict"] is True
+        assert "dummy" in captured["state_dict"]
+
+    def test_load_pretrained_weights_downloads_with_absolute_model_dir(
+        self, embeddings, tmp_path, monkeypatch
+    ):
+        """Download fallback should still use an absolute model_dir."""
+        model = AptaTrans(
+            apta_embedding=embeddings[0],
+            prot_embedding=embeddings[1],
+            pretrained=False,
+        )
+
+        monkeypatch.chdir(tmp_path)
+
+        captured = {}
+
+        def fake_exists(path):
+            assert Path(path).is_absolute()
+            return False
+
+        def fake_load_state_dict_from_url(url, model_dir, map_location):
+            captured["url"] = url
+            captured["model_dir"] = model_dir
+            captured["map_location"] = map_location
+            return {"dummy": torch.tensor(1.0)}
+
+        def fake_load_state_dict(self, state_dict, strict=True):
+            captured["state_dict"] = state_dict
+            captured["strict"] = strict
+
+        monkeypatch.setattr(aptatrans_model.os.path, "exists", fake_exists)
+        monkeypatch.setattr(
+            aptatrans_model.torch.hub,
+            "load_state_dict_from_url",
+            fake_load_state_dict_from_url,
+        )
+        monkeypatch.setattr(AptaTrans, "load_state_dict", fake_load_state_dict)
+        monkeypatch.setattr(
+            aptatrans_model.torch, "load", lambda *args, **kwargs: pytest.fail(
+                "Local weights should not be loaded when they do not exist"
+            )
+        )
+
+        model.load_pretrained_weights()
+
+        assert Path(captured["model_dir"]).is_absolute()
+        assert Path(captured["model_dir"]).name == "weights"
+        assert captured["strict"] is True
+        assert "dummy" in captured["state_dict"]
 
 
 class MockAptaTransNeuralNet(nn.Module):


### PR DESCRIPTION

#### Reference Issues/PRs
Fixes #428

#### What does this implement/fix? Explain your changes.
This PR removes the `os.path.relpath()` wrapper from `AptaTrans.load_pretrained_weights()` so the pretrained weights path remains absolute and independent of the current working directory.

The existing logic now consistently checks the bundled weights file from the package location and, if it is missing, downloads the checkpoint using an absolute `model_dir` anchored to the package directory.

#### What should a reviewer concentrate their feedback on?
- Whether the pretrained-weights path is now stable across working directories.
- Whether the regression tests correctly exercise both the local-load and download fallback branches without network access.

#### Did you add any tests for the change?
Yes.
- Added a regression test that `load_pretrained_weights()` still uses an absolute local path when the working directory changes.
- Added a regression test that the download fallback still uses an absolute `model_dir`.

#### Any other comments?
The change is intentionally minimal and only affects pretrained-weight path handling.

#### PR checklist
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks.