### PR TITLE
docs: fix typos, broken badges, and incorrect docstrings across READM…

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ The python library for easy aptamer design.
 |---|---|
 | **Open&#160;Source** | [![BSD 3-clause](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://github.com/gc-os-ai/pyaptamer/blob/main/LICENSE) [![GC.OS Sponsored](https://img.shields.io/badge/GC.OS-Sponsored%20Project-orange.svg?style=flat&colorA=0eac92&colorB=2077b4)](https://gc-os-ai.github.io/) | |
 | **Community** | [![!discord](https://img.shields.io/static/v1?logo=discord&label=discord&message=chat&color=lightgreen)](https://discord.gg/7uKdHfdcJG) [![!slack](https://img.shields.io/static/v1?logo=linkedin&label=LinkedIn&message=news&color=lightblue)](https://www.linkedin.com/company/german-center-for-open-source-ai/) |
-| **CI/CD** | [![github-actions](https://img.shields.io/github/actions/workflow/status/gc-os-ai/pyaptamer/release.yml?logo=github)](https://github.com/sktime/pytorch-forecasting/actions/workflows/pypi_release.yml) |
-| **Code** | [![!pypi](https://img.shields.io/pypi/v/pytorch-forecasting?color=orange)](https://pypi.org/project/pyaptamer/) [![!python-versions](https://img.shields.io/pypi/pyversions/pyaptamer)](https://www.python.org/) [![!black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)  |
+| **CI/CD** | [![github-actions](https://img.shields.io/github/actions/workflow/status/gc-os-ai/pyaptamer/release.yml?logo=github)](https://github.com/gc-os-ai/pyaptamer/actions/workflows/release.yml) |
+| **Code** | [![!pypi](https://img.shields.io/pypi/v/pyaptamer?color=orange)](https://pypi.org/project/pyaptamer/) [![!python-versions](https://img.shields.io/pypi/pyversions/pyaptamer)](https://www.python.org/) [![!black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)  |
 
 ## 🌟 Features
 

--- a/pyaptamer/aptanet/_feature_classifier.py
+++ b/pyaptamer/aptanet/_feature_classifier.py
@@ -198,6 +198,7 @@ class AptaNetRegressor(RegressorMixin, BaseEstimator):
 
     Parameters
     ----------
+    input_dim : int or None, default=None
         Size of the input layer in the neural net. If `None`, it should be
         inferred from the feature matrix shape by the underlying module.
     hidden_dim : int, default=128
@@ -215,13 +216,13 @@ class AptaNetRegressor(RegressorMixin, BaseEstimator):
     eps : float, default=1e-08
         Epsilon value for numerical stability in RMSprop.
     estimator : sklearn estimator or None, default=None
-        Estimator used for feature selection. If `None`, a `RandomForestClassifier`.
+        Estimator used for feature selection. If `None`, a `RandomForestRegressor`.
     random_state : int or None, default=None
         Random seed for reproducibility. When set, both NumPy and Torch seeds are fixed.
     threshold : str or float, default="mean"
         Threshold passed to `SelectFromModel` (e.g., "mean" or a float).
     verbose : int, default=0
-        Verbosity level for the underlying skorch `NeuralNetBinaryClassifier`.
+        Verbosity level for the underlying skorch `NeuralNetRegressor`.
     """
 
     def __init__(

--- a/pyaptamer/data/loader.py
+++ b/pyaptamer/data/loader.py
@@ -15,10 +15,8 @@ class MoleculeLoader:
     Parameters
     ------------
     path : str, Path, or list thereof
-        file location or list of file locations with molecule files
-        str can be any of the following... [fill in]
-
-        the following formats are currently supported:
+        file location or list of file locations with molecule files.
+        The following formats are currently supported:
 
         * ``pdb`` format
 

--- a/pyaptamer/mcts/_algorithm.py
+++ b/pyaptamer/mcts/_algorithm.py
@@ -11,9 +11,8 @@ from skbase.base import BaseObject
 
 class MCTS(BaseObject):
     """
-    MCTS algorithm implementation for string optimization, specifically for aptamr
-    generation as described in aptamer generation as described in [1]_, originally
-    introduced in [2]_.
+    MCTS algorithm implementation for string optimization, specifically for aptamer
+    generation as described in [1]_, originally introduced in [2]_.
 
     Adapted from:
 
@@ -345,7 +344,7 @@ class TreeNode:
     Attributes
     ----------
     n_visits : int
-        Counter tracking the umber of visits to this node.
+        Counter tracking the number of visits to this node.
     children : dict[str, TreeNode]
         Dictionary of child nodes indexed by value.
 

--- a/pyaptamer/utils/_rna.py
+++ b/pyaptamer/utils/_rna.py
@@ -182,21 +182,21 @@ def encode_rna(
 ):
     """Encode RNA sequences into their numerical representations.
 
-    This function tokenizes protein sequences using a greedy longest-match approach,
-    where longer amino acid patterns are preferred over shorter ones. Sequences are
-    either trunacted or zero-padded to `max_len` tokens.
+    This function tokenizes RNA sequences using a greedy longest-match approach,
+    where longer k-mer patterns are preferred over shorter ones. Sequences are
+    either truncated or zero-padded to `max_len` tokens.
 
     Parameters
     ----------
     sequences : list[str]
         List of RNA sequences to be encoded.
     words : dict[str, int]
-        A dictionary mappings RNA 3-mers to unique indices.
+        A dictionary mapping RNA 3-mers to unique indices.
     max_len : int
         Maximum length of each encoded sequence. Sequences will be truncated
         or padded to this length.
     word_max_len : int, optional, default=3
-        Maximum length of amino acid patterns to consider during tokenization.
+        Maximum length of k-mer patterns to consider during tokenization.
     return_type : str, optional, default="tensor"
         The type of the returned encoded sequences.
 


### PR DESCRIPTION
## What

Fix a collection of typos, broken links, and incorrect docstrings found
during a first read-through of the codebase.

## Changes

- **README.md** - CI/CD badge link pointed to `sktime/pytorch-forecasting`
  (a different project); PyPI version badge fetched `pytorch-forecasting`
  instead of `pyaptamer`. Both now point to the correct repo/package.

- **mcts/_algorithm.py** - Two bugs in the `MCTS` class docstring:
  `aptamr` (misspelling) and the phrase `aptamer generation as described in`
  duplicated. Also `umber` → ``number` in `TreeNode` attribute description.

- **utils/_rna.py** - `encode_rna()` docstring said `tokenizes protein
  sequences` and "amino acid patterns" despite being an RNA encoder.
  Also fixed `trunacted` and `mappings` typos.

- **aptanet/_feature_classifier.py** - `AptaNetRegressor` docstring was
  missing the `input_dim` parameter name entirely; incorrectly referenced
  `RandomForestClassifier` and `NeuralNetBinaryClassifier` (both are
  Classifier variants the actual code at line 259 uses `RandomForestRegressor`).

- **data/loader.py** -Removed the unfinished `str can be any of the
  following... [fill in]` placeholder from `MoleculeLoader`'s public docstring.

## Type of change

- [x] Documentation / docstring fix
- [ ] Bug fix
- [ ] New feature
