### PR TITLE
BUG: Implement dynamic has_y tag management in APIDataset to resolve …

### DIFF
--- a/pyaptamer/datasets/dataclasses/_api.py
+++ b/pyaptamer/datasets/dataclasses/_api.py
@@ -41,19 +41,28 @@ class APIDataset(BaseObject):
     }
 
     def __init__(self, x_apta=None, x_prot=None, y=None):
-        super().__init__()
+        super().__init__()  # Initialize BaseObject first
+        
         if x_apta is None and x_prot is None:
             self._X = None
             self.y = None
+            # Update tag even for empty initialization
+            self.set_tags(has_y=False)
             return
+
         self._X = self._check_inputs(x_apta, x_prot)
-        # Normalize y to a 1D numpy array (handles DataFrame, Series, 2D column vectors)
+        
+        # Normalize y to a 1D numpy array
         if y is not None:
             if isinstance(y, pd.DataFrame):
                 y = y.iloc[:, 0]
             self.y = np.asarray(y).ravel()
         else:
             self.y = None
+
+        # THE FIX: Sync the instance tags with reality
+        # If y is None, has_y becomes False, stopping the DataLoader crash
+        self.set_tags(has_y=(self.y is not None))
 
     def load(self) -> pd.DataFrame:
         """Return X as a 2-column pd.DataFrame with columns [aptamer, protein]."""

--- a/pyaptamer/datasets/dataclasses/tests/test_api.py
+++ b/pyaptamer/datasets/dataclasses/tests/test_api.py
@@ -117,11 +117,15 @@ def test_init_unsupported_type_raises():
 def test_y_is_none_when_unlabeled():
     ds = APIDataset(x_apta=[APTA_A], x_prot=[PROT_A])
     assert ds.y is None
+    # Dynamic tag check
+    assert ds.get_tags()["has_y"] is False
 
 
 def test_y_stored_as_numpy_array():
     ds = APIDataset(x_apta=[APTA_A], x_prot=[PROT_A], y=[1])
     assert isinstance(ds.y, np.ndarray)
+    # Dynamic tag check
+    assert ds.get_tags()["has_y"] is True
 
 
 # -- from_any tests --------------------------------------------------


### PR DESCRIPTION
Reference Issues/PRs
Fixes the has_y metadata discrepancy identified during the refactor in #430. Relates to the TypeError in DataLoader reported by @DashratRajpurohit.

What does this implement/fix? Explain your changes.
I have implemented a dynamic tag-management system for APIDataset.

The Problem: has_y was previously a static class-level attribute. During unlabeled inference (when y=None), the container incorrectly signaled that labels were present. This caused the TorchDataset and DataLoader to attempt to yield non-existent labels, resulting in a crash.

The Solution: I shifted tag management to the instance level within __init__. By using self.set_tags(has_y=(self.y is not None)), the container now dynamically synchronizes its metadata with the actual data state. This ensures the skbase interface correctly informs downstream loaders whether to expect labels.

What should a reviewer concentrate their feedback on?
The use of self.set_tags after super().__init__ to ensure proper skbase object initialization.

The placement of the tag update within the __init__ logic to catch all initialization paths, including empty inits.

Did you add any tests for the change?
Yes. I integrated new assertions into pyaptamer/datasets/dataclasses/tests/test_api.py to verify:

has_y is False when y=None (Inference mode).

has_y is True when labels are provided (Training mode).

Verified the entire suite with pytest: 388 passed.

Any other comments?
This fix addresses the root architectural cause (metadata discrepancy) rather than patching the symptom in the training pipeline, maintaining better long-term framework integrity.