### PR TITLE
[ENH] Add input validation to pairs_to_features and generate_kmer_vecs

### DIFF
--- a/pyaptamer/utils/_aptanet_utils.py
+++ b/pyaptamer/utils/_aptanet_utils.py
@@ -1,12 +1,15 @@
 __author__ = "satvshr"
 __all__ = ["generate_kmer_vecs", "pairs_to_features"]
 
+import warnings
 from itertools import product
 
 import numpy as np
 import pandas as pd
 
 from pyaptamer.pseaac import AptaNetPSeAAC
+
+_DNA_ALPHABET = frozenset("ACGT")
 
 
 def generate_kmer_vecs(aptamer_sequence, k=4):
@@ -19,16 +22,44 @@ def generate_kmer_vecs(aptamer_sequence, k=4):
     Parameters
     ----------
     aptamer_sequence : str
-        The DNA sequence of the aptamer.
+        The DNA sequence of the aptamer. Must be non-empty and consist of characters
+        from the DNA alphabet {A, C, G, T}. Characters outside this set are ignored
+        during counting, which will produce incorrect feature vectors. Consider calling
+        ``dna2rna`` first for RNA sequences containing 'U'.
     k : int, optional
-        Maximum k-mer length (default is 4).
+        Maximum k-mer length (default is 4). Must be >= 1.
 
     Returns
     -------
     np.ndarray
         1D numpy array of normalized frequency vector for all possible k-mers from
         length 1 to k.
+
+    Raises
+    ------
+    ValueError
+        If ``aptamer_sequence`` is empty.
+    ValueError
+        If ``k`` is less than 1.
     """
+    if not aptamer_sequence:
+        raise ValueError(
+            "aptamer_sequence must be a non-empty string, got an empty string."
+        )
+    if k < 1:
+        raise ValueError(f"k must be >= 1, got {k}.")
+
+    invalid = set(aptamer_sequence.upper()) - _DNA_ALPHABET
+    if invalid:
+        warnings.warn(
+            f"aptamer_sequence contains characters outside the DNA alphabet "
+            f"{{A, C, G, T}}: {sorted(invalid)}. These characters will be ignored "
+            "during k-mer counting, producing incorrect feature vectors. "
+            "For RNA sequences, call dna2rna() first to convert 'U' -> 'T'.",
+            UserWarning,
+            stacklevel=2,
+        )
+
     DNA_BASES = list("ACGT")
 
     # Generate all possible k-mers from 1 to k
@@ -82,16 +113,41 @@ def pairs_to_features(X, k=4):
     np.ndarray
         A 2D NumPy array where each row corresponds to the concatenated feature vector
         for a given (aptamer, protein) pair.
-    """
-    pseaac = AptaNetPSeAAC()
-    feats = []
 
+    Raises
+    ------
+    ValueError
+        If ``X`` is a DataFrame and is missing the required 'aptamer' or 'protein'
+        columns.
+    ValueError
+        If any aptamer or protein sequence is not a non-empty string.
+    """
     if isinstance(X, pd.DataFrame):
+        missing = [c for c in ("aptamer", "protein") if c not in X.columns]
+        if missing:
+            raise ValueError(
+                f"DataFrame is missing required column(s): {missing}. "
+                f"Found columns: {list(X.columns)}. "
+                "Expected a DataFrame with 'aptamer' and 'protein' columns."
+            )
         pairs = zip(X["aptamer"], X["protein"], strict=False)
     else:
         pairs = X
 
-    for aptamer_seq, protein_seq in pairs:
+    pseaac = AptaNetPSeAAC()
+    feats = []
+
+    for idx, (aptamer_seq, protein_seq) in enumerate(pairs):
+        if not isinstance(aptamer_seq, str) or not aptamer_seq:
+            raise ValueError(
+                f"aptamer sequence at index {idx} must be a non-empty string, "
+                f"got {type(aptamer_seq).__name__!r}: {aptamer_seq!r}."
+            )
+        if not isinstance(protein_seq, str) or not protein_seq:
+            raise ValueError(
+                f"protein sequence at index {idx} must be a non-empty string, "
+                f"got {type(protein_seq).__name__!r}: {protein_seq!r}."
+            )
         kmer = generate_kmer_vecs(aptamer_seq, k=k)
         pseaac_vec = np.asarray(pseaac.transform(protein_seq))
         feats.append(np.concatenate([kmer, pseaac_vec]))


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #507

#### What does this implement/fix? Explain your changes.

`pairs_to_features()` and `generate_kmer_vecs()` previously accepted malformed inputs silently, producing cryptic downstream errors or numerically incorrect feature vectors. This PR adds validation at the entry points of both functions.

**`pairs_to_features`**

- If `X` is a DataFrame, checks that both `'aptamer'` and `'protein'` columns exist. Raises `ValueError` listing the missing columns and the columns that were found — instead of a bare `KeyError('aptamer')` deep inside a `zip()` call.
- Validates that each aptamer and protein sequence is a non-empty string at the per-pair level, with an index-based error message pointing to the problematic row.

**`generate_kmer_vecs`**

- Raises `ValueError` for empty `aptamer_sequence` (previously caused a silent zero-vector or a confusing numpy error downstream).
- Raises `ValueError` for `k < 1`.
- Emits a `UserWarning` when the sequence contains characters outside `{A, C, G, T}` (e.g. RNA `U`), pointing users to `dna2rna()`. This catches the common mistake of passing RNA sequences without conversion, which previously produced silently wrong feature vectors.

#### What should a reviewer concentrate their feedback on?

- The wording and level of the `UserWarning` for non-ACGT characters — should this be a `ValueError` instead of a warning? I chose a warning to be non-breaking, but a stricter approach is defensible.
- Whether the per-pair index in the sequence-level `ValueError` message is useful enough.

#### Did you add any tests for the change?

The existing test suite covers the happy path. New tests for the error paths can be added; happy to add them in a follow-up or in this PR if preferred.

#### Any other comments?

`pairs_to_features` is used as a `FunctionTransformer` inside `AptaNetPipeline`, so unvalidated inputs previously surfaced as confusing sklearn pipeline errors. These changes make the error message point directly to the input problem.

#### PR checklist

- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks.