### PR TITLE
[BUG] Add defensive column validation to APIDataset.from_any

### DIFF
--- a/pyaptamer/datasets/dataclasses/_api.py
+++ b/pyaptamer/datasets/dataclasses/_api.py
@@ -98,14 +98,18 @@ class APIDataset(BaseObject):
         if isinstance(X, APIDataset):
             return X
 
-        # Rename DataFrame columns to canonical before coercion. The rest of
-        # the codebase always sees ["aptamer", "protein"].
-        if isinstance(X, pd.DataFrame) and (
-            apta_col != "aptamer" or prot_col != "protein"
-        ):
-            X = X.rename(columns={apta_col: "aptamer", prot_col: "protein"})
-
         df = coerce_input(X)
+
+        # If input was a DataFrame, ensure it has the required columns
+        if isinstance(X, pd.DataFrame):
+            missing = [c for c in [apta_col, prot_col] if c not in df.columns]
+            if missing:
+                raise ValueError(f"DataFrame is missing required columns: {missing}")
+
+            # Rename to canonical names ["aptamer", "protein"]
+            if apta_col != "aptamer" or prot_col != "protein":
+                df = df.rename(columns={apta_col: "aptamer", prot_col: "protein"})
+
         return cls(x_apta=df["aptamer"], x_prot=df["protein"], y=y)
 
     def _check_inputs(self, x_apta, x_prot) -> pd.DataFrame:

--- a/pyaptamer/datasets/dataclasses/tests/test_api.py
+++ b/pyaptamer/datasets/dataclasses/tests/test_api.py
@@ -190,3 +190,15 @@ def test_from_any_with_molecule_loader_pair():
 def test_from_any_unsupported_raises():
     with pytest.raises(TypeError):
         APIDataset.from_any("not a valid input")
+
+
+def test_from_any_missing_columns():
+    """ValueError is raised if a DataFrame is missing required columns."""
+    df = pd.DataFrame({"wrong_apta": [APTA_A], "protein": [PROT_A]})
+    # Default columns
+    with pytest.raises(ValueError, match="missing required columns"):
+        APIDataset.from_any(df, y=[1])
+
+    # Custom columns
+    with pytest.raises(ValueError, match="missing required columns"):
+        APIDataset.from_any(df, y=[1], apta_col="wrong_apta", prot_col="missing")


### PR DESCRIPTION
### Reference Issues/PRs
Relates to the dataclass input handling refactor introduced in PR #441.

### What does this implement/fix? Explain your changes.
This PR adds defensive validation to `APIDataset.from_any` when handling `pd.DataFrame` inputs to prevent cryptic downstream `KeyError`s.

**The Problem:**
Following the refactor to support dynamic column names (`apta_col` and `prot_col`), if a user passes a DataFrame that is missing the specified columns, the `coerce_input` method passes the dataframe through silently. This results in a confusing `KeyError` deeper in the initialization process when the code attempts to extract the canonical `["aptamer"]` and `["protein"]` series.

**The Solution:**
I have added an explicit validation check immediately after coercion. If the input is a DataFrame, the method now verifies that both expected columns exist. If they are missing, it halts execution and raises a clear `ValueError: DataFrame is missing required columns: [...]`. This ensures the dynamic column feature fails gracefully and provides immediate, actionable feedback to the user.

### Steps to Reproduce / Proof of Fix
Prior to this PR, passing a malformed DataFrame resulted in an unhandled exception. It now correctly raises a validation error:

```python
import pyaptamer
import pandas as pd

# User provides a dataframe but makes a typo in the column name
bad_df = pd.DataFrame({
    "wrong_aptamer_name": ["ATCG"], 
    "protein": ["MKT"]
})
```

**Before PR:** 
Crashes with KeyError: 'aptamer' during initialization
**After PR:** 
Fails gracefully and alerts the user
pyaptamer.APIDataset.from_any(bad_df) 
-> ValueError: DataFrame is missing required columns: ['aptamer']

**Did you add any tests for the change?**

Yes. I added test_from_any_missing_columns in tests/test_api.py to strictly verify that the ValueError triggers correctly for both default column names and custom kwargs column names.