### PR TITLE
[BUG] fix undefined fixture reference in MCTS test suite

### DIFF
--- a/pyaptamer/mcts/tests/test_mcts.py
+++ b/pyaptamer/mcts/tests/test_mcts.py
@@ -30,12 +30,11 @@ def val_not_found():
 
 
 @pytest.fixture
-def tree_with_children(tree_node):
+def tree_with_children(root):
     """Provide a TreeNode with some children already added."""
     for val in ["A_", "C_", "G_"]:
-        tree_node.create_child(val=val)
-    return tree_node
-
+        root.create_child(val=val)
+    return root
 
 class TestTreeNode:
     """Tests for the TreeNode() class."""


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #517

#### What does this implement/fix? Explain your changes.
This PR fixes an undefined fixture reference in the MCTS test suite.

The `tree_with_children` fixture was returning a non-existent `tree_node`, which would cause a failure if the fixture were used. This has been corrected to return the existing `root` fixture.

#### What should a reviewer concentrate their feedback on?
- Correctness of the fixture fix (`tree_node` → `root`)
- Ensuring no unintended side effects in the test suite

#### Did you add any tests for the change?
No new tests were added. This is a small fix correcting an existing test fixture.

#### Any other comments?
All relevant tests pass locally. One unrelated test (`test_download_structure`) fails due to SSL/certificate issues during external data download, which is not affected by this change.

#### PR checklist
- [x] The PR title starts with [BUG]
- [ ] Added/modified tests
- [ ] Used pre-commit hooks