### PR TITLE
[BUG] Preserve (n, max_len) shape from rna2vec and encode_rna on empty input

### DIFF
--- a/pyaptamer/utils/_rna.py
+++ b/pyaptamer/utils/_rna.py
@@ -170,7 +170,16 @@ def rna2vec(
 
             result.append(padded_sequence)
 
-    return np.array(result)
+    if not result:
+        # Preserve the documented (n_sequences, max_sequence_length) shape
+        # when every input sequence was filtered out (or the input was empty).
+        # numpy cannot infer the inner dimension from an empty list, so build
+        # the empty 2-D array explicitly.
+        if max_sequence_length is not None:
+            return np.empty((0, max_sequence_length), dtype=np.int64)
+        return np.empty((0, 0), dtype=np.int64)
+
+    return np.stack(result)
 
 
 def encode_rna(
@@ -249,8 +258,12 @@ def encode_rna(
         padded_tokens = tokens + [0] * (max_len - len(tokens))
         encoded_sequences.append(padded_tokens)
 
-    # convert to numpy array first
-    result = np.array(encoded_sequences, dtype=np.int64)
+    # convert to numpy array, preserving the documented
+    # (n_sequences, max_len) shape even when the input is empty
+    if encoded_sequences:
+        result = np.array(encoded_sequences, dtype=np.int64)
+    else:
+        result = np.empty((0, max_len), dtype=np.int64)
 
     if return_type == "numpy":
         return result

--- a/pyaptamer/utils/_rna.py
+++ b/pyaptamer/utils/_rna.py
@@ -175,9 +175,7 @@ def rna2vec(
         # when every input sequence was filtered out (or the input was empty).
         # numpy cannot infer the inner dimension from an empty list, so build
         # the empty 2-D array explicitly.
-        if max_sequence_length is not None:
-            return np.empty((0, max_sequence_length), dtype=np.int64)
-        return np.empty((0, 0), dtype=np.int64)
+        return np.empty((0, max_sequence_length), dtype=np.int64)
 
     return np.stack(result)
 

--- a/pyaptamer/utils/tests/test_rna.py
+++ b/pyaptamer/utils/tests/test_rna.py
@@ -167,6 +167,22 @@ def test_rna2vec_edge_cases():
     assert len(result) == 0
 
 
+def test_rna2vec_empty_input_preserves_shape():
+    """Empty input must keep the documented (n_sequences, max_len) shape."""
+    # explicit empty input
+    result = rna2vec([], sequence_type="rna", max_sequence_length=275)
+    assert result.shape == (0, 275)
+    assert result.dtype == np.int64
+
+    # all sequences too short -> all dropped, must still be (0, max_len)
+    result = rna2vec(["A", "AA", ""], sequence_type="rna", max_sequence_length=10)
+    assert result.shape == (0, 10)
+
+    # secondary structure with empty input
+    result = rna2vec([], sequence_type="ss", max_sequence_length=42)
+    assert result.shape == (0, 42)
+
+
 def test_rna2vec_default_parameters():
     """Check that default parameters work correctly."""
     sequences = ["ACGU"]
@@ -242,3 +258,20 @@ def test_encode_rna(sequences, words, max_len, word_max_len, expected):
 
     # verify all values are non-negative
     assert (encoded >= 0).all()
+
+
+def test_encode_rna_empty_input_preserves_shape():
+    """Empty input must keep the documented (n_sequences, max_len) shape."""
+    words = {"A": 1, "C": 2, "G": 3, "U": 4}
+
+    # default tensor return
+    encoded = encode_rna([], words, max_len=10)
+    assert isinstance(encoded, torch.Tensor)
+    assert encoded.shape == (0, 10)
+    assert encoded.dtype == torch.int64
+
+    # explicit numpy return
+    encoded_np = encode_rna([], words, max_len=7, return_type="numpy")
+    assert isinstance(encoded_np, np.ndarray)
+    assert encoded_np.shape == (0, 7)
+    assert encoded_np.dtype == np.int64


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #564.

#### What does this implement/fix? Explain your changes.

`pyaptamer.utils.rna2vec` and `pyaptamer.utils.encode_rna` both document a 2-D return shape of `(n_sequences, max_len)`, but when every input sequence is filtered out (or the input list is empty) they fall through to `np.array([])`/`np.array(encoded_sequences, dtype=np.int64)` and return a 1-D array of shape `(0,)`. The shape contract is broken: any caller that does `result.shape[1]`, slices along axis 1, stacks the result with another `(n, max_len)` array, or feeds it into `nn.Embedding` crashes on what should be a no-op empty batch.

The fix:

- Construct the empty result explicitly with `np.empty((0, max_len), dtype=np.int64)` in both functions, so the shape stays `(0, max_len)` (or `(0, max_sequence_length)` for `rna2vec`).
- Switch `rna2vec`'s populated branch to `np.stack(result)` so dtype and shape stay consistent with the empty branch and so the function still returns a proper 2-D array when sequences are present.
- For `encode_rna`, the populated branch is unchanged (`np.array(encoded_sequences, dtype=np.int64)` with at least one row already gives the correct 2-D shape).

Behaviour for non-empty input is unchanged. The existing edge-case test that exercises `rna2vec(["A"])`, `rna2vec(["AA"])`, etc. (where all sequences are silently dropped) continues to pass via `len(result) == 0`, since the new shape `(0, max_len)` still has length 0.

#### What should a reviewer concentrate their feedback on?

- [x] Empty/all-dropped input now returns shape `(0, max_len)` rather than `(0,)`.
- [x] Non-empty input still returns the documented `(n_sequences, max_len)` shape and the same dtype.
- [x] No silent change in masking/encoding behaviour; only the empty-result branch is touched.

#### Did you add any tests for the change?

Yes:

- `test_rna2vec_empty_input_preserves_shape` covers `rna2vec([])` for both `sequence_type="rna"` and `sequence_type="ss"`, and `rna2vec(["A", "AA", ""])` (all sequences dropped) for the RNA path.
- `test_encode_rna_empty_input_preserves_shape` covers `encode_rna([], words, max_len)` for both `return_type="tensor"` and `return_type="numpy"`.

All existing tests in `pyaptamer/utils/tests/test_rna.py` continue to pass, and the broader test suite (`pyaptamer/datasets`, `pyaptamer/utils`, `pyaptamer/mcts`, etc.) reports 297 passed, 2 skipped locally.

#### Any other comments?

This is independent of the open silent-drop work in #511 / #372 / #363 / #284, which proposes changing `rna2vec`/`encode_rna` to keep dropped sequences as zero rows instead of removing them. This PR is purely about the shape returned when the result list ends up empty; either silent-drop or keep-rows behaviour will compose cleanly with this fix.

#### PR checklist

- [x] The PR title starts with `[BUG]`.
- [x] Added regression tests for both functions.
- [x] Ran `pre-commit` on the changed files.
