### PR TITLE
[DOC] Fix incorrect domain descriptions and parameter name in _rna.py docstrings

### DIFF
--- a/pyaptamer/utils/_rna.py
+++ b/pyaptamer/utils/_rna.py
@@ -22,7 +22,7 @@ def dna2rna(sequence: str) -> str:
 
     Parameters
     ----------
-    seq : str
+    sequence : str
         The DNA sequence to be converted.
 
     Returns
@@ -182,16 +182,16 @@ def encode_rna(
 ):
     """Encode RNA sequences into their numerical representations.
 
-    This function tokenizes protein sequences using a greedy longest-match approach,
-    where longer amino acid patterns are preferred over shorter ones. Sequences are
-    either trunacted or zero-padded to `max_len` tokens.
+    This function tokenizes RNA sequences using a greedy longest-match approach,
+    where longer nucleotide patterns are preferred over shorter ones. Sequences are
+    either truncated or zero-padded to `max_len` tokens.
 
     Parameters
     ----------
     sequences : list[str]
         List of RNA sequences to be encoded.
     words : dict[str, int]
-        A dictionary mappings RNA 3-mers to unique indices.
+        A dictionary mapping RNA 3-mers to unique indices.
     max_len : int
         Maximum length of each encoded sequence. Sequences will be truncated
         or padded to this length.


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #513

#### What does this implement/fix? Explain your changes.
Fixes four docstring errors in `pyaptamer/utils/_rna.py`:

| Location | Before | After |
|---|---|---|
| `dna2rna` param name (line 25) | `seq : str` | `sequence : str` |
| `encode_rna` description (line 185) | `"protein sequences"` | `"RNA sequences"` |
| `encode_rna` description (line 185) | `"amino acid patterns"` | `"nucleotide patterns"` |
| `encode_rna` typo (line 187) | `"trunacted"` | `"truncated"` |
| `encode_rna` grammar (line 194) | `"A dictionary mappings"` | `"A dictionary mapping"` |

The description of `encode_rna()` was copy-pasted from the protein encoder and never corrected — it described an RNA tokenizer as operating on "protein sequences" using "amino acid patterns". The `dna2rna()` parameter name mismatch (`seq` vs `sequence`) would cause a `TypeError` if the argument were passed as a keyword argument.

#### What should a reviewer concentrate their feedback on?
That the corrected `encode_rna()` description accurately reflects RNA / nucleotide processing.

#### Did you add any tests for the change?
- [ ] No tests added — docstring-only changes.

#### PR checklist
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
- [ ] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks.
