### PR TITLE
[ENH] dual-encoder architecture for protein-conditioned aptamer generation

### DIFF
--- a/pyaptamer/aptamlm/__init__.py
+++ b/pyaptamer/aptamlm/__init__.py
@@ -1,0 +1,9 @@
+"""
+AptaMLM: dual-encoder model for protein-conditioned aptamer generation.
+"""
+
+__author__ = ["NoorMajdoub"]
+__all__ = ["AptaMLM", "AptaMLMPipeline"]
+
+from pyaptamer.aptamlm._model import AptaMLM
+from pyaptamer.aptamlm._pipeline import AptaMLMPipeline

--- a/pyaptamer/aptamlm/_model.py
+++ b/pyaptamer/aptamlm/_model.py
@@ -1,0 +1,262 @@
+"""
+AptaMLM dual-encoder model for protein-conditioned aptamer generation.
+"""
+
+__author__ = ["NoorMajdoub"]
+__all__ = ["ProteinModule", "NucleotideModule", "AptaMLM"]
+
+import torch
+import torch.nn as nn
+from torch import Tensor
+
+
+class ProteinModule(nn.Module):
+    """Protein encoder module for AptaMLM.
+
+    Takes frozen ESM2 hidden states and refines them via self-attention,
+    then projects to a shared model dimension used by the NucleotideModule.
+
+    Parameters
+    ----------
+    prot_dim : int, optional, default=1280
+        Hidden dimension of the upstream ESM2 encoder.
+    d_model : int, optional, default=128
+        Internal model dimension.
+    n_heads : int, optional, default=4
+        Number of attention heads. Must evenly divide ``d_model``.
+    n_layers : int, optional, default=3
+        Number of stacked self-attention + feedforward layers.
+    dropout : float, optional, default=0.1
+        Dropout probability applied inside the transformer layers.
+    """
+
+    def __init__(
+        self,
+        prot_dim: int = 1280,
+        d_model: int = 128,
+        n_heads: int = 4,
+        n_layers: int = 3,
+        dropout: float = 0.1,
+    ):
+        super().__init__()
+        self.proj = nn.Sequential(
+            nn.Linear(prot_dim, d_model),
+            nn.LayerNorm(d_model),
+        )
+        self.blocks = nn.ModuleList(
+            [
+                nn.TransformerEncoderLayer(
+                    d_model=d_model,
+                    nhead=n_heads,
+                    dim_feedforward=d_model * 4,
+                    dropout=dropout,
+                    batch_first=True,
+                    activation="gelu",
+                )
+                for _ in range(n_layers)
+            ]
+        )
+
+    def forward(self, x: Tensor, padding_mask: Tensor | None = None) -> Tensor:
+        x = self.proj(x)
+        for block in self.blocks:
+            x = block(x, src_key_padding_mask=padding_mask)
+        return x
+
+
+class CrossAttentionLayer(nn.Module):
+    """Cross-attention layer bridging the protein and nucleotide modules."""
+
+    def __init__(
+        self,
+        d_model: int = 128,
+        n_heads: int = 4,
+        dropout: float = 0.1,
+    ):
+        super().__init__()
+        self.attn = nn.MultiheadAttention(
+            embed_dim=d_model,
+            num_heads=n_heads,
+            dropout=dropout,
+            batch_first=True,
+        )
+        self.norm = nn.LayerNorm(d_model)
+        self.dropout = nn.Dropout(dropout)
+
+    def forward(
+        self,
+        nuc_repr: Tensor,
+        prot_repr: Tensor,
+        prot_key_padding_mask: Tensor | None = None,
+    ) -> Tensor:
+        attn_out, _ = self.attn(
+            query=nuc_repr,
+            key=prot_repr,
+            value=prot_repr,
+            key_padding_mask=prot_key_padding_mask,
+        )
+        return self.norm(nuc_repr + self.dropout(attn_out))
+
+
+class NucleotideModule(nn.Module):
+    """Nucleotide encoder module for AptaMLM.
+
+    Takes frozen NucleotideTransformer hidden states, refines them via
+    self-attention, then attends to the protein representation via
+    cross-attention.
+
+    Parameters
+    ----------
+    nuc_dim : int, optional, default=1280
+        Hidden dimension of the upstream NucleotideTransformer encoder.
+    d_model : int, optional, default=128
+        Internal model dimension. Must match ``ProteinModule.d_model``.
+    n_heads : int, optional, default=4
+        Number of attention heads. Must evenly divide ``d_model``.
+    n_layers : int, optional, default=3
+        Number of stacked self-attention layers applied before cross-attention.
+    dropout : float, optional, default=0.1
+        Dropout probability.
+    """
+
+    def __init__(
+        self,
+        nuc_dim: int = 1280,
+        d_model: int = 128,
+        n_heads: int = 4,
+        n_layers: int = 3,
+        dropout: float = 0.1,
+    ):
+        super().__init__()
+        self.proj = nn.Sequential(
+            nn.Linear(nuc_dim, d_model),
+            nn.LayerNorm(d_model),
+        )
+        self.self_attn_blocks = nn.ModuleList(
+            [
+                nn.TransformerEncoderLayer(
+                    d_model=d_model,
+                    nhead=n_heads,
+                    dim_feedforward=d_model * 4,
+                    dropout=dropout,
+                    batch_first=True,
+                    activation="gelu",
+                )
+                for _ in range(n_layers)
+            ]
+        )
+        self.cross_attn_blocks = nn.ModuleList(
+            [
+                CrossAttentionLayer(d_model, n_heads, dropout)
+                for _ in range(n_layers)
+            ]
+        )
+
+    def forward(
+        self,
+        nuc: Tensor,
+        prot: Tensor,
+        nuc_padding_mask: Tensor | None = None,
+        prot_padding_mask: Tensor | None = None,
+    ) -> Tensor:
+        nuc = self.proj(nuc)
+        for self_attn, cross_attn in zip(
+            self.self_attn_blocks, self.cross_attn_blocks
+        ):
+            nuc = self_attn(nuc, src_key_padding_mask=nuc_padding_mask)
+            nuc = cross_attn(nuc, prot, prot_key_padding_mask=prot_padding_mask)
+        return nuc
+
+
+class AptaMLM(nn.Module):
+    """Dual-encoder masked language model for aptamer generation.
+
+    Given a target protein sequence and a (partially masked) aptamer
+    sequence, predicts the identity of each masked nucleotide token.
+
+    Both frozen encoders (ESM2 and NucleotideTransformer) are kept fixed
+    during training so that only the lightweight bridge layers are updated.
+    This is appropriate given the small size of available protein-aptamer
+    binding datasets (~725 positive pairs in AptaTrans).
+
+    Parameters
+    ----------
+    prot_dim : int, optional, default=1280
+        Hidden dimension of ESM2 (650M variant outputs 1280).
+    nuc_dim : int, optional, default=1280
+        Hidden dimension of NucleotideTransformer.
+    d_model : int, optional, default=128
+        Shared internal dimension for both modules.
+    n_heads : int, optional, default=4
+        Number of attention heads. Must evenly divide ``d_model``.
+    n_layers : int, optional, default=3
+        Number of transformer layers in each module.
+    dropout : float, optional, default=0.1
+        Dropout probability.
+    vocab_size : int
+        Vocabulary size of the NucleotideTransformer tokenizer.
+    """
+
+    def __init__(
+        self,
+        prot_dim: int = 1280,
+        nuc_dim: int = 1280,
+        d_model: int = 128,
+        n_heads: int = 4,
+        n_layers: int = 3,
+        dropout: float = 0.1,
+        vocab_size: int = 4107,
+    ):
+        super().__init__()
+        self.protein_module = ProteinModule(
+            prot_dim, d_model, n_heads, n_layers, dropout
+        )
+        self.nuc_module = NucleotideModule(
+            nuc_dim, d_model, n_heads, n_layers, dropout
+        )
+        self.head = nn.Linear(d_model, vocab_size)
+
+    def forward(
+        self,
+        prot_hidden: Tensor,
+        nuc_hidden: Tensor,
+        prot_padding_mask: Tensor | None = None,
+        nuc_padding_mask: Tensor | None = None,
+    ) -> Tensor:
+        prot_repr = self.protein_module(prot_hidden, prot_padding_mask)
+        nuc_repr = self.nuc_module(
+            nuc_hidden, prot_repr, nuc_padding_mask, prot_padding_mask
+        )
+        return self.head(nuc_repr)
+
+
+def mask_tokens(
+    input_ids: Tensor,
+    mask_token_id: int,
+    mask_prob: float = 0.15,
+) -> tuple[Tensor, Tensor]:
+    """Randomly mask a fraction of nucleotide tokens for MLM training.
+
+    Parameters
+    ----------
+    input_ids : Tensor
+        Token ids of shape ``(batch, seq_len)``.
+    mask_token_id : int
+        The id of the ``[MASK]`` token in the nucleotide tokenizer vocabulary.
+    mask_prob : float, optional, default=0.15
+        Fraction of tokens to mask.
+
+    Returns
+    -------
+    masked_input_ids : Tensor
+        Token ids with masked positions replaced, same shape as ``input_ids``.
+    labels : Tensor
+        Ground-truth token ids at masked positions, ``-100`` elsewhere.
+    """
+    labels = input_ids.clone()
+    prob_matrix = torch.full(input_ids.shape, mask_prob)
+    mask = torch.bernoulli(prob_matrix).bool()
+    labels[~mask] = -100
+    masked_input_ids = input_ids.clone()
+    masked_input_ids[mask] = mask_token_id
+    return masked_input_ids, labels

--- a/pyaptamer/aptamlm/_pipeline.py
+++ b/pyaptamer/aptamlm/_pipeline.py
@@ -1,0 +1,200 @@
+"""
+AptaMLM pipeline for protein-conditioned aptamer generation.
+"""
+
+__author__ = ["NoorMajdoub"]
+__all__ = ["AptaMLMPipeline"]
+
+
+import torch
+from torch import Tensor
+from transformers import AutoModel, AutoModelForMaskedLM, AutoTokenizer
+
+from pyaptamer import logger
+from pyaptamer.aptamlm._model import AptaMLM
+
+
+class AptaMLMPipeline:
+    """AptaMLM pipeline for protein-conditioned aptamer generation.
+
+    Uses a dual-encoder architecture inspired by BAnG and PepMLM
+    to generate DNA/RNA aptamer sequences conditioned on a target protein
+    sequence. A frozen ESM2 protein encoder and a frozen NucleotideTransformer
+    aptamer encoder are bridged by learned cross-attention layers. At
+    inference time, all aptamer positions are initialised as ``[MASK]``
+    tokens and decoded given the protein context (Decoding strategy still not fixed).
+
+    Parameters
+    ----------
+    model : AptaMLM
+        An initialised ``AptaMLM`` model instance.
+    device : torch.device
+        Device on which to run inference.
+    esm2_model_name : str, optional, default="facebook/esm2_t33_650M_UR50D"
+        HuggingFace model identifier for the ESM2 protein encoder.
+    nt_model_name : str, optional,
+        default="InstaDeepAI/nucleotide-transformer-500m-human-ref"
+
+    Attributes
+    ----------
+    prot_tokenizer : transformers.PreTrainedTokenizer
+        Tokenizer for protein sequences (ESM2).
+    nuc_tokenizer : transformers.PreTrainedTokenizer
+        Tokenizer for nucleotide sequences (NucleotideTransformer).
+    prot_encoder : transformers.PreTrainedModel
+        Frozen ESM2 encoder.
+    nuc_encoder : transformers.PreTrainedModel
+        Frozen NucleotideTransformer encoder.
+
+
+    """
+
+    def __init__(
+        self,
+        model: AptaMLM,
+        device: torch.device,
+        esm2_model_name: str = "facebook/esm2_t33_650M_UR50D",
+        nt_model_name: str = (
+            "InstaDeepAI/nucleotide-transformer-500m-human-ref"
+        ),
+    ) -> None:
+        self.model = model.to(device)
+        self.device = device
+
+        logger.info("Loading ESM2 protein encoder from %s...", esm2_model_name)
+        self.prot_tokenizer = AutoTokenizer.from_pretrained(esm2_model_name)
+        self.prot_encoder = AutoModel.from_pretrained(esm2_model_name).to(device)
+        for param in self.prot_encoder.parameters():
+            param.requires_grad = False
+        self.prot_encoder.eval()
+
+        logger.info(
+            "Loading NucleotideTransformer encoder from %s...", nt_model_name
+        )
+        self.nuc_tokenizer = AutoTokenizer.from_pretrained(nt_model_name)
+        self.nuc_encoder = AutoModelForMaskedLM.from_pretrained(nt_model_name).to(
+            device
+        )
+        for param in self.nuc_encoder.parameters():
+            param.requires_grad = False
+        self.nuc_encoder.eval()
+
+    @torch.no_grad()
+    def _encode_protein(self, sequence: str) -> tuple[Tensor, Tensor]:
+        """Tokenize and encode a protein sequence with ESM2.
+
+        Parameters
+        ----------
+        sequence : str
+            Amino-acid sequence string.
+
+        Returns
+        -------
+        hidden : Tensor
+            ESM2 last hidden states of shape ``(1, seq_len_prot, 1280)``.
+        padding_mask : Tensor
+            Boolean padding mask of shape ``(1, seq_len_prot)``.
+            ``True`` indicates a padding position.
+        """
+        inputs = self.prot_tokenizer(
+            sequence,
+            return_tensors="pt",
+            padding=True,
+            truncation=True,
+        ).to(self.device)
+
+        outputs = self.prot_encoder(
+            **inputs,
+            output_hidden_states=True,
+        )
+        hidden = outputs.hidden_states[-1]
+        padding_mask = inputs["attention_mask"] == 0
+        return hidden, padding_mask
+
+    @torch.no_grad()
+    def _encode_aptamer(self, sequence: str) -> tuple[Tensor, Tensor]:
+        """Tokenize and encode an aptamer sequence with NucleotideTransformer.
+
+        Parameters
+        ----------
+        sequence : str
+            DNA/RNA nucleotide sequence string.
+
+        Returns
+        -------
+        hidden : Tensor
+            NucleotideTransformer last hidden states of shape
+            ``(1, seq_len_nuc, 1280)``.
+        padding_mask : Tensor
+            Boolean padding mask of shape ``(1, seq_len_nuc)``.
+            ``True`` indicates a padding position.
+        """
+        inputs = self.nuc_tokenizer(
+            sequence,
+            return_tensors="pt",
+            padding=True,
+            truncation=True,
+        ).to(self.device)
+
+        outputs = self.nuc_encoder(
+            **inputs,
+            output_hidden_states=True,
+        )
+        hidden = outputs.hidden_states[-1]
+        padding_mask = inputs["attention_mask"] == 0
+        return hidden, padding_mask
+
+    # ------------------------------------------------------------------
+    # Public API /Main generation function to be calld
+    # ------------------------------------------------------------------
+
+    @torch.no_grad()
+    def generate(
+        self,
+        protein_sequence: str,  # the reference
+        aptamer_length: int = 30,
+        top_k: int = 1,
+    ) -> str:
+        """Generate an aptamer sequence conditioned on a target protein.
+
+        All ``aptamer_length`` positions are initialised as ``[MASK]``
+        tokens and decoded in a single forward pass.
+            .. todo::
+                Implement the decoding strategy
+               fixed ``aptamer_length`` argument, analogous to the
+               autoregressive decoding in BAnG.
+
+        Returns
+        -------
+        str
+            Generated aptamer sequence as a nucleotide string.
+        """
+        self.model.eval()
+
+        # encode protein
+        prot_hidden, prot_padding_mask = self._encode_protein(protein_sequence)
+
+        # build a fully masked aptamer input
+        mask_token_id = self.nuc_tokenizer.mask_token_id
+        masked_ids = torch.full(
+            (1, aptamer_length),
+            fill_value=mask_token_id,
+            dtype=torch.long,
+            device=self.device,
+        )
+
+        # encode the masked aptamer
+        nuc_inputs = self.nuc_tokenizer.decode(
+            masked_ids[0].tolist(), skip_special_tokens=False
+        )
+        nuc_hidden, nuc_padding_mask = self._encode_aptamer(nuc_inputs)
+
+        # forward pass through the bridge + MLM head
+        self.model(
+            prot_hidden,
+            nuc_hidden,
+            prot_padding_mask=prot_padding_mask,
+            nuc_padding_mask=nuc_padding_mask,
+        )
+
+        # TODO : Decoding strategy  and return the aptamer generated


### PR DESCRIPTION

#### Reference Issues/PRs
Addresses #131 

#### What does this implement/fix? Explain your changes.
Implements initial version of AptaMLM: a dual-encoder architecture for protein-conditioned aptamer generation, adapting the PepMLM approach to nucleic acids as discussed in #131.
- Protein encoder: frozen ESM2 (same backbone as PepMLM)
- Nucleotide encoder: frozen NucleotideTransformer
- Cross-attention between both encoders as a bridge for protein conditionned encoding of the nucleotide.

#### What should a reviewer concentrate their feedback on?

- Cross-attention bridge between the two encoders .
- Choice of the frozen encoders.
- Masking approach
#### Did you add any tests for the change?

Forward pass and MLM loss verified to run. Formal unit tests not yet .(Check the notebook in the mentionned repo)

#### Any other comments?
This is a an initial architecture implementation , the training loop is not yet finalised as I didn't confirm the decoding strategy .
Tried to combine the structure from the PepMLM paper discussed in the the issue #131 with the paper BAnG that I believe can help this approach (https://arxiv.org/abs/2502.21274) (BAnG: Bidirectional Anchored Generation for Conditional RNA Design)
Before reviewing this code ,I would recommend checking the notebook and read me in this repo as they provide a clearer implementation walkthrough with  execution results:  https://github.com/NoorMajdoub/pyaptamer_dual_encoder

PS: Also tried to implement contrastive loss to address the issue of scarcity of positive samples mentioned in the issue , and to make use of the negative samples in the dataset.

#### PR checklist


- [ X] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
- [ ] Added/modified tests
- [ ] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
  To run hooks independent of commit, execute `pre-commit run --all-files`

