### PR TITLE
[BUG] Replace assert with ValueError in MCTS._reconstruct

### DIFF
--- a/pyaptamer/mcts/_algorithm.py
+++ b/pyaptamer/mcts/_algorithm.py
@@ -143,9 +143,10 @@ class MCTS(BaseObject):
         # if the sequence is not reconstructed yet, it should have an even length
         # because it should consist of pairs such as 'A_' and '_A' (i.e., nucleotide +
         # direction marker).
-        assert len(sequence) % 2 == 0, (
-            f"Encoded sequence must have even length, got {len(sequence)}."
-        )
+        if len(sequence) % 2 != 0:
+            raise ValueError(
+                f"Encoded sequence must have even length, got {len(sequence)}."
+            )
 
         # reconstruct
         result = ""

--- a/pyaptamer/mcts/tests/test_mcts.py
+++ b/pyaptamer/mcts/tests/test_mcts.py
@@ -292,6 +292,17 @@ class TestMCTS:
         # mixed prepend/append
         assert mcts._reconstruct("A_C__GU_") == "UCAG"
 
+    def test_reconstruct_odd_length_raises_value_error(self, mcts):
+        """_reconstruct must raise ValueError for odd-length encoded sequences.
+
+        Regression test for GH #521: the check was an assert statement, which
+        Python strips with -O, causing an IndexError instead of a clear error.
+        """
+        import pytest
+
+        with pytest.raises(ValueError, match="even length"):
+            mcts._reconstruct("A_C")  # length 3 – odd
+
     def test_selection_not_fully_expanded(self, mcts):
         """Check selection step when the node is not fully expanded."""
         # from root with no childrem, should return the root itself


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #521

#### What does this implement/fix? Explain your changes.

`MCTS._reconstruct` checked that the encoded sequence had even length using an `assert`:

```python
assert len(sequence) % 2 == 0, (
    f"Encoded sequence must have even length, got {len(sequence)}."
)
```

Python removes `assert` statements when run with `python -O` (or when bytecode is compiled with optimizations). Once stripped, an odd-length sequence that contains a `'_'` direction-marker reaches the loop body, where `sequence[i + 1]` raises an unguarded `IndexError` with no helpful message.

The fix replaces the `assert` with an explicit `ValueError`, consistent with how `MCTS.__init__` already validates `depth` and `n_iterations`:

```python
if len(sequence) % 2 != 0:
    raise ValueError(
        f"Encoded sequence must have even length, got {len(sequence)}."
    )
```

This guarantees the check runs regardless of the interpreter's optimization level.

#### What should a reviewer concentrate their feedback on?

The logic change is a one-for-one replacement of `assert` with `if ... raise ValueError`. The only other change is a new test.

#### Did you add any tests for the change?

Yes — `test_reconstruct_odd_length_raises_value_error` in `pyaptamer/mcts/tests/test_mcts.py` verifies that `_reconstruct("A_C")` (odd length) raises `ValueError` with the expected message.

#### PR checklist

- [x] The PR title starts with `[BUG]`
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure code is compliant