### PR TITLE
fix: implement true RNA reverse complement in augment_reverse and correct tests

### DIFF
--- a/pyaptamer/utils/_augment.py
+++ b/pyaptamer/utils/_augment.py
@@ -3,9 +3,11 @@ __all__ = ["augment_reverse"]
 
 import numpy as np
 
+_RNA_COMPLEMENT = str.maketrans("ACGUacgu", "UGCAugca")
+
 
 def augment_reverse(*sequence_arrays: np.ndarray) -> tuple[np.ndarray, ...]:
-    """Augment arrays of sequences by adding the reversed sequences.
+    """Augment arrays of sequences by adding their reverse complement.
 
     Parameters
     ----------
@@ -15,15 +17,15 @@ def augment_reverse(*sequence_arrays: np.ndarray) -> tuple[np.ndarray, ...]:
     Returns
     -------
     tuple[np.ndarray, ...]
-        A tuple of arrays, each containing sequences with their reversed sequences.
+        A tuple of arrays, each containing sequences with their reverse complements
         added.
     """
     results = []
     for sequences in sequence_arrays:
-        # create array of reversed sequences
-        reversed_sequences = np.array([seq[::-1] for seq in sequences])
-        # concatenate original and reversed sequences
-        result = np.concatenate([sequences, reversed_sequences])
+        rc_sequences = np.array(
+            [seq[::-1].translate(_RNA_COMPLEMENT) for seq in sequences]
+        )
+        result = np.concatenate([sequences, rc_sequences])
         results.append(result)
 
     return tuple(results)

--- a/pyaptamer/utils/tests/test_augment.py
+++ b/pyaptamer/utils/tests/test_augment.py
@@ -8,32 +8,34 @@ from pyaptamer.utils._augment import augment_reverse
 
 
 def test_augment_reverse_single_array():
-    sequences = np.array(["AAC", "BBB", "ATCG"])
+    # "AUCG" -> reverse "GCUA" -> complement "CGAU"
+    # "AAAA" -> reverse "AAAA" -> complement "UUUU"
+    # "GCGC" -> reverse "CGCG" -> complement "GCGC" (palindrome)
+    sequences = np.array(["AUCG", "AAAA", "GCGC"])
     result = augment_reverse(sequences)
 
-    expected = (np.array(["AAC", "BBB", "ATCG", "CAA", "BBB", "GCTA"]),)
+    expected = (np.array(["AUCG", "AAAA", "GCGC", "CGAU", "UUUU", "GCGC"]),)
     assert len(result) == 1
     assert len(result[0]) == 6
     np.testing.assert_array_equal(result[0], expected[0])
 
 
 def test_augment_reverse_multiple_arrays():
-    seq1 = np.array(["ABC", "DEF"])
-    seq2 = np.array(["XYZ"])
-    seq3 = np.array(["123", "456", "789"])
+    # "AAUG" -> reverse "GUAA" -> complement "CAUU"
+    # "CCGG" -> reverse "GGCC" -> complement "CCGG"
+    seq1 = np.array(["AAUG", "CCGG"])
+    # "UGCA" -> reverse "ACGU" -> complement "UGCA"
+    seq2 = np.array(["UGCA"])
 
-    result = augment_reverse(seq1, seq2, seq3)
+    result = augment_reverse(seq1, seq2)
 
     expected = (
-        np.array(["ABC", "DEF", "CBA", "FED"]),
-        np.array(["XYZ", "ZYX"]),
-        np.array(["123", "456", "789", "321", "654", "987"]),
+        np.array(["AAUG", "CCGG", "CAUU", "CCGG"]),
+        np.array(["UGCA", "UGCA"]),
     )
-    assert len(result) == 3
+    assert len(result) == 2
     assert len(result[0]) == 4
     assert len(result[1]) == 2
-    assert len(result[2]) == 6
 
     np.testing.assert_array_equal(result[0], expected[0])
     np.testing.assert_array_equal(result[1], expected[1])
-    np.testing.assert_array_equal(result[2], expected[2])


### PR DESCRIPTION
## SUMMARY

This PR fixes `augment_reverse()` in `pyaptamer/utils/_augment.py`, which was only reversing sequences instead of generating true reverse complements. It also updates tests in `pyaptamer/utils/tests/test_augment.py` to use real RNA sequences and validate correct behavior.

---

## FIX

**Before**

```python
reversed_sequences = np.array([seq[::-1] for seq in sequences])
```

**After**

```python
_RNA_COMPLEMENT = str.maketrans("ACGUacgu", "UGCAugca")

rc_sequences = np.array(
    [seq[::-1].translate(_RNA_COMPLEMENT) for seq in sequences]
)
```


---

## VERIFICATION

Tests now use real RNA inputs and pass successfully. Example: `"AUCG"` correctly returns `"CGAU"` instead of just `"GCUA"`. Palindromes like `"GCGC"` behave correctly as well.
