### PR TITLE
Fix rna2vec dataset misalignment and resolve PSeAAC Asparagine bias (#363, #491)

### DIFF
--- a/pyaptamer/pseaac/_pseaac_aptanet.py
+++ b/pyaptamer/pseaac/_pseaac_aptanet.py
@@ -6,7 +6,11 @@ from collections import Counter
 import numpy as np
 
 from pyaptamer.pseaac._props import aa_props
-from pyaptamer.utils._pseaac_utils import AMINO_ACIDS, clean_protein_seq
+from pyaptamer.utils._pseaac_utils import (
+    AMINO_ACIDS,
+    UNKNOWN_AMINO_ACID,
+    clean_protein_seq,
+)
 
 
 class AptaNetPSeAAC:
@@ -102,6 +106,9 @@ class AptaNetPSeAAC:
 
         # Load normalized property matrix (20x21, rows=AA, cols=NP1-NP21)
         self.np_matrix = aa_props(type="numpy", normalize=True)
+        self.np_matrix = np.vstack(
+            [self.np_matrix, self.np_matrix.mean(axis=0, keepdims=True)]
+        )
         # Each prop_group is a tuple of 3 columns (property indices)
         self.prop_groups = [
             (0, 1, 2),
@@ -130,8 +137,10 @@ class AptaNetPSeAAC:
             ['A', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'K', 'L', 'M', 'N', 'P', 'Q', 'R',
             'S', 'T', 'V', 'W', 'Y']
         """
-        counts = Counter(seq)
-        total = len(seq)
+        counts = Counter(aa for aa in seq if aa in AMINO_ACIDS)
+        total = sum(counts.values())
+        if total == 0:
+            return np.zeros(len(AMINO_ACIDS))
         return np.array([counts.get(aa, 0) / total for aa in AMINO_ACIDS])
 
     def _avg_theta_val(self, seq_vec, seq_len, n, prop_group):
@@ -175,7 +184,8 @@ class AptaNetPSeAAC:
         ----------
         protein_sequence : str
             The input protein sequence consisting of valid amino acid characters
-            (A, C, D, E, F, G, H, I, K, L, M, N, P, Q, R, S, T, V, W, Y).
+            (A, C, D, E, F, G, H, I, K, L, M, N, P, Q, R, S, T, V, W, Y) and
+            the unknown placeholder X.
 
         Returns
         -------
@@ -201,7 +211,7 @@ class AptaNetPSeAAC:
                 f"Sequence length: {seq_len}, `lambda_val`: {self.lambda_val}."
             )
 
-        aa_to_idx = {aa: i for i, aa in enumerate(AMINO_ACIDS)}
+        aa_to_idx = {aa: i for i, aa in enumerate(AMINO_ACIDS + [UNKNOWN_AMINO_ACID])}
         seq_vec = np.array([aa_to_idx[aa] for aa in seq], dtype=np.int32)
 
         aa_freq = self._normalized_aa(seq)
@@ -218,6 +228,8 @@ class AptaNetPSeAAC:
 
             sum_all_theta_val = np.sum(all_theta_val)
             denominator_val = sum_all_aa_freq + (self.weight * sum_all_theta_val)
+            if denominator_val == 0:
+                denominator_val = 1.0
 
             # First 20 features: normalized amino acid composition
             all_pseaac.extend(np.round(aa_freq / denominator_val, 3))

--- a/pyaptamer/pseaac/_pseaac_general.py
+++ b/pyaptamer/pseaac/_pseaac_general.py
@@ -6,7 +6,11 @@ from collections import Counter
 import numpy as np
 
 from pyaptamer.pseaac._props import aa_props
-from pyaptamer.utils._pseaac_utils import AMINO_ACIDS, clean_protein_seq
+from pyaptamer.utils._pseaac_utils import (
+    AMINO_ACIDS,
+    UNKNOWN_AMINO_ACID,
+    clean_protein_seq,
+)
 
 
 class PSeAAC:
@@ -134,6 +138,10 @@ class PSeAAC:
             prop_indices=prop_indices, type="numpy", normalize=True
         )
         self._n_cols = self.np_matrix.shape[1]  # The number of properties selected
+        self.np_matrix = np.vstack(
+            [self.np_matrix, self.np_matrix.mean(axis=0, keepdims=True)]
+        )
+        self.amino_acids = AMINO_ACIDS + [UNKNOWN_AMINO_ACID]
 
         if custom_groups:
             self.prop_groups = custom_groups
@@ -173,8 +181,10 @@ class PSeAAC:
             ['A', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'K', 'L', 'M', 'N', 'P', 'Q', 'R',
             'S', 'T', 'V', 'W', 'Y']
         """
-        counts = Counter(seq)
-        total = len(seq)
+        counts = Counter(aa for aa in seq if aa in AMINO_ACIDS)
+        total = sum(counts.values())
+        if total == 0:
+            return np.zeros(len(AMINO_ACIDS))
         return np.array([counts.get(aa, 0) / total for aa in AMINO_ACIDS])
 
     def _avg_theta_val(self, seq_vec, seq_len, n, prop_group):
@@ -218,7 +228,8 @@ class PSeAAC:
         ----------
         protein_sequence : str
             The input protein sequence consisting of valid amino acid characters
-            (A, C, D, E, F, G, H, I, K, L, M, N, P, Q, R, S, T, V, W, Y).
+            (A, C, D, E, F, G, H, I, K, L, M, N, P, Q, R, S, T, V, W, Y) and
+            the unknown placeholder X.
         lambda_val : int, default=30
             The maximum distance between residues considered in the sequence-order
             correlation (θ) calculations.
@@ -250,7 +261,7 @@ class PSeAAC:
                 f"Sequence length: {seq_len}, `lambda_val`: {self.lambda_val}."
             )
 
-        aa_to_idx = {aa: i for i, aa in enumerate(AMINO_ACIDS)}
+        aa_to_idx = {aa: i for i, aa in enumerate(self.amino_acids)}
         seq_vec = np.array([aa_to_idx[aa] for aa in seq], dtype=np.int32)
 
         aa_freq = self._normalized_aa(seq)
@@ -267,6 +278,8 @@ class PSeAAC:
 
             sum_all_theta_val = np.sum(all_theta_val)
             denominator_val = sum_all_aa_freq + (self.weight * sum_all_theta_val)
+            if denominator_val == 0:
+                denominator_val = 1.0
 
             # First 20 features: normalized amino acid composition
             all_pseaac.extend(np.round(aa_freq / denominator_val, 3))

--- a/pyaptamer/pseaac/tests/test_pseaac.py
+++ b/pyaptamer/pseaac/tests/test_pseaac.py
@@ -6,6 +6,7 @@ import pytest
 from pyaptamer.pseaac import AptaNetPSeAAC, PSeAAC
 from pyaptamer.pseaac._props import aa_props
 from pyaptamer.pseaac.tests._props import solution
+from pyaptamer.utils._pseaac_utils import clean_protein_seq
 
 vector = "ACDFFKKIIKKLLMMNNPPQQQRRRRIIIIRRR"
 
@@ -50,6 +51,26 @@ def test_pseaac_transform_sequence_too_short(PCLASS, seq, lambda_val):
         p.transform(seq)
 
 
+def test_clean_protein_seq_uses_x_placeholder():
+    """Invalid residues should be converted to the neutral X placeholder."""
+    with pytest.warns(UserWarning, match="Replaced with 'X'"):
+        cleaned = clean_protein_seq("ABZ*")
+
+    assert cleaned == "AXXX"
+
+
+def test_clean_protein_seq_preserves_existing_x():
+    """Existing X residues should be treated as the intended unknown placeholder."""
+    import warnings
+
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+        cleaned = clean_protein_seq("AXX")
+
+    assert cleaned == "AXX"
+    assert len(record) == 0
+
+
 @pytest.mark.parametrize(
     "seq,expected_vector",
     [
@@ -77,6 +98,23 @@ def test_pseaac_vectorization(seq, expected_vector):
         if not np.isclose(a, b, atol=1e-3)
     ]
     assert not mismatches, f"Vector values mismatch at indices: {mismatches}"
+
+
+@pytest.mark.parametrize("PCLASS", [PSeAAC, AptaNetPSeAAC])
+def test_pseaac_handles_unknown_residues(PCLASS):
+    """Unknown residues should not introduce NaNs or map to Asparagine bias."""
+    seq = "ACDEFGHIKLMNPQRSTVWYACDEFGHIKLMNPQZ"
+    p = PCLASS()
+
+    with pytest.warns(UserWarning, match="Replaced with 'X'"):
+        cleaned = clean_protein_seq(seq)
+
+    assert cleaned.endswith("X")
+
+    features = p.transform(seq)
+
+    assert len(features) == 350
+    assert np.all(np.isfinite(features))
 
 
 @pytest.mark.parametrize(

--- a/pyaptamer/utils/_pseaac_utils.py
+++ b/pyaptamer/utils/_pseaac_utils.py
@@ -11,15 +11,16 @@ is used for efficient membership testing.
 Functions
 ---------
 clean_protein_seq(seq)
-    Replaces invalid amino acids with "N" and warn the user.
+    Replaces invalid amino acids with "X" and warn the user.
 """
 
 AMINO_ACIDS = list("ACDEFGHIKLMNPQRSTVWY")
+UNKNOWN_AMINO_ACID = "X"
 
 
 def clean_protein_seq(seq):
     """
-    Replace invalid amino acids with "N" and warn the user.
+    Replace invalid amino acids with "X" and warn the user.
 
     Parameters
     ----------
@@ -30,7 +31,7 @@ def clean_protein_seq(seq):
     -------
     str
         Cleaned protein sequence where all invalid characters have been replaced
-        with "N".
+        with "X".
     """
     import warnings
 
@@ -38,15 +39,15 @@ def clean_protein_seq(seq):
     invalid_found = False
 
     for aa in seq:
-        if aa in AMINO_ACIDS:
+        if aa in AMINO_ACIDS or aa == UNKNOWN_AMINO_ACID:
             cleaned.append(aa)
         else:
-            cleaned.append("N")
+            cleaned.append(UNKNOWN_AMINO_ACID)
             invalid_found = True
 
     if invalid_found:
         warnings.warn(
-            "Invalid amino acid(s) found in sequence. Replaced with 'N'.",
+            "Invalid amino acid(s) found in sequence. Replaced with 'X'.",
             UserWarning,
             stacklevel=2,
         )

--- a/pyaptamer/utils/_rna.py
+++ b/pyaptamer/utils/_rna.py
@@ -151,24 +151,23 @@ def rna2vec(
             triplets.get(sequence[i : i + 3], 0) for i in range(len(sequence) - 2)
         ]
 
-        # skip sequences that convert to an empty list
-        if any(converted):
-            # truncate if too long
-            if max_sequence_length is not None and len(converted) > max_sequence_length:
-                converted = converted[:max_sequence_length]
+        # process sequence regardless of content or length
+        # truncate if too long
+        if max_sequence_length is not None and len(converted) > max_sequence_length:
+            converted = converted[:max_sequence_length]
 
-            # pad if too short
-            if max_sequence_length is not None:
-                pad_length = max_sequence_length - len(converted)
-                padded_sequence = np.pad(
-                    array=converted,
-                    pad_width=(0, pad_length),
-                    constant_values=0,
-                )
-            else:
-                padded_sequence = np.array(converted)
+        # pad if too short
+        if max_sequence_length is not None:
+            pad_length = max_sequence_length - len(converted)
+            padded_sequence = np.pad(
+                array=converted,
+                pad_width=(0, pad_length),
+                constant_values=0,
+            )
+        else:
+            padded_sequence = np.array(converted)
 
-            result.append(padded_sequence)
+        result.append(padded_sequence)
 
     return np.array(result)
 

--- a/pyaptamer/utils/tests/test_rna.py
+++ b/pyaptamer/utils/tests/test_rna.py
@@ -149,22 +149,27 @@ def test_rna2vec_edge_cases():
 
     # empty sequence
     result = rna2vec([""], sequence_type="rna")
-    assert len(result) == 0
+    assert len(result) == 1
+    assert np.all(result == 0)
 
     # single character sequence (can't form triplet)
     result = rna2vec(["A"], sequence_type="rna")
-    assert len(result) == 0
+    assert len(result) == 1
+    assert np.all(result == 0)
 
     # double character sequence (can't form triplet)
     result = rna2vec(["AA"], sequence_type="rna")
-    assert len(result) == 0
+    assert len(result) == 1
+    assert np.all(result == 0)
 
     # test with secondary structure sequences - edge cases
     result = rna2vec(["S"], sequence_type="ss")
-    assert len(result) == 0
+    assert len(result) == 1
+    assert np.all(result == 0)
 
     result = rna2vec(["SS"], sequence_type="ss")
-    assert len(result) == 0
+    assert len(result) == 1
+    assert np.all(result == 0)
 
 
 def test_rna2vec_default_parameters():


### PR DESCRIPTION
### Description
This PR addresses two critical reliability and scientific consistency issues in the `pyaptamer` pipeline:

#### 1. Fix Silent Data Misalignment in `rna2vec` (#363)
- **Problem**: Previously, `rna2vec` silently dropped sequences shorter than 3 nucleotides. In batch processing, this caused the output feature matrix to have fewer rows than the input sequence list, leading to a silent misalignment between features and labels.
- **Solution**: Removed the conditional check that skipped conversions. Every input sequence now produces an output row; short/empty sequences are zero-padded, maintaining a strict 1:1 mapping with labels.

#### 2. Resolve PSeAAC Asparagine Bias (#491)
- **Problem**: Unknown residues were previously mapped to 'N' (Asparagine), biasing PSeAAC feature extraction.
- **Solution**: Unknown residues now map to `'X'`, using a **mean property vector** (neutral statistical approach). Credit to @NandiniDhanrale for the initial placeholder concept.

### Changes
- Modified `pyaptamer/utils/_rna.py`, `pyaptamer/utils/_pseaac_utils.py`, `pyaptamer/pseaac/_pseaac_general.py`, and `pyaptamer/pseaac/_pseaac_aptanet.py`.
- Updated test suites with comprehensive coverage.

### Verification
- All 34 tests in the RNA and PSeAAC suites passed.