### PR TITLE
[BUG] Raise ValueError for invalid return_type in encode_rna

### DIFF
--- a/pyaptamer/utils/_rna.py
+++ b/pyaptamer/utils/_rna.py
@@ -198,7 +198,8 @@ def encode_rna(
     word_max_len : int, optional, default=3
         Maximum length of amino acid patterns to consider during tokenization.
     return_type : str, optional, default="tensor"
-        The type of the returned encoded sequences.
+        The type of the returned encoded sequences. Must be ``"tensor"`` or
+        ``"numpy"``.
 
         * "tensor": returns a PyTorch Tensor
         * "numpy": returns a NumPy ndarray
@@ -215,6 +216,13 @@ def encode_rna(
     >>> print(encode_rna("ACD", words, max_len=5))
     tensor([[4, 3, 0, 0, 0]])
     """
+    _VALID_RETURN_TYPES = ("tensor", "numpy")
+    if return_type not in _VALID_RETURN_TYPES:
+        raise ValueError(
+            f"Invalid return_type '{return_type}'. "
+            f"Must be one of {_VALID_RETURN_TYPES}."
+        )
+
     # handle single protein input
     if isinstance(sequences, str):
         sequences = [sequences]

--- a/pyaptamer/utils/tests/test_rna.py
+++ b/pyaptamer/utils/tests/test_rna.py
@@ -242,3 +242,18 @@ def test_encode_rna(sequences, words, max_len, word_max_len, expected):
 
     # verify all values are non-negative
     assert (encoded >= 0).all()
+
+
+@pytest.mark.parametrize("bad_type", ["list", "array", "", "TENSOR", "Numpy"])
+def test_encode_rna_invalid_return_type(bad_type):
+    """Invalid return_type values must raise ValueError."""
+    words = {"A": 1, "C": 2}
+    with pytest.raises(ValueError, match="Invalid return_type"):
+        encode_rna("AC", words, max_len=4, return_type=bad_type)
+
+
+def test_encode_rna_numpy_return_type():
+    """return_type='numpy' must return a NumPy ndarray."""
+    words = {"A": 1, "C": 2}
+    result = encode_rna("AC", words, max_len=4, return_type="numpy")
+    assert isinstance(result, np.ndarray)


### PR DESCRIPTION
<!--
Welcome to pyaptamer, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
Fixes #566 


#### What does this implement/fix? Explain your changes.
`encode_rna()` silently accepted invalid `return_type` values, leading to unexpected behavior downstream. This PR adds an upfront validation check that raises a `ValueError` with a clear message when `return_type` is not one of the supported values (`"tensor"` or `"numpy"`). The docstring is also updated to explicitly state the valid options.

#### What should a reviewer concentrate their feedback on?
- Whether the validation placement (before any processing) is appropriate
- Whether the error message is clear and actionable
- Whether the test parametrization covers sufficient edge cases (e.g. case sensitivity, empty string)

#### Did you add any tests for the change?

Yes:
- [x] `test_encode_rna_invalid_return_type` — parametrized test verifying `ValueError` is raised for invalid inputs (`"list"`, `"array"`, `""`, `"TENSOR"`, `"Numpy"`)
- [x] `test_encode_rna_numpy_return_type` — verifies the `"numpy"` return path produces an `np.ndarray`


#### Any other comments?
<!--
We value all user contributions, no matter how small or complex they are. If you have any questions, feel free to post
in the dev-chat channel on the pyaptamer discord channel in gc-os server https://discord.gg/7uKdHfdcJG. If we are slow to review (>7 working days), likewise feel free to ping us on discord. Thank you for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
  To run hooks independent of commit, execute `pre-commit run --all-files`

<!--
Thanks for contributing!
-->
