### PR TITLE
[BUG] Align MaskedDataset masking logic with standard BERT implementation

### DIFF
--- a/pyaptamer/datasets/dataclasses/_masked.py
+++ b/pyaptamer/datasets/dataclasses/_masked.py
@@ -85,6 +85,10 @@ class MaskedDataset(Dataset):
         self.box = np.array(list(range(max_len)))
         self.len = len(self.x)
 
+        # Determine vocabulary from dataset (excluding padding 0 and special mask_idx if present)
+        vocab = np.unique(self.x)
+        self.vocab = vocab[(vocab > 0) & (vocab != self.mask_idx)]
+
     def _mask_rna(self, x_masked: Tensor, mask_positions: list[int]) -> Tensor:
         """Mask adjacent nucleotides for RNA sequences.
 
@@ -123,14 +127,6 @@ class MaskedDataset(Dataset):
         """
         return self.len
 
-    # TODO: For now this method applies masking as originally intended in AptaTrans
-    # code. However, there may some errors:
-    # (1.) 80% of the positions are masked but the remaining 20% are not masked at all.
-    # In BERT, the remaining 20% are replaced with random tokens or 10% replaced with
-    # random tokens and 10% left unchanged.
-    # (2.) The masking has two sample phases, one with `self.masked_rate` and one with
-    # hardcoded `0.8 * self.masked_rate`. This means that the actual masking rate
-    # becomes `0.8 * self.masked_rate` which seems confusing and possibly not intended.
     def __getitem__(self, index: int) -> tuple[Tensor, Tensor, Tensor, Tensor]:
         """
         Get a single masked sequence sample.
@@ -165,15 +161,30 @@ class MaskedDataset(Dataset):
             pos for pos in valid_positions if pos not in mask_positions
         ]
 
-        # apply masking
-        actual_mask_positions = random.sample(
-            mask_positions, int(len(mask_positions) * 0.8)
-        )
-        x_masked[actual_mask_positions] = self.mask_idx
+        # shuffle to partition into 80% mask token, 10% random sequence token, 10% unchanged
+        random.shuffle(mask_positions)
+        n_mask = int(len(mask_positions) * 0.8)
+        n_rand = int(len(mask_positions) * 0.1)
 
-        # for RNA, also mask adjacent nucleotides for base pairing
-        if self.is_rna:
-            x_masked = self._mask_rna(x_masked, actual_mask_positions)
+        actual_mask_positions = mask_positions[:n_mask]
+        random_token_positions = mask_positions[n_mask:n_mask + n_rand]
+        # unchanged_positions = mask_positions[n_mask + n_rand:]  # implicit, left intact
+
+        # 1. replace with mask token (80%)
+        if actual_mask_positions:
+            x_masked[actual_mask_positions] = self.mask_idx
+
+            # for RNA, also mask adjacent nucleotides for base pairing
+            if self.is_rna:
+                x_masked = self._mask_rna(x_masked, actual_mask_positions)
+
+        # 2. replace with random token from dataset vocabulary (10%)
+        if random_token_positions and len(self.vocab) > 0:
+            rand_tokens = torch.tensor(
+                np.random.choice(self.vocab, len(random_token_positions)),
+                dtype=x_masked.dtype
+            )
+            x_masked[random_token_positions] = rand_tokens
 
         # zero out non-masked positions in target
         y_masked[no_mask_positions] = 0


### PR DESCRIPTION
## Reference Issues/PRs
Fixes #496

## What does this implement/fix? Explain your changes.
This PR resolves an underlying bug detailed in the codebase's `TODO` comments regarding `MaskedDataset.__getitem__` acting inconsistently with standard Masked Language Modeling frameworks. 

Previously, the sequence masking logic correctly identified the total number of items to mask (15%), but only replaced 80% of those with the `[MASK]` token, abandoning the standard 10% random token replacement and 10% unchanged sequence mechanic entirely.

**Changes:**
- **Dynamic Vocabulary Identification:** Added logic in `MaskedDataset.__init__` to explicitly determine valid, non-padded vocabulary tokens dynamically. 
- **True 80-10-10 Token Segregation:** Updated the masking operations in `__getitem__` to correctly shuffle and partition the `n_to_mask` tokens into the standard configuration (80% replaced with `mask_idx`, 10% replaced with a random token from the dynamic vocabulary, 10% unchanged).
- Removed stale `TODO` comments highlighting the old buggy behavior.

## What should a reviewer concentrate their feedback on?
- Please review the dynamic vocabulary generation in the `__init__` method. It derives the vocab directly from the unique values in the dataset array since a `vocab_size` parameter wasn't part of the original class signature. 
- Verify the indexing math mapping `mask_positions` perfectly across `x_masked` after `random.shuffle`.

## Did you add any tests for the change?
No new tests were explicitly added as this strictly corrects the probabilistic behavior of an already active Dataset component. I manually simulated testing on `MaskedDataset` extractions to ensure the probabilities generated accurately match 80/10/10 mathematical frequencies.

#### Any other comments?
N/A

#### PR checklist
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
- [ ] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. 
