### PR TITLE
[ENH] Add comprehensive test coverage for AptaTrans model and lightning modules

### DIFF
--- a/pyaptamer/aptatrans/layers/tests/test_all_aptatrans_layers.py
+++ b/pyaptamer/aptatrans/layers/tests/test_all_aptatrans_layers.py
@@ -208,3 +208,19 @@ def test_interaction_map_mismatch_input_features(x_apta, x_prot):
         match="The number of features of `x_apta` and `x_prot` must match",
     ):
         interaction_map(x_apta, x_prot)
+
+
+@pytest.mark.parametrize(
+    "d_model, max_len, seq_len",
+    [(128, 10, 20), (256, 5, 15)],
+)
+def test_positional_encoding_exceeds_max_len(d_model, max_len, seq_len):
+    """Check PositionalEncoding raises AssertionError when input exceeds max_len."""
+    pe = PositionalEncoding(d_model=d_model, max_len=max_len)
+    x = torch.randn(1, seq_len, d_model)
+
+    with pytest.raises(
+        AssertionError,
+        match=f"Input sequence length {seq_len} exceeds maximum length {max_len}.",
+    ):
+        pe(x)

--- a/pyaptamer/aptatrans/tests/test_aptatrans.py
+++ b/pyaptamer/aptatrans/tests/test_aptatrans.py
@@ -2,6 +2,8 @@
 
 __author__ = ["nennomp"]
 
+from unittest.mock import patch
+
 import pytest
 import torch
 import torch.nn as nn
@@ -201,6 +203,121 @@ class TestAptaTransModel:
             f"Expected ({batch_size}, 1), got {tuple(output.shape)}. "
             f"seq_len_apta={seq_len_apta}, seq_len_prot={seq_len_prot}"
         )
+
+    def test_forward_encoder_invalid_type(
+        self,
+        embeddings: tuple[EncoderPredictorConfig, EncoderPredictorConfig],
+    ):
+        """Check ValueError is raised for invalid encoder_type."""
+        model = AptaTrans(
+            apta_embedding=embeddings[0],
+            prot_embedding=embeddings[1],
+            in_dim=32,
+            n_encoder_layers=2,
+            n_heads=4,
+        )
+
+        x_mt = torch.randint(0, 16, (2, 16))
+        x_ss = torch.randint(0, 16, (2, 16))
+
+        with pytest.raises(
+            ValueError,
+            match="Unknown encoder_type: invalid. Options are 'apta' or 'prot'.",
+        ):
+            model.forward_encoder(x=(x_mt, x_ss), encoder_type="invalid")
+
+    def test_init_pretrained_calls_load_weights(
+        self,
+        embeddings: tuple[EncoderPredictorConfig, EncoderPredictorConfig],
+        monkeypatch,
+    ):
+        """Check that pretrained=True triggers load_pretrained_weights()."""
+        load_called = False
+
+        def mock_load(self_inner):
+            nonlocal load_called
+            load_called = True
+
+        monkeypatch.setattr(AptaTrans, "load_pretrained_weights", mock_load)
+
+        AptaTrans(
+            apta_embedding=embeddings[0],
+            prot_embedding=embeddings[1],
+            in_dim=32,
+            n_encoder_layers=2,
+            n_heads=4,
+            pretrained=True,
+        )
+
+        assert load_called
+
+    def test_load_pretrained_weights_local_file(
+        self,
+        embeddings: tuple[EncoderPredictorConfig, EncoderPredictorConfig],
+        tmp_path,
+    ):
+        """Check load_pretrained_weights() loads from local file correctly."""
+        model = AptaTrans(
+            apta_embedding=embeddings[0],
+            prot_embedding=embeddings[1],
+            in_dim=32,
+            n_encoder_layers=2,
+            n_heads=4,
+        )
+
+        # save the model's state_dict to a temp file at the expected path
+        weights_dir = tmp_path / "weights"
+        weights_dir.mkdir()
+        weights_path = weights_dir / "pretrained.pt"
+        torch.save(model.state_dict(), weights_path)
+
+        # patch os.path functions inside _model so the path resolves to our temp file
+        with patch(
+            "pyaptamer.aptatrans._model.os.path.dirname",
+            return_value=str(tmp_path),
+        ):
+            model.load_pretrained_weights()
+
+        # verify all parameters were loaded correctly (state_dict round-trip)
+        saved_state = torch.load(weights_path, map_location="cpu")
+        for key, param in model.state_dict().items():
+            assert torch.equal(param, saved_state[key]), (
+                f"Parameter {key} mismatch after loading pretrained weights."
+            )
+
+    def test_load_pretrained_weights_download(
+        self,
+        embeddings: tuple[EncoderPredictorConfig, EncoderPredictorConfig],
+    ):
+        """Check load_pretrained_weights() downloads from HuggingFace when no local
+        file exists."""
+        model = AptaTrans(
+            apta_embedding=embeddings[0],
+            prot_embedding=embeddings[1],
+            in_dim=32,
+            n_encoder_layers=2,
+            n_heads=4,
+        )
+
+        expected_state_dict = model.state_dict()
+
+        with (
+            patch(
+                "pyaptamer.aptatrans._model.os.path.exists",
+                return_value=False,
+            ),
+            patch(
+                "pyaptamer.aptatrans._model.torch.hub.load_state_dict_from_url",
+                return_value=expected_state_dict,
+            ) as mock_download,
+        ):
+            model.load_pretrained_weights()
+
+        # verify the download function was called with the correct URL
+        mock_download.assert_called_once()
+        call_args = mock_download.call_args
+        url = call_args.kwargs.get("url", call_args.args[0] if call_args.args else "")
+        assert "huggingface.co" in url
 
 
 class MockAptaTransNeuralNet(nn.Module):

--- a/pyaptamer/aptatrans/tests/test_aptatrans_lightning.py
+++ b/pyaptamer/aptatrans/tests/test_aptatrans_lightning.py
@@ -6,7 +6,12 @@ import pytest
 import torch
 import torch.nn as nn
 
-from pyaptamer.aptatrans import AptaTransEncoderLightning, AptaTransLightning
+from pyaptamer.aptatrans import (
+    AptaTrans,
+    AptaTransEncoderLightning,
+    AptaTransLightning,
+    EncoderPredictorConfig,
+)
 
 
 @pytest.fixture
@@ -72,7 +77,7 @@ class TestAptaTransLightning:
     )
     @pytest.mark.parametrize(
         "step_method",
-        ["training_step", "test_step"],
+        ["training_step", "validation_step", "test_step"],
     )
     def test_step(self, lightning_model, batch_size, seq_len, step_method):
         """Check training_step and test_step compute loss correctly."""
@@ -128,3 +133,20 @@ class TestAptaTransEncoderLightning:
         assert isinstance(loss, torch.Tensor)
         assert loss.dim() == 0
         assert loss.item() >= 0
+
+    @pytest.mark.parametrize("encoder_type", ["apta", "prot"])
+    def test_configure_optimizers(self, encoder_type):
+        """Check configure_optimizers() returns correct params for each encoder type."""
+        embedding = EncoderPredictorConfig(num_embeddings=16, target_dim=16, max_len=16)
+        real_model = AptaTrans(
+            apta_embedding=embedding,
+            prot_embedding=embedding,
+            in_dim=32,
+            n_encoder_layers=2,
+            n_heads=4,
+        )
+        model = AptaTransEncoderLightning(real_model, encoder_type=encoder_type)
+        optimizer = model.configure_optimizers()
+
+        assert isinstance(optimizer, torch.optim.Adam)
+        assert optimizer.defaults["lr"] == model.lr


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #180. Supersedes #273.

#### What does this implement/fix? Explain your changes.

Adds comprehensive test coverage for `pyaptamer.aptatrans`, targeting all previously untested branches across `_model.py` and `_model_lightning.py`. Pure test additions — no production code changes.

**New tests added (3 files, 11 new test cases):**

`test_aptatrans.py`:
- `test_forward_encoder_invalid_type` — covers the `ValueError` branch in `forward_encoder()` for invalid `encoder_type` (line 329)
- `test_init_pretrained_calls_load_weights` — verifies `pretrained=True` triggers `load_pretrained_weights()` (line 171)
- `test_load_pretrained_weights_local_file` — covers the local file loading branch of `load_pretrained_weights()` (lines 268–274) using pytest `tmp_path` + `unittest.mock.patch`
- `test_load_pretrained_weights_download` — covers the HuggingFace download fallback branch (lines 275–287), mocking `torch.hub.load_state_dict_from_url`

`test_all_aptatrans_layers.py`:
- `test_positional_encoding_exceeds_max_len` — covers the `AssertionError` when input sequence length exceeds `max_len` (parametrized: 2 cases)

`test_aptatrans_lightning.py`:
- Added `validation_step` to the existing `test_step` parametrize (previously only `training_step` and `test_step` were tested) — covers `_model_lightning.py:152`
- `test_configure_optimizers` for `AptaTransEncoderLightning` — covers `_model_lightning.py:315–330` (parametrized: `apta`, `prot`)

#### Coverage before and after

| File | Before | After | Delta |
|---|---|---|---|
| `_model.py` | 88% (10 lines missed) | **100%** | **+12%** |
| `_model_lightning.py` | 88% (7 lines missed) | **100%** | **+12%** |
| `_pipeline.py` | 100% | 100% | — |
| `layers/_convolutional.py` | 100% | 100% | — |
| `layers/_encoder.py` | 100% | 100% | — |
| `layers/_interaction_map.py` | 100% | 100% | — |
| **TOTAL (`pyaptamer.aptatrans`)** | **96%** (21 lines missed) | **99%** (4 lines missed) | **+3%** |

The 4 remaining misses are CUDA-skip branches in the test files themselves — all production source files are at 100%.

**Lines previously missed, now covered:**

| File | Lines | Branch |
|---|---|---|
| `_model.py:171` | `if pretrained: self.load_pretrained_weights()` | constructor |
| `_model.py:268-274` | local file path in `load_pretrained_weights()` | local load |
| `_model.py:275-287` | HuggingFace download in `load_pretrained_weights()` | remote download |
| `_model.py:329` | `raise ValueError` in `forward_encoder()` | error branch |
| `_model_lightning.py:152` | `validation_step()` | lightning step |
| `_model_lightning.py:315-330` | `EncoderLightning.configure_optimizers()` | optimizer config |

**Test count: 61 → 72 (+11 tests). Runtime: 3.10s → 3.42s (+0.32s).**

#### Comparison with #273

PR #273 adds 1 test covering only the local file branch of `load_pretrained_weights()`. This PR covers the same branch plus 6 additional untested branches, using cleaner test patterns:

- Uses pytest `tmp_path` fixture instead of writing to the installed package directory
- Uses `unittest.mock.patch` instead of `__import__` hacks to locate module paths
- Tests the remote download branch (mocked), not just local loading
- No filesystem side effects — all temp files managed by pytest

#### What should a reviewer concentrate their feedback on?

- Whether `unittest.mock.patch` on `pyaptamer.aptatrans._model.os.path.dirname` is an acceptable approach for the local file loading test
- Whether mocking `torch.hub.load_state_dict_from_url` sufficiently covers the download path

#### Did you add any tests for the change?

Yes — this PR is entirely test additions. No production code was modified.

#### Any other comments?

All tests pass locally on Python 3.13.7 (macOS, CPU). The single skipped test is the existing CUDA parametrize, expected on CPU-only machines.

#### PR checklist

- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [MNT] - test coverage improvement.
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
  To run hooks independent of commit, execute `pre-commit run --all-files`