### PR TITLE
[MNT] Replace validate_data with check_array in predict methods

### DIFF
--- a/pyaptamer/aptanet/_feature_classifier.py
+++ b/pyaptamer/aptanet/_feature_classifier.py
@@ -9,7 +9,7 @@ from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
 from sklearn.feature_selection import SelectFromModel
 from sklearn.pipeline import Pipeline
 from sklearn.utils.multiclass import type_of_target
-from sklearn.utils.validation import check_is_fitted, validate_data
+from sklearn.utils.validation import check_is_fitted, validate_data, check_array
 from torch import optim
 
 from pyaptamer.aptanet._aptanet_nn import AptaNetMLP
@@ -125,7 +125,7 @@ class AptaNetClassifier(ClassifierMixin, BaseEstimator):
         self.classes_, y = np.unique(y, return_inverse=True)
         self.pipeline_ = self._build_pipeline()
         self.pipeline_.fit(
-            X.astype(np.float32, copy=False), y.astype(np.float32, copy=False)
+            X.astype(np.float32, copy=False), y.astype(np.int64, copy=False)
         )
         return self
 
@@ -144,7 +144,7 @@ class AptaNetClassifier(ClassifierMixin, BaseEstimator):
             Probability estimates for each class.
         """
         check_is_fitted(self)
-        X = validate_data(self, X, reset=False).astype(np.float32, copy=False)
+        X = check_array(X).astype(np.float32, copy=False)
         return self.pipeline_.predict_proba(X)
 
     def predict(self, X):
@@ -162,7 +162,7 @@ class AptaNetClassifier(ClassifierMixin, BaseEstimator):
             Predicted class labels.
         """
         check_is_fitted(self)
-        X = validate_data(self, X, reset=False).astype(np.float32, copy=False)
+        X = check_array(X).astype(np.float32, copy=False)
         y = self.pipeline_.predict(X).astype(int, copy=False)
         return self.classes_[y]
 
@@ -327,7 +327,7 @@ class AptaNetRegressor(RegressorMixin, BaseEstimator):
             Predicted continuous values.
         """
         check_is_fitted(self)
-        X = validate_data(self, X, reset=False).astype(np.float32, copy=False)
+        X = check_array(X).astype(np.float32, copy=False)
         return self.pipeline_.predict(X).reshape(-1)
 
     def score(self, X, y):

--- a/pyaptamer/aptanet/_feature_classifier.py
+++ b/pyaptamer/aptanet/_feature_classifier.py
@@ -125,7 +125,7 @@ class AptaNetClassifier(ClassifierMixin, BaseEstimator):
         self.classes_, y = np.unique(y, return_inverse=True)
         self.pipeline_ = self._build_pipeline()
         self.pipeline_.fit(
-            X.astype(np.float32, copy=False), y.astype(np.int64, copy=False)
+            X.astype(np.float32, copy=False), y.astype(np.float32, copy=False)
         )
         return self
 


### PR DESCRIPTION
#### Reference Issues/PRs
N/A
#### What does this implement/fix? Explain your changes.

This PR replaces validate_data with check_array in the predict, predict_proba, and regressor predict methods.

This makes the input validation in prediction steps more consistent with how sklearn typically handles it.

#### What should a reviewer concentrate their feedback on?

- Whether using check_array instead of validate_data in prediction methods is appropriate
- Any potential impact on existing prediction behavior

#### Did you add any tests for the change?

No additional tests were added. The changes were verified by running the classifier and ensuring predictions work as expected.

#### Any other comments?
This is a small cleanup to make the prediction methods follow sklearn conventions more closely.

#### PR checklist


- [x] The PR title starts with [MNT]
- [ ] Added/modified tests
- [ ] Used pre-commit hooks