### PR TITLE
fix(GreedyEncoder): mark get_test_params as classmethod

### DIFF
--- a/pyaptamer/trafos/encode/_greedy.py
+++ b/pyaptamer/trafos/encode/_greedy.py
@@ -132,12 +132,13 @@ class GreedyEncoder(BaseTransform):
 
         return result_df
 
-    def get_test_params(self):
+    @classmethod
+    def get_test_params(cls):
         """Get test parameters for GreedyEncoder.
 
         Returns
         -------
-        params : dict
+        params : list of dict
             Test parameters for GreedyEncoder.
         """
         param0 = {


### PR DESCRIPTION
Resolves #568.

`skbase.base.BaseEstimator` defines `get_test_params` as a classmethod, and the rest of pyaptamer's transformers inherit that signature. `GreedyEncoder` overrode it as an instance method, so the class-level call the test framework uses raised:

```
TypeError: missing 1 required positional argument: 'self'
```

## Change

Add `@classmethod` and rename the parameter to `cls` so the override matches the parent contract. The body is unchanged; behavior is identical when invoked from an instance.

Docstring return type updated from `dict` to `list of dict` to match the actual `[param0, param1]` return.

## Verification

- `GreedyEncoder.get_test_params()` now returns the param list at the class level (matches the issue's reproducer).
- Both returned param dicts still instantiate cleanly via `GreedyEncoder(**p)`.
- No other callers in the repo rely on the instance-method form (verified via `grep -rn 'get_test_params'`).