### PR TITLE
[BUG] Fix AptaNetPipeline.fit to return self (sklearn compatibility)

### DIFF
--- a/pyaptamer/aptanet/_pipeline.py
+++ b/pyaptamer/aptanet/_pipeline.py
@@ -58,7 +58,7 @@ class AptaNetPipeline(BaseObject, BaseEstimator):
     >>> X_train_pairs = [(aptamer_seq, protein_seq) for _ in range(40)]
     >>> y_train = np.array([0] * 20 + [1] * 20, dtype=np.float32)
     >>> X_test_pairs = [(aptamer_seq, protein_seq) for _ in range(10)]
-    >>> pipe.fit(X_train_pairs, y_train)  # doctest: +ELLIPSIS
+    >>> _ = pipe.fit(X_train_pairs, y_train)
     >>> preds = pipe.predict(X_test_pairs)
     >>> proba = pipe.predict_proba(X_test_pairs)
     """
@@ -79,6 +79,7 @@ class AptaNetPipeline(BaseObject, BaseEstimator):
     def fit(self, X, y):
         self.pipeline_ = self._build_pipeline()
         self.pipeline_.fit(X, y)
+        return self
 
     def predict_proba(self, X):
         check_is_fitted(self)

--- a/pyaptamer/experiments/_aptamer_aptanet.py
+++ b/pyaptamer/experiments/_aptamer_aptanet.py
@@ -27,7 +27,7 @@ class AptamerEvalAptaNet(BaseAptamerEval):
     >>> pairs = [(aptamer_seq, protein_seq) for _ in range(5)]
     >>> labels = np.array([0] * 5, dtype=np.float32)
     >>> pipeline = AptaNetPipeline()
-    >>> pipeline.fit(pairs, labels)
+    >>> _ = pipeline.fit(pairs, labels)
     >>> target = "ACDEFACDEFACDEFACDEFACDEFACDEFACDEFACDEF"
     >>> experiment = AptamerEvalAptaNet(target, pipeline)
     >>> aptamer_candidate = "AUGGC"

--- a/pyaptamer/tests/test_pipeline.py
+++ b/pyaptamer/tests/test_pipeline.py
@@ -1,0 +1,14 @@
+import numpy as np
+from pyaptamer.aptanet import AptaNetPipeline
+
+def test_fit_returns_self():
+    aptamer = "AGCTTAGCGTACAGCTTAAAAGGGTTTCCCCTGCCCGCGTAC"
+    protein = "ACDEFGHIKLMNPQRSTVWYACDEFGHIKLMNPQRSTVWY"
+
+    X = [(aptamer, protein) for _ in range(10)]
+    y = np.array([0, 1] * 5, dtype=np.float32)
+
+    pipe = AptaNetPipeline()
+    result = pipe.fit(X, y)
+
+    assert result is pipe


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #448

#### What does this implement/fix? Explain your changes.

The fit() method of AptaNetPipeline was returning None, which is inconsistent with sklearn estimators.
This change makes fit() return self, so method chaining works as expected.
Doctests were also updated to reflect this behavior.

#### What should a reviewer concentrate their feedback on?

Correctness of returning self from fit()
Whether the doctest updates are appropriate
Consistency with sklearn-style estimator behavior

#### Did you add any tests for the change?

Yes, added a unit test to verify that fit() returns the pipeline instance.

#### Any other comments?

All tests pass locally except one online loader test that fails due to SSL/network issues, which seems unrelated to this change.

#### PR checklist
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
- [x] Added/modified tests
- [ ] Used pre-commit hooks when committing to ensure that code is compliant with hooks.

