### PR TITLE
[BUG] Fix MaskedDataset._mask_rna overwriting padding tokens for RNA

### DIFF
--- a/pyaptamer/datasets/dataclasses/_masked.py
+++ b/pyaptamer/datasets/dataclasses/_masked.py
@@ -85,8 +85,14 @@ class MaskedDataset(Dataset):
         self.box = np.array(list(range(max_len)))
         self.len = len(self.x)
 
-    def _mask_rna(self, x_masked: Tensor, mask_positions: list[int]) -> Tensor:
+    def _mask_rna(
+        self, x_masked: Tensor, mask_positions: list[int], seq_len: int
+    ) -> Tensor:
         """Mask adjacent nucleotides for RNA sequences.
+
+        Adjacent positions are constrained to the actual non-padding length of
+        the sequence so that padding tokens are never overwritten with
+        ``self.mask_idx``.
 
         Parameters
         ----------
@@ -94,6 +100,9 @@ class MaskedDataset(Dataset):
             The tensor containing the masked sequence.
         mask_positions : list[int]
             List of positions that have been masked.
+        seq_len : int
+            Length of the non-padding region of the sequence. Adjacent positions
+            beyond this length (i.e. padding) are skipped.
 
         Returns
         -------
@@ -102,8 +111,8 @@ class MaskedDataset(Dataset):
         """
         adjacent_positions = []
         for pos in mask_positions:
-            # mask position + 1 (if within bounds)
-            if pos < self.max_len - 1:
+            # mask position + 1 (if within the non-padding region)
+            if pos < seq_len - 1:
                 adjacent_positions.append(pos + 1)
             # mask position - 1 (if within bounds)
             if pos > 0:
@@ -173,7 +182,9 @@ class MaskedDataset(Dataset):
 
         # for RNA, also mask adjacent nucleotides for base pairing
         if self.is_rna:
-            x_masked = self._mask_rna(x_masked, actual_mask_positions)
+            x_masked = self._mask_rna(
+                x_masked, actual_mask_positions, seq_len=int(seq_len)
+            )
 
         # zero out non-masked positions in target
         y_masked[no_mask_positions] = 0

--- a/pyaptamer/datasets/dataclasses/tests/__init__.py
+++ b/pyaptamer/datasets/dataclasses/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for PyTorch dataset classes."""

--- a/pyaptamer/datasets/dataclasses/tests/test_masked.py
+++ b/pyaptamer/datasets/dataclasses/tests/test_masked.py
@@ -1,0 +1,126 @@
+"""Test suite for MaskedDataset."""
+
+import random
+
+import numpy as np
+import pytest
+import torch
+
+from pyaptamer.datasets.dataclasses import MaskedDataset
+
+
+def test_masked_dataset_length_mismatch():
+    """Constructor must reject ``x`` and ``y`` of different lengths."""
+    with pytest.raises(ValueError, match="must have the same length"):
+        MaskedDataset(
+            x=[[1, 2], [3, 4]],
+            y=[[1, 2]],
+            max_len=2,
+            mask_idx=9,
+        )
+
+
+def test_masked_dataset_basic_lengths_and_types():
+    """``__len__`` and ``__getitem__`` return the documented shapes/types."""
+    sequences = [[1, 2, 3, 4, 0], [2, 1, 4, 0, 0]]
+    targets = [[1, 2, 3, 4, 0], [2, 1, 4, 0, 0]]
+
+    ds = MaskedDataset(
+        sequences, targets, max_len=5, mask_idx=9, masked_rate=0.2, is_rna=False
+    )
+    assert len(ds) == 2
+
+    random.seed(0)
+    x_masked, y_masked, x, y = ds[0]
+    assert x_masked.shape == (5,)
+    assert y_masked.shape == (5,)
+    assert x.dtype == torch.int64
+    assert y.dtype == torch.int64
+    # Padding positions in input must remain padding (0).
+    assert x_masked[-1].item() == 0
+
+
+def test_mask_rna_does_not_overwrite_padding():
+    """RNA adjacent masking must not turn padding tokens into ``mask_idx``.
+
+    Reproduces the bug in which ``_mask_rna`` used ``self.max_len`` as the
+    upper bound when picking right-neighbour positions, so the slot just past
+    the actual sequence (the first padding token) could be masked.
+    """
+    sequences = [[1, 2, 3, 0, 0]]
+    targets = [[1, 2, 3, 0, 0]]
+
+    ds = MaskedDataset(
+        sequences, targets, max_len=5, mask_idx=99, masked_rate=1.0, is_rna=True
+    )
+
+    # Sweep enough seeds to make sure the last non-padding position
+    # (index 2) is selected for masking at least once. With masked_rate=1.0
+    # every non-padding position is sampled, so this is guaranteed on the
+    # first iteration; the loop simply guards against any future RNG change.
+    for seed in range(20):
+        random.seed(seed)
+        x_masked, _, x, _ = ds[0]
+        assert x[3].item() == 0  # sanity: original was padding
+        assert x[4].item() == 0
+        # Padding tokens must remain padding after masking.
+        assert x_masked[3].item() == 0, (
+            f"seed={seed}: padding at index 3 was overwritten with mask_idx"
+        )
+        assert x_masked[4].item() == 0
+
+
+def test_mask_rna_still_masks_internal_neighbours():
+    """Adjacent masking must still apply for positions inside the sequence."""
+    sequences = [[1, 2, 3, 4, 5]]
+    targets = [[1, 2, 3, 4, 5]]
+
+    ds = MaskedDataset(
+        sequences, targets, max_len=5, mask_idx=99, masked_rate=1.0, is_rna=True
+    )
+
+    # When every non-padding position is in mask_positions, the right-
+    # neighbour and left-neighbour rules together cover the whole sequence.
+    random.seed(0)
+    x_masked, _, _, _ = ds[0]
+    assert (x_masked == 99).all().item()
+
+
+def test_mask_rna_unit_helper_respects_seq_len():
+    """Direct unit test on the ``_mask_rna`` helper for the bounds fix."""
+    ds = MaskedDataset(
+        x=[[1, 2, 3, 0, 0]],
+        y=[[1, 2, 3, 0, 0]],
+        max_len=5,
+        mask_idx=99,
+        masked_rate=1.0,
+        is_rna=True,
+    )
+
+    x_masked = torch.tensor([1, 2, 99, 0, 0], dtype=torch.int64)
+    out = ds._mask_rna(x_masked.clone(), mask_positions=[2], seq_len=3)
+    # left neighbour (1) is masked; right neighbour (3) is padding -> unchanged
+    assert out[1].item() == 99
+    assert out[3].item() == 0
+    assert out[4].item() == 0
+
+
+def test_y_masked_zeroed_at_no_mask_positions():
+    """``y_masked`` must zero out positions that were never selected for masking.
+
+    Positions sampled into ``mask_positions`` keep their original target value
+    (whether or not they end up actually replaced with ``mask_idx`` after the
+    80% sub-sample), while every other valid position is zeroed in y.
+    """
+    sequences = np.array([[1, 2, 3, 4, 5]])
+    targets = np.array([[1, 2, 3, 4, 5]])
+    ds = MaskedDataset(
+        sequences, targets, max_len=5, mask_idx=99, masked_rate=0.4, is_rna=False
+    )
+    random.seed(0)
+    _, y_masked, x, _ = ds[0]
+    # At least one position must be zeroed (since masked_rate < 1).
+    assert (y_masked == 0).any().item()
+    # Wherever y_masked is non-zero, it equals x.
+    nz = y_masked != 0
+    assert torch.equal(y_masked[nz], x[nz])


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #562.

#### What does this implement/fix? Explain your changes.

`MaskedDataset._mask_rna` masks adjacent positions of each chosen mask position so that RNA base-pair partners are co-masked. The right-neighbour bounds check used `self.max_len`, which is the padded length, not the actual non-padding length of the sample. As a result, when the last non-padding token at index `seq_len - 1` was selected for masking, position `seq_len` (the first padding slot, originally `0`) was overwritten with `mask_idx`. The corrupted padding token was then fed to the model as a real masked position to predict.

The fix:

- Adds a `seq_len` parameter to `_mask_rna` and uses it to constrain the right-neighbour bound (`pos < seq_len - 1`). The left-neighbour bound was already correct via `pos > 0`.
- Passes the existing `seq_len` value (already computed in `__getitem__` for the random sampling step) into `_mask_rna`.
- No other behaviour of the masking pipeline changes; valid (non-padding) interior positions are still masked exactly as before.

#### What should a reviewer concentrate their feedback on?

- [x] The bound used in `_mask_rna` is the actual sequence length, not the padded length.
- [x] Padding tokens are never overwritten with `mask_idx` after the fix.
- [x] Existing adjacent-masking behaviour for purely interior positions is preserved.

#### Did you add any tests for the change?

Yes. There were no tests for `MaskedDataset` before this PR. The new `pyaptamer/datasets/dataclasses/tests/test_masked.py` covers:

- length mismatch validation in `__init__`,
- shapes/dtypes from `__getitem__`,
- the regression: padding tokens stay padding after RNA adjacent masking, swept across multiple seeds,
- adjacent masking still propagates fully inside the non-padding region,
- a direct unit test on `_mask_rna` with explicit `seq_len`,
- `y_masked` zero-out behaviour at non-masked positions.

The padding-regression test fails on `main` (the right neighbour of the last real token gets overwritten with `mask_idx`) and passes after the fix. All 115 tests in `pyaptamer/datasets`, `pyaptamer/utils`, and `pyaptamer/mcts` pass locally.

#### Any other comments?

This is independent of the open work on `MaskedDataset` random replacement (#500 / #502), which addresses the BERT-style 10 percent random-token branch rather than the RNA adjacent masking path. The two fixes do not overlap.

#### PR checklist

- [x] The PR title starts with `[BUG]`.
- [x] Added tests covering the fix and the broader `MaskedDataset` behaviour.
- [x] Ran `pre-commit` on the changed files.
