### PR TITLE
[BUG] Prevent AptaNet estimators from mutating global random state

### DIFF
--- a/pyaptamer/aptanet/_feature_classifier.py
+++ b/pyaptamer/aptanet/_feature_classifier.py
@@ -118,15 +118,34 @@ class AptaNetClassifier(ClassifierMixin, BaseEstimator):
                 f"Only binary classification is supported. Got target type {y_type}."
             )
 
+        np_state = None
+        torch_state = None
+        torch_cuda_state = None
+
         if self.random_state is not None:
+            np_state = np.random.get_state()
+            torch_state = torch.get_rng_state()
+
+            if torch.cuda.is_available():
+                torch_cuda_state = torch.cuda.get_rng_state()
+
             np.random.seed(self.random_state)
             torch.manual_seed(self.random_state)
 
-        self.classes_, y = np.unique(y, return_inverse=True)
-        self.pipeline_ = self._build_pipeline()
-        self.pipeline_.fit(
-            X.astype(np.float32, copy=False), y.astype(np.float32, copy=False)
-        )
+        try:
+            self.classes_, y = np.unique(y, return_inverse=True)
+            self.pipeline_ = self._build_pipeline()
+            self.pipeline_.fit(
+                X.astype(np.float32, copy=False), y.astype(np.float32, copy=False)
+            )
+        finally:
+            if self.random_state is not None:
+                np.random.set_state(np_state)
+                torch.set_rng_state(torch_state)
+
+                if torch.cuda.is_available():
+                    torch.cuda.set_rng_state(torch_cuda_state)
+
         return self
 
     def predict_proba(self, X):
@@ -302,14 +321,33 @@ class AptaNetRegressor(RegressorMixin, BaseEstimator):
         X, y = validate_data(self, X, y)
         y = y.reshape(-1, 1)
 
+        np_state = None
+        torch_state = None
+        torch_cuda_state = None
+
         if self.random_state is not None:
+            np_state = np.random.get_state()
+            torch_state = torch.get_rng_state()
+
+            if torch.cuda.is_available():
+                torch_cuda_state = torch.cuda.get_rng_state()
+
             np.random.seed(self.random_state)
             torch.manual_seed(self.random_state)
 
-        self.pipeline_ = self._build_pipeline()
-        self.pipeline_.fit(
-            X.astype(np.float32, copy=False), y.astype(np.float32, copy=False)
-        )
+        try:
+            self.pipeline_ = self._build_pipeline()
+            self.pipeline_.fit(
+                X.astype(np.float32, copy=False), y.astype(np.float32, copy=False)
+            )
+        finally:
+            if self.random_state is not None:
+                np.random.set_state(np_state)
+                torch.set_rng_state(torch_state)
+
+                if torch.cuda.is_available():
+                    torch.cuda.set_rng_state(torch_cuda_state)
+
         return self
 
     def predict(self, X):

--- a/pyaptamer/aptanet/_feature_classifier.py
+++ b/pyaptamer/aptanet/_feature_classifier.py
@@ -127,7 +127,7 @@ class AptaNetClassifier(ClassifierMixin, BaseEstimator):
             torch_state = torch.get_rng_state()
 
             if torch.cuda.is_available():
-                torch_cuda_state = torch.cuda.get_rng_state()
+                torch_cuda_state = torch.cuda.get_rng_state_all()
 
             np.random.seed(self.random_state)
             torch.manual_seed(self.random_state)
@@ -144,7 +144,7 @@ class AptaNetClassifier(ClassifierMixin, BaseEstimator):
                 torch.set_rng_state(torch_state)
 
                 if torch.cuda.is_available():
-                    torch.cuda.set_rng_state(torch_cuda_state)
+                    torch.cuda.set_rng_state_all(torch_cuda_state)
 
         return self
 
@@ -330,7 +330,7 @@ class AptaNetRegressor(RegressorMixin, BaseEstimator):
             torch_state = torch.get_rng_state()
 
             if torch.cuda.is_available():
-                torch_cuda_state = torch.cuda.get_rng_state()
+                torch_cuda_state = torch.cuda.get_rng_state_all()
 
             np.random.seed(self.random_state)
             torch.manual_seed(self.random_state)
@@ -346,7 +346,7 @@ class AptaNetRegressor(RegressorMixin, BaseEstimator):
                 torch.set_rng_state(torch_state)
 
                 if torch.cuda.is_available():
-                    torch.cuda.set_rng_state(torch_cuda_state)
+                    torch.cuda.set_rng_state_all(torch_cuda_state)
 
         return self
 


### PR DESCRIPTION
<!--
Welcome to pyaptamer, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.
If no issue exists, you can open one here: https://github.com/gc-os-ai/pyaptamer/issues
-->
fixes #531 

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
This PR implements a state-restoration context manager inside the `fit()` methods of AptaNet estimators that:
- snapshots the user's global numpy and torch RNG states.
- sets the passed `random_state` to ensure the underlying PyTorch model remains deterministic and reproducible.
- then restores the user's global states back after training completes.

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->
No, existing tests are intact and passing.

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
  To run hooks independent of commit, execute `pre-commit run --all-files`