### PR TITLE
[ENH] Add visualization module with plotting utilities for metrics

### DIFF
--- a/pyaptamer/visualization/__init__.py
+++ b/pyaptamer/visualization/__init__.py
@@ -1,0 +1,17 @@
+"""Visualization module for pyaptamer."""
+
+from pyaptamer.visualization._benchmarking import plot_benchmark_results
+from pyaptamer.visualization._interaction import plot_interaction_map
+from pyaptamer.visualization._metrics import (
+    plot_confusion_matrix,
+    plot_roc_curve,
+)
+from pyaptamer.visualization._training import plot_training_curves
+
+__all__ = [
+    "plot_confusion_matrix",
+    "plot_roc_curve",
+    "plot_benchmark_results",
+    "plot_training_curves",
+    "plot_interaction_map",
+]

--- a/pyaptamer/visualization/_benchmarking.py
+++ b/pyaptamer/visualization/_benchmarking.py
@@ -1,0 +1,62 @@
+__author__ = "Alleny244"
+__all__ = ["plot_benchmark_results"]
+
+import numpy as np
+
+
+def plot_benchmark_results(
+    results,
+    metric=None,
+    title="Benchmark Results",
+    ax=None,
+):
+    """
+    Plot benchmark results as a grouped bar chart.
+
+    Parameters
+    ----------
+    results : pd.DataFrame
+        DataFrame returned by :meth:`Benchmarking.run` with a
+        ``pd.MultiIndex`` of (estimator, metric) and columns
+        ``["train", "test"]``.
+    metric : str, optional
+        If provided, filter results to a single metric. Otherwise all
+        metrics are plotted.
+    title : str, default="Benchmark Results"
+        Title for the plot.
+    ax : matplotlib.axes.Axes, optional
+        Axes to plot on. If None, a new figure is created.
+
+    Returns
+    -------
+    ax : matplotlib.axes.Axes
+        The axes with the plotted benchmark results.
+    """
+    import matplotlib.pyplot as plt
+
+    df = results.copy()
+    if metric is not None:
+        df = df.xs(metric, level="metric")
+        x_labels = df.index.tolist()
+    else:
+        x_labels = [f"{est}\n{met}" for est, met in df.index]
+
+    x = np.arange(len(x_labels))
+    width = 0.35
+
+    if ax is None:
+        _, ax = plt.subplots(figsize=(max(6, len(x_labels) * 2), 5))
+
+    ax.bar(x - width / 2, df["train"], width, label="Train")
+    ax.bar(x + width / 2, df["test"], width, label="Test")
+
+    ax.set(
+        xticks=x,
+        xticklabels=x_labels,
+        ylabel="Score",
+        title=title,
+    )
+    ax.legend()
+    ax.set_ylim(0, 1.05)
+
+    return ax

--- a/pyaptamer/visualization/_interaction.py
+++ b/pyaptamer/visualization/_interaction.py
@@ -1,0 +1,76 @@
+__author__ = "Alleny244"
+__all__ = ["plot_interaction_map"]
+
+import numpy as np
+
+
+def plot_interaction_map(
+    interaction_map,
+    aptamer_seq=None,
+    protein_seq=None,
+    title="Aptamer–Protein Interaction Map",
+    cmap="viridis",
+    ax=None,
+):
+    """
+    Plot a 2D interaction heatmap from AptaTrans.
+
+    Parameters
+    ----------
+    interaction_map : array-like of shape (apt_len, prot_len)
+        Interaction scores between aptamer and protein positions.
+        Accepts NumPy arrays or PyTorch tensors.
+    aptamer_seq : str, optional
+        Aptamer sequence for axis labels. If longer than the map
+        dimension, it is truncated.
+    protein_seq : str, optional
+        Protein sequence for axis labels. If longer than the map
+        dimension, it is truncated.
+    title : str, default="Aptamer–Protein Interaction Map"
+        Title for the plot.
+    cmap : str, default="viridis"
+        Matplotlib colormap name.
+    ax : matplotlib.axes.Axes, optional
+        Axes to plot on. If None, a new figure is created.
+
+    Returns
+    -------
+    ax : matplotlib.axes.Axes
+        The axes with the plotted interaction map.
+    """
+    import matplotlib.pyplot as plt
+
+    if hasattr(interaction_map, "detach"):
+        interaction_map = interaction_map.detach().cpu().numpy()
+
+    interaction_map = np.asarray(interaction_map).squeeze()
+    if interaction_map.ndim != 2:
+        raise ValueError(
+            f"Expected a 2D interaction map, got shape {interaction_map.shape}."
+        )
+
+    if ax is None:
+        _, ax = plt.subplots(figsize=(10, 6))
+
+    im = ax.imshow(interaction_map, aspect="auto", cmap=cmap)
+    ax.figure.colorbar(im, ax=ax)
+
+    apt_len, prot_len = interaction_map.shape
+
+    if aptamer_seq is not None:
+        labels = list(aptamer_seq[:apt_len])
+        ax.set_yticks(range(len(labels)))
+        ax.set_yticklabels(labels, fontsize=6)
+
+    if protein_seq is not None:
+        labels = list(protein_seq[:prot_len])
+        ax.set_xticks(range(len(labels)))
+        ax.set_xticklabels(labels, fontsize=6, rotation=90)
+
+    ax.set(
+        xlabel="Protein Position",
+        ylabel="Aptamer Position",
+        title=title,
+    )
+
+    return ax

--- a/pyaptamer/visualization/_metrics.py
+++ b/pyaptamer/visualization/_metrics.py
@@ -1,0 +1,130 @@
+__author__ = "Alleny244"
+__all__ = ["plot_confusion_matrix", "plot_roc_curve"]
+
+import numpy as np
+from sklearn.metrics import auc, confusion_matrix, roc_curve
+
+
+def plot_confusion_matrix(
+    y_true,
+    y_pred,
+    labels=None,
+    normalize=False,
+    title="Confusion Matrix",
+    cmap="Blues",
+    ax=None,
+):
+    """
+    Plot a confusion matrix heatmap.
+
+    Parameters
+    ----------
+    y_true : array-like of shape (n_samples,)
+        Ground truth labels.
+    y_pred : array-like of shape (n_samples,)
+        Predicted labels.
+    labels : list of str, optional
+        Display labels for the classes.
+    normalize : bool, default=False
+        If True, normalize the matrix by row (true class).
+    title : str, default="Confusion Matrix"
+        Title for the plot.
+    cmap : str, default="Blues"
+        Matplotlib colormap name.
+    ax : matplotlib.axes.Axes, optional
+        Axes to plot on. If None, a new figure is created.
+
+    Returns
+    -------
+    ax : matplotlib.axes.Axes
+        The axes with the plotted confusion matrix.
+    """
+    import matplotlib.pyplot as plt
+
+    cm = confusion_matrix(y_true, y_pred)
+    if normalize:
+        row_sums = cm.sum(axis=1, keepdims=True)
+        row_sums = np.where(row_sums == 0, 1, row_sums)
+        cm = cm.astype(float) / row_sums
+
+    if ax is None:
+        _, ax = plt.subplots()
+
+    n_classes = cm.shape[0]
+    im = ax.imshow(cm, interpolation="nearest", cmap=cmap)
+    ax.figure.colorbar(im, ax=ax)
+
+    if labels is None:
+        labels = [str(i) for i in range(n_classes)]
+
+    ax.set(
+        xticks=np.arange(n_classes),
+        yticks=np.arange(n_classes),
+        xticklabels=labels,
+        yticklabels=labels,
+        xlabel="Predicted",
+        ylabel="True",
+        title=title,
+    )
+
+    fmt = ".2f" if normalize else "d"
+    thresh = cm.max() / 2.0
+    for i in range(n_classes):
+        for j in range(n_classes):
+            ax.text(
+                j,
+                i,
+                format(cm[i, j], fmt),
+                ha="center",
+                va="center",
+                color="white" if cm[i, j] > thresh else "black",
+            )
+
+    return ax
+
+
+def plot_roc_curve(
+    y_true,
+    y_score,
+    title="ROC Curve",
+    ax=None,
+):
+    """
+    Plot a Receiver Operating Characteristic (ROC) curve.
+
+    Parameters
+    ----------
+    y_true : array-like of shape (n_samples,)
+        True binary labels.
+    y_score : array-like of shape (n_samples,)
+        Predicted probabilities for the positive class.
+    title : str, default="ROC Curve"
+        Title for the plot.
+    ax : matplotlib.axes.Axes, optional
+        Axes to plot on. If None, a new figure is created.
+
+    Returns
+    -------
+    ax : matplotlib.axes.Axes
+        The axes with the plotted ROC curve.
+    """
+    import matplotlib.pyplot as plt
+
+    fpr, tpr, _ = roc_curve(y_true, y_score)
+    roc_auc = auc(fpr, tpr)
+
+    if ax is None:
+        _, ax = plt.subplots()
+
+    ax.plot(fpr, tpr, lw=2, label=f"AUC = {roc_auc:.2f}")
+    ax.plot([0, 1], [0, 1], "k--", lw=1)
+    ax.set(
+        xlim=[0.0, 1.0],
+        ylim=[0.0, 1.05],
+        xlabel="False Positive Rate",
+        ylabel="True Positive Rate",
+        title=title,
+    )
+    ax.legend(loc="lower right")
+
+    return ax

--- a/pyaptamer/visualization/_training.py
+++ b/pyaptamer/visualization/_training.py
@@ -1,0 +1,48 @@
+__author__ = "Alleny244"
+__all__ = ["plot_training_curves"]
+
+
+def plot_training_curves(
+    train_losses,
+    val_losses=None,
+    title="Training Curves",
+    ax=None,
+):
+    """
+    Plot training and optional validation loss curves.
+
+    Parameters
+    ----------
+    train_losses : list of float
+        Training loss values per epoch.
+    val_losses : list of float, optional
+        Validation loss values per epoch.
+    title : str, default="Training Curves"
+        Title for the plot.
+    ax : matplotlib.axes.Axes, optional
+        Axes to plot on. If None, a new figure is created.
+
+    Returns
+    -------
+    ax : matplotlib.axes.Axes
+        The axes with the plotted curves.
+    """
+    import matplotlib.pyplot as plt
+
+    if ax is None:
+        _, ax = plt.subplots()
+
+    epochs = range(1, len(train_losses) + 1)
+    ax.plot(epochs, train_losses, label="Train Loss")
+
+    if val_losses is not None:
+        ax.plot(epochs, val_losses, label="Val Loss")
+
+    ax.set(
+        xlabel="Epoch",
+        ylabel="Loss",
+        title=title,
+    )
+    ax.legend()
+
+    return ax

--- a/pyaptamer/visualization/tests/test_visualization.py
+++ b/pyaptamer/visualization/tests/test_visualization.py
@@ -1,0 +1,104 @@
+import matplotlib
+import numpy as np
+import pandas as pd
+import pytest
+
+matplotlib.use("Agg")
+
+from pyaptamer.visualization import (
+    plot_benchmark_results,
+    plot_confusion_matrix,
+    plot_interaction_map,
+    plot_roc_curve,
+    plot_training_curves,
+)
+
+
+class TestPlotConfusionMatrix:
+    def test_basic(self):
+        y_true = [0, 0, 1, 1]
+        y_pred = [0, 1, 1, 1]
+        ax = plot_confusion_matrix(y_true, y_pred)
+        assert ax is not None
+        assert ax.get_title() == "Confusion Matrix"
+
+    def test_normalized(self):
+        y_true = [0, 0, 1, 1]
+        y_pred = [0, 1, 1, 1]
+        ax = plot_confusion_matrix(y_true, y_pred, normalize=True)
+        assert ax is not None
+
+    def test_custom_labels(self):
+        y_true = [0, 0, 1, 1]
+        y_pred = [0, 0, 1, 1]
+        ax = plot_confusion_matrix(y_true, y_pred, labels=["Neg", "Pos"])
+        labels = [t.get_text() for t in ax.get_xticklabels()]
+        assert labels == ["Neg", "Pos"]
+
+
+class TestPlotRocCurve:
+    def test_basic(self):
+        y_true = [0, 0, 1, 1]
+        y_score = [0.1, 0.4, 0.6, 0.9]
+        ax = plot_roc_curve(y_true, y_score)
+        assert ax is not None
+        assert "AUC" in ax.get_legend().get_texts()[0].get_text()
+
+    def test_perfect_prediction(self):
+        y_true = [0, 0, 1, 1]
+        y_score = [0.0, 0.0, 1.0, 1.0]
+        ax = plot_roc_curve(y_true, y_score)
+        assert "1.00" in ax.get_legend().get_texts()[0].get_text()
+
+
+class TestPlotBenchmarkResults:
+    @pytest.fixture()
+    def benchmark_df(self):
+        index = pd.MultiIndex.from_tuples(
+            [("ModelA", "accuracy"), ("ModelA", "f1"), ("ModelB", "accuracy")],
+            names=["estimator", "metric"],
+        )
+        return pd.DataFrame(
+            {"train": [0.9, 0.85, 0.88], "test": [0.8, 0.75, 0.82]},
+            index=index,
+        )
+
+    def test_all_metrics(self, benchmark_df):
+        ax = plot_benchmark_results(benchmark_df)
+        assert ax is not None
+
+    def test_single_metric(self, benchmark_df):
+        ax = plot_benchmark_results(benchmark_df, metric="accuracy")
+        assert ax is not None
+
+
+class TestPlotTrainingCurves:
+    def test_train_only(self):
+        ax = plot_training_curves([1.0, 0.8, 0.6, 0.4])
+        assert ax is not None
+        assert len(ax.get_lines()) == 1
+
+    def test_train_and_val(self):
+        ax = plot_training_curves([1.0, 0.8, 0.6], [0.9, 0.85, 0.7])
+        assert len(ax.get_lines()) == 2
+
+
+class TestPlotInteractionMap:
+    def test_numpy_input(self):
+        imap = np.random.rand(10, 20)
+        ax = plot_interaction_map(imap)
+        assert ax is not None
+
+    def test_with_sequences(self):
+        imap = np.random.rand(5, 8)
+        ax = plot_interaction_map(imap, aptamer_seq="AGCTA", protein_seq="ACDEFGHI")
+        assert ax is not None
+
+    def test_invalid_shape(self):
+        with pytest.raises(ValueError, match="2D"):
+            plot_interaction_map(np.random.rand(5))
+
+    def test_squeeze_batch_dim(self):
+        imap = np.random.rand(1, 1, 5, 8)
+        ax = plot_interaction_map(imap)
+        assert ax is not None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,10 +27,14 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+viz = [
+    "matplotlib>=3.7.0",
+]
 dev = [
     "ruff>=0.12.0",
     "pytest>=9.0.3",
     "pre-commit",
+    "matplotlib>=3.7.0",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
…enchmarks, and interaction maps

<!--
Welcome to pyaptamer, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
Fixes #573 

#### What does this implement/fix? Explain your changes.
Adds a new pyaptamer.visualization module with five plotting utilities:

- plot_confusion_matrix — confusion matrix heatmap with optional row normalization
- plot_roc_curve — ROC curve with AUC annotation
- plot_benchmark_results — grouped bar chart consuming Benchmarking.run() DataFrames
- plot_training_curves — epoch-wise train/validation loss curves
- plot_interaction_map — 2D heatmap for AptaTrans interaction maps (supports both NumPy arrays and PyTorch tensors)

All functions return matplotlib.axes.Axes and accept an optional ax parameter for subplot composability. matplotlib is added as an optional dependency under [viz].

#### What should a reviewer concentrate their feedback on?

- Whether the API design (function signatures, parameter names) is consistent with the rest of pyaptamer
- Whether matplotlib should be a core dependency instead of optional
- Whether any additional plots would be valuable for v1 (e.g. attention weight visualizations)

#### Did you add any tests for the change?
Yes — 13 tests in pyaptamer/visualization/tests/test_visualization.py:

-  TestPlotConfusionMatrix — basic, normalized, custom labels
-  TestPlotRocCurve — basic and perfect prediction
-  TestPlotBenchmarkResults — all metrics and single metric filter
-  TestPlotTrainingCurves — train only and train+val
-  TestPlotInteractionMap — numpy input, sequences, invalid shape, batch dim squeeze

#### Any other comments?
None.



#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
  To run hooks independent of commit, execute `pre-commit run --all-files`

<!--
Thanks for contributing!
-->
