### PR TITLE
[BUG] Add input validation to pairs_to_features

### DIFF
--- a/pyaptamer/utils/_aptanet_utils.py
+++ b/pyaptamer/utils/_aptanet_utils.py
@@ -69,9 +69,10 @@ def pairs_to_features(X, k=4):
 
     Parameters
     ----------
-    X : list of tuple of str or pandas.DataFrame
-        A list where each element is a tuple `(aptamer_sequence, protein_sequence)`,
-        or a DataFrame containing 'aptamer' and 'protein' columns.
+    X : iterable of tuple[str, str] or pandas.DataFrame
+        An iterable where each element is a tuple
+        `(aptamer_sequence, protein_sequence)`, or a DataFrame containing
+        'aptamer' and 'protein' columns.
 
     k : int, optional
         The k-mer size used to generate the k-mer vector from the aptamer sequence.
@@ -103,9 +104,15 @@ def pairs_to_features(X, k=4):
 
         pairs = zip(X["aptamer"], X["protein"], strict=False)
     else:
-        if not X:
+        try:
+            pairs = list(X)
+        except TypeError as exc:
+            raise ValueError(
+                "pairs_to_features() expects an iterable of pairs or a DataFrame."
+            ) from exc
+
+        if len(pairs) == 0:
             raise ValueError("pairs_to_features() requires at least one pair.")
-        pairs = X
 
     for pair in pairs:
         if not isinstance(pair, (tuple, list)) or len(pair) != 2:

--- a/pyaptamer/utils/_aptanet_utils.py
+++ b/pyaptamer/utils/_aptanet_utils.py
@@ -80,18 +80,47 @@ def pairs_to_features(X, k=4):
     Returns
     -------
     np.ndarray
-        A 2D NumPy array where each row corresponds to the concatenated feature vector
-        for a given (aptamer, protein) pair.
+    A 2D NumPy array where each row corresponds to the concatenated feature vector
+    for a given (aptamer, protein) pair.
     """
     pseaac = AptaNetPSeAAC()
     feats = []
 
+    if X is None:
+        raise ValueError("pairs_to_features() requires at least one pair.")
+
     if isinstance(X, pd.DataFrame):
+        required_columns = {"aptamer", "protein"}
+        missing_columns = required_columns.difference(X.columns)
+        if missing_columns:
+            missing = ", ".join(sorted(missing_columns))
+            raise ValueError(
+                "DataFrame input to pairs_to_features() is missing required "
+                f"column(s): {missing}."
+            )
+        if X.empty:
+            raise ValueError("pairs_to_features() requires at least one pair.")
+
         pairs = zip(X["aptamer"], X["protein"], strict=False)
     else:
+        if not X:
+            raise ValueError("pairs_to_features() requires at least one pair.")
         pairs = X
 
-    for aptamer_seq, protein_seq in pairs:
+    for pair in pairs:
+        if not isinstance(pair, (tuple, list)) or len(pair) != 2:
+            raise ValueError(
+                "Each input pair must contain exactly two values: "
+                "(aptamer_sequence, protein_sequence)."
+            )
+
+        aptamer_seq, protein_seq = pair
+        if not isinstance(aptamer_seq, str) or not isinstance(protein_seq, str):
+            raise ValueError(
+                "Each input pair must contain two strings: "
+                "(aptamer_sequence, protein_sequence)."
+            )
+
         kmer = generate_kmer_vecs(aptamer_seq, k=k)
         pseaac_vec = np.asarray(pseaac.transform(protein_seq))
         feats.append(np.concatenate([kmer, pseaac_vec]))

--- a/pyaptamer/utils/tests/test_aptanet_utils.py
+++ b/pyaptamer/utils/tests/test_aptanet_utils.py
@@ -71,6 +71,28 @@ def test_pairs_to_features_accepts_dataframe_input():
     assert feats.dtype == np.float32
 
 
+def test_pairs_to_features_accepts_iterable_input():
+    """Iterable inputs such as generators should be normalized safely."""
+    pairs = (
+        pair
+        for pair in [
+            ("ATGC", "ACDEFGHIKLMNPQRSTVWYACDEFGHIKLMNPQ"),
+            ("AAAA", "ACDEFGHIKLMNPQRSTVWYACDEFGHIKLMNPQ"),
+        ]
+    )
+
+    feats = pairs_to_features(pairs, k=2)
+
+    assert feats.shape[0] == 2
+    assert feats.dtype == np.float32
+
+
+def test_pairs_to_features_rejects_non_iterable():
+    """Non-iterable inputs should raise a clear ValueError."""
+    with pytest.raises(ValueError, match="expects an iterable of pairs or a DataFrame"):
+        pairs_to_features(123)
+
+
 def test_generate_kmer_vecs_basic_smoke():
     """A small smoke test keeps the k-mer helper covered."""
     vec = generate_kmer_vecs("ATGC", k=2)

--- a/pyaptamer/utils/tests/test_aptanet_utils.py
+++ b/pyaptamer/utils/tests/test_aptanet_utils.py
@@ -1,0 +1,78 @@
+"""Tests for AptaNet utility helpers."""
+
+__author__ = ["nennomp"]
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from pyaptamer.utils._aptanet_utils import generate_kmer_vecs, pairs_to_features
+
+
+def test_pairs_to_features_happy_path():
+    """Valid pairs should be converted to a float32 feature matrix."""
+    pairs = [
+        ("ATGC", "ACDEFGHIKLMNPQRSTVWYACDEFGHIKLMNPQ"),
+        ("AAAA", "ACDEFGHIKLMNPQRSTVWYACDEFGHIKLMNPQ"),
+    ]
+
+    feats = pairs_to_features(pairs, k=2)
+
+    assert isinstance(feats, np.ndarray)
+    assert feats.dtype == np.float32
+    assert feats.shape[0] == 2
+
+
+def test_pairs_to_features_rejects_empty_input():
+    """Empty input should raise a clear ValueError."""
+    with pytest.raises(ValueError, match="requires at least one pair"):
+        pairs_to_features([])
+
+
+@pytest.mark.parametrize(
+    "pairs",
+    [
+        [("ATGC",)],
+        [("ATGC", "ACDE", "EXTRA")],
+        [("ATGC", 123)],
+        [("ATGC", None)],
+        ["ATGC"],
+    ],
+)
+def test_pairs_to_features_rejects_malformed_pairs(pairs):
+    """Malformed input pairs should raise a clear ValueError."""
+    with pytest.raises(ValueError, match="Each input pair must contain"):
+        pairs_to_features(pairs)
+
+
+def test_pairs_to_features_rejects_missing_dataframe_columns():
+    """DataFrame input must provide both aptamer and protein columns."""
+    df = pd.DataFrame({"aptamer": ["ATGC"]})
+
+    with pytest.raises(ValueError, match="missing required column"):
+        pairs_to_features(df)
+
+
+def test_pairs_to_features_accepts_dataframe_input():
+    """DataFrame input with required columns should still work."""
+    df = pd.DataFrame(
+        {
+            "aptamer": ["ATGC", "AAAA"],
+            "protein": [
+                "ACDEFGHIKLMNPQRSTVWYACDEFGHIKLMNPQ",
+                "ACDEFGHIKLMNPQRSTVWYACDEFGHIKLMNPQ",
+            ],
+        }
+    )
+
+    feats = pairs_to_features(df, k=2)
+
+    assert feats.shape[0] == 2
+    assert feats.dtype == np.float32
+
+
+def test_generate_kmer_vecs_basic_smoke():
+    """A small smoke test keeps the k-mer helper covered."""
+    vec = generate_kmer_vecs("ATGC", k=2)
+    assert isinstance(vec, np.ndarray)
+    assert vec.ndim == 1


### PR DESCRIPTION

#### Reference Issues/PRs
Fixes #408

#### What does this implement/fix? Explain your changes.
This PR adds input validation to `pairs_to_features()` so malformed inputs fail fast with clear `ValueError` messages.

The helper now validates:
- empty input
- malformed pair lengths
- non-string aptamer/protein values
- missing `aptamer` / `protein` DataFrame columns

The feature extraction logic is unchanged for valid inputs.

#### What should a reviewer concentrate their feedback on?
- Whether the validation messages are clear enough for callers.
- Whether the accepted input forms remain backward-compatible for valid pair data.

#### Did you add any tests for the change?
Yes.
- Added regression tests for empty input, malformed pairs, non-string values, and missing DataFrame columns.
- Added a happy-path test to confirm valid list and DataFrame inputs still work.

#### Any other comments?
This is a narrow input-safety fix for the AptaNet utility path.

#### PR checklist
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks.