### PR TITLE
[BUG] Fix undefined fixture reference in MCTS test suite

### DIFF
--- a/pyaptamer/mcts/tests/test_mcts.py
+++ b/pyaptamer/mcts/tests/test_mcts.py
@@ -30,11 +30,11 @@ def val_not_found():
 
 
 @pytest.fixture
-def tree_with_children(tree_node):
+def tree_with_children(root):
     """Provide a TreeNode with some children already added."""
     for val in ["A_", "C_", "G_"]:
-        tree_node.create_child(val=val)
-    return tree_node
+        root.create_child(val=val)
+    return root
 
 
 class TestTreeNode:


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #517

#### What does this implement/fix? Explain your changes.
The `tree_with_children` fixture in `test_mcts.py` referenced `tree_node` as a parameter, but no such fixture exists in the file. The correct fixture is `root`, which is already defined. This fix prevents pytest from failing when any test tries to use `tree_with_children`.

#### What should a reviewer concentrate their feedback on?
- Verified all 42 tests pass after the change
- Only the fixture parameter name was changed, no logic modified

#### Did you add any tests for the change?
No new tests needed — existing tests already validate the fixture works correctly with the `root` parameter.

#### Any other comments?
Pre-commit hooks passed. The fix is minimal and only touches the fixture definition.

#### PR checklist
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
