### PR TITLE
[FIX] Optimize dna2rna to linear time O(N) (#323)

### DIFF
--- a/pyaptamer/utils/_rna.py
+++ b/pyaptamer/utils/_rna.py
@@ -30,12 +30,9 @@ def dna2rna(sequence: str) -> str:
     str
         The converted RNA sequence.
     """
-    # replace nucleotides 'T' with 'U'
-    result = sequence.translate(str.maketrans("T", "U"))
-    for char in result:
-        if char not in "ACGU":
-            result = result.replace(char, "N")  # replace unknown nucleotides with 'N'
-    return result
+    
+    valid = {"A", "C", "G", "U"}
+    return "".join("U" if char == "T" else (char if char in valid else "N") for char in sequence)
 
 
 def generate_nplets(letters: list[str], repeat: int | Iterable[int]) -> dict[str, int]:


### PR DESCRIPTION
This PR resolves the O(N^2) performance bottleneck in `dna2rna` reported in #323. 

**Improvements:**
- Replaced the nested `.replace()` calls with a single-pass implementation, ensuring linear time complexity O(N).
- Strictly preserves existing behavior (case-sensitivity and 'ACGU' character set).
- Addresses feedback from PR #339 by keeping the implementation surgical and avoiding redundant or confusing tests.

Verified with local benchmarks: significant performance improvement for long sequences while maintaining 100% backward compatibility with the existing test suite.