### PR TITLE
[ENH] Optimize greedy tokenization in seq2vec and encode_rna

### DIFF
--- a/pyaptamer/utils/_aptatrans_utils.py
+++ b/pyaptamer/utils/_aptatrans_utils.py
@@ -61,43 +61,32 @@ def seq2vec(
     outputs = []
     outputs_ss = []
 
+    valid_words = [w for w, idx in words.items() if idx != 0 and len(w) <= word_max_len]
+    valid_words.sort(key=len, reverse=True)
+    
+    if not valid_words:
+        return np.zeros((0, seq_max_len)), np.zeros((0, seq_max_len))
+
+    import re
+    pattern = re.compile("|".join(map(re.escape, valid_words)))
+
     for seq, ss in zip(*sequence_list, strict=False):
         output = []
         output_ss = []
-        i = 0
 
-        while i < len(seq):
-            matched = False
+        for match in pattern.finditer(seq):
+            substring = match.group()
+            substring_ss = ss[match.start() : match.end()]
 
-            # try to match longest possible substring first
-            for j in range(word_max_len, 0, -1):
-                if i + j <= len(seq):
-                    substring = seq[i : i + j]
-                    substring_ss = ss[i : i + j]
+            output.append(words[substring])
+            output_ss.append(words_ss.get(substring_ss, 0))
 
-                    # check if substring exists in vocabulary (0 is unknown token)
-                    word_idx = words.get(substring, 0)
-                    if word_idx != 0:
-                        matched = True
-                        output.append(word_idx)
-                        # 0 marks unknown secondary structure tokens
-                        output_ss.append(words_ss.get(substring_ss, 0))
+            if len(output) == seq_max_len:
+                outputs.append(np.array(output))
+                outputs_ss.append(np.array(output_ss))
+                output = []
+                output_ss = []
 
-                        # if at `seq_max_len`, store and reset
-                        if len(output) == seq_max_len:
-                            outputs.append(np.array(output))
-                            outputs_ss.append(np.array(output_ss))
-                            output = []
-                            output_ss = []
-
-                        i += j
-                        break
-
-            # skip character if no match found
-            if not matched:
-                i += 1
-
-        # add remaining output if not empty
         if len(output) > 0:
             outputs.append(np.array(output))
             outputs_ss.append(np.array(output_ss))

--- a/pyaptamer/utils/_rna.py
+++ b/pyaptamer/utils/_rna.py
@@ -219,35 +219,47 @@ def encode_rna(
     if isinstance(sequences, str):
         sequences = [sequences]
 
+    import re
+    valid_words = [w for w in words.keys() if len(w) <= word_max_len]
+    valid_words.sort(key=len, reverse=True)
+    
+    if valid_words:
+        pattern = re.compile("|".join(map(re.escape, valid_words)))
+    else:
+        pattern = None
+
     encoded_sequences = []
     for seq in sequences:
         tokens = []
-        i = 0
-
-        while i < len(seq):
-            # try to match the longest possible pattern first
-            matched = False
-            for pattern_len in range(min(word_max_len, len(seq) - i), 0, -1):
-                pattern = seq[i : i + pattern_len]
-                if pattern in words:
-                    tokens.append(words[pattern])
-                    i += pattern_len
-                    matched = True
+        last_end = 0
+        
+        if pattern:
+            for match in pattern.finditer(seq):
+                skipped = match.start() - last_end
+                if skipped > 0:
+                    tokens.extend([0] * skipped)
+                
+                if len(tokens) >= max_len:
                     break
-
-            # if no pattern matched, use unknown token (0) and advance by 1
-            if not matched:
-                tokens.append(0)
-                i += 1
-
-            # stop if we've reached max_len tokens
-            if len(tokens) >= max_len:
-                tokens = tokens[:max_len]
-                break
-
-        # pad sequence to max_len
-        padded_tokens = tokens + [0] * (max_len - len(tokens))
-        encoded_sequences.append(padded_tokens)
+                    
+                tokens.append(words[match.group()])
+                last_end = match.end()
+                
+                if len(tokens) >= max_len:
+                    break
+                    
+        # add remaining 0s for skipped characters at the end
+        if len(tokens) < max_len:
+            skipped = len(seq) - last_end
+            if skipped > 0:
+                tokens.extend([0] * skipped)
+                
+        # truncate or pad to exactly max_len
+        tokens = tokens[:max_len]
+        if len(tokens) < max_len:
+            tokens.extend([0] * (max_len - len(tokens)))
+            
+        encoded_sequences.append(tokens)
 
     # convert to numpy array first
     result = np.array(encoded_sequences, dtype=np.int64)


### PR DESCRIPTION
#### Reference Issues/PRs
Resolves #555.

#### What does this implement/fix? Explain your changes.
This PR optimizes the greedy longest-match tokenization logic found in `seq2vec` (`pyaptamer/utils/_aptatrans_utils.py`) and `encode_rna` (`pyaptamer/utils/_rna.py`).

Currently, these functions tokenize sequences using manual `while` loops combined with string slicing, which suffers from significant Python interpreter overhead. This PR addresses the performance `TODO`s in `_aptatrans_utils.py` by:
- Refactoring `seq2vec` and `encode_rna` to use compiled regular expressions (`re.compile`) instead of iterative string slices.
- Utilizing `pattern.finditer(seq)` to push the matching logic down to the highly optimized C-level regex engine.
- Maintaining the exact original behavior for both methods: longest-match priority is preserved (by sorting vocabulary descending by length), unknown characters are skipped in `seq2vec`, and skipped intervals are accurately padded with `0` tokens in `encode_rna`.

#### What should a reviewer concentrate their feedback on?
- The translation of the manual slicing loop into the `re.finditer` logic.
- Edge case handling in `encode_rna` where skipped/unknown characters are tracked and appropriately filled with `0`s.

#### Did you add any tests for the change?
- Existing tokenization tests pass and verify the behavior.
- I locally verified that the regex approach returns byte-for-byte identical NumPy array outputs as the original string-slicing method for a variety of sequences. 

#### Any other comments?
N/A

#### PR checklist
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. 
- [ ] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. 
