### PR TITLE
[ENH] Add motif discovery module with k-mer enrichment analysis

### DIFF
--- a/pyaptamer/motifs/__init__.py
+++ b/pyaptamer/motifs/__init__.py
@@ -1,0 +1,7 @@
+"""Sequence motif discovery for aptamer pools."""
+
+__author__ = ["Alleny244"]
+__all__ = ["MotifFinder", "EnrichmentTracker"]
+
+from pyaptamer.motifs._enrichment import EnrichmentTracker
+from pyaptamer.motifs._finder import MotifFinder

--- a/pyaptamer/motifs/_enrichment.py
+++ b/pyaptamer/motifs/_enrichment.py
@@ -1,0 +1,153 @@
+"""Track sequence enrichment across SELEX rounds."""
+
+__author__ = ["Alleny244"]
+__all__ = ["EnrichmentTracker"]
+
+from collections import Counter
+
+import pandas as pd
+from skbase.base import BaseObject
+
+from pyaptamer import logger
+
+
+class EnrichmentTracker(BaseObject):
+    """Track sequence enrichment across multiple SELEX rounds.
+
+    Computes fold-enrichment and frequency changes for sequences
+    observed across sequential selection rounds, enabling identification
+    of sequences that are being positively selected.
+
+    Parameters
+    ----------
+    min_count : int, optional, default=2
+        Minimum count threshold for a sequence to be considered
+        in enrichment calculations. Sequences below this threshold
+        in all rounds are filtered out.
+    pseudocount : float, optional, default=1.0
+        Pseudocount added to frequencies to avoid division by zero
+        when computing fold-enrichment.
+
+    Attributes
+    ----------
+    round_counts_ : list[Counter]
+        Raw sequence counts per round after fitting.
+    enrichment_ : pd.DataFrame
+        Enrichment statistics computed after calling ``compute``.
+
+    Examples
+    --------
+    >>> from pyaptamer.motifs import EnrichmentTracker
+    >>> rounds = [
+    ...     ["ACGT", "ACGT", "TGCA", "AAAA"],
+    ...     ["ACGT", "ACGT", "ACGT", "TGCA"],
+    ... ]
+    >>> tracker = EnrichmentTracker(min_count=1)
+    >>> tracker.add_round(rounds[0])
+    >>> tracker.add_round(rounds[1])
+    >>> result = tracker.compute()
+    """
+
+    def __init__(self, min_count: int = 2, pseudocount: float = 1.0):
+        self.min_count = min_count
+        self.pseudocount = pseudocount
+        self.round_counts_: list[Counter] = []
+        self.enrichment_: pd.DataFrame | None = None
+        super().__init__()
+
+    def add_round(self, sequences: list[str]) -> "EnrichmentTracker":
+        """Add a SELEX round of sequences.
+
+        Parameters
+        ----------
+        sequences : list[str]
+            List of nucleotide sequences from one SELEX round.
+
+        Returns
+        -------
+        self : EnrichmentTracker
+        """
+        self.round_counts_.append(Counter(sequences))
+        self.enrichment_ = None
+        return self
+
+    def compute(self) -> pd.DataFrame:
+        """Compute enrichment statistics across all added rounds.
+
+        Returns
+        -------
+        enrichment : pd.DataFrame
+            DataFrame with columns for each round's frequency and
+            fold-enrichment between consecutive rounds. Index is
+            the sequence string.
+
+        Raises
+        ------
+        ValueError
+            If fewer than 2 rounds have been added.
+        """
+        if len(self.round_counts_) < 2:
+            raise ValueError(
+                "At least 2 rounds are required to compute enrichment. "
+                f"Got {len(self.round_counts_)}."
+            )
+
+        all_seqs = set()
+        for counts in self.round_counts_:
+            all_seqs.update(counts.keys())
+
+        all_seqs = {
+            seq
+            for seq in all_seqs
+            if any(c[seq] >= self.min_count for c in self.round_counts_)
+        }
+
+        data = {}
+        for i, counts in enumerate(self.round_counts_):
+            total = sum(counts.values())
+            freqs = {seq: counts[seq] / total for seq in all_seqs}
+            data[f"freq_round_{i}"] = freqs
+
+        df = pd.DataFrame(data)
+
+        for i in range(1, len(self.round_counts_)):
+            prev_col = f"freq_round_{i - 1}"
+            curr_col = f"freq_round_{i}"
+            df[f"fold_enrichment_{i}"] = (
+                df[curr_col] + self.pseudocount / sum(self.round_counts_[i].values())
+            ) / (
+                df[prev_col]
+                + self.pseudocount / sum(self.round_counts_[i - 1].values())
+            )
+
+        df = df.sort_values(df.columns[-1], ascending=False)
+
+        self.enrichment_ = df
+        logger.info(
+            "Computed enrichment for %d sequences across %d rounds.",
+            len(df),
+            len(self.round_counts_),
+        )
+        return df
+
+    def top_enriched(self, n: int = 10, round_idx: int = -1) -> pd.DataFrame:
+        """Return the top-n enriched sequences.
+
+        Parameters
+        ----------
+        n : int, optional, default=10
+            Number of top sequences to return.
+        round_idx : int, optional, default=-1
+            Which fold-enrichment column to rank by. -1 uses the last.
+
+        Returns
+        -------
+        top : pd.DataFrame
+            Top-n rows from the enrichment DataFrame.
+        """
+        if self.enrichment_ is None:
+            self.compute()
+
+        fold_cols = [c for c in self.enrichment_.columns if c.startswith("fold_")]
+        col = fold_cols[round_idx]
+        return self.enrichment_.nlargest(n, col)

--- a/pyaptamer/motifs/_finder.py
+++ b/pyaptamer/motifs/_finder.py
@@ -1,0 +1,283 @@
+"""Motif discovery from aptamer sequence pools."""
+
+__author__ = ["Alleny244"]
+__all__ = ["MotifFinder"]
+
+from collections import Counter
+
+import numpy as np
+import pandas as pd
+from skbase.base import BaseEstimator
+
+from pyaptamer import logger
+
+
+class MotifFinder(BaseEstimator):
+    """Discover conserved sequence motifs in aptamer pools.
+
+    Identifies over-represented k-mers in a pool of sequences using
+    frequency analysis and information-theoretic scoring. Builds a
+    position weight matrix (PWM) for each discovered motif.
+
+    Parameters
+    ----------
+    k : int, optional, default=6
+        Length of k-mers to scan for.
+    top_n : int, optional, default=10
+        Number of top over-represented k-mers to report.
+    background : dict[str, float] or None, optional, default=None
+        Background nucleotide frequencies. If None, assumes uniform
+        distribution (0.25 each for A, C, G, T/U).
+    alphabet : str, optional, default="DNA"
+        Sequence alphabet. One of "DNA" or "RNA".
+
+    Attributes
+    ----------
+    kmer_counts_ : Counter
+        Raw k-mer counts from fitted sequences.
+    kmer_scores_ : pd.DataFrame
+        K-mer enrichment scores after fitting.
+    motifs_ : list[dict]
+        Discovered motifs with PWM and consensus information.
+    n_sequences_ : int
+        Number of sequences used for fitting.
+
+    References
+    ----------
+    .. [1] Bailey, Timothy L., and Charles Elkan. "Fitting a mixture model by
+    expectation maximization to discover motifs in biopolymers." Proceedings
+    of the Second International Conference on Intelligent Systems for
+    Molecular Biology. Vol. 2. AAAI Press, 1994.
+
+    Examples
+    --------
+    >>> from pyaptamer.motifs import MotifFinder
+    >>> sequences = ["ACGTACGTAA", "TACGTACGTT", "GACGTACGTC"]
+    >>> finder = MotifFinder(k=4, top_n=3)
+    >>> finder.fit(sequences)
+    MotifFinder(k=4, top_n=3)
+    >>> finder.motifs_[0]["consensus"]
+    'ACGT'
+    """
+
+    _tags = {
+        "object_type": "motif_finder",
+    }
+
+    ALPHABETS = {
+        "DNA": "ACGT",
+        "RNA": "ACGU",
+    }
+
+    def __init__(
+        self,
+        k: int = 6,
+        top_n: int = 10,
+        background: dict[str, float] | None = None,
+        alphabet: str = "DNA",
+    ):
+        self.k = k
+        self.top_n = top_n
+        self.background = background
+        self.alphabet = alphabet
+        super().__init__()
+
+    def fit(self, X, y=None):
+        """Fit the motif finder to a collection of sequences.
+
+        Parameters
+        ----------
+        X : list[str] or pd.DataFrame
+            Input sequences. If a DataFrame, uses the first column.
+        y : ignored
+
+        Returns
+        -------
+        self : MotifFinder
+        """
+        sequences = self._to_sequence_list(X)
+        self.n_sequences_ = len(sequences)
+
+        if self.alphabet not in self.ALPHABETS:
+            raise ValueError(
+                f"Unknown alphabet '{self.alphabet}'. "
+                f"Must be one of {list(self.ALPHABETS.keys())}."
+            )
+
+        chars = self.ALPHABETS[self.alphabet]
+        bg = self.background or {c: 1.0 / len(chars) for c in chars}
+
+        self.kmer_counts_ = self._count_kmers(sequences, self.k)
+        self.kmer_scores_ = self._score_kmers(self.kmer_counts_, bg, sequences)
+        self.motifs_ = self._build_motifs(sequences, chars)
+
+        logger.info(
+            "Discovered %d motifs from %d sequences (k=%d).",
+            len(self.motifs_),
+            self.n_sequences_,
+            self.k,
+        )
+        return self
+
+    def transform(self, X):
+        """Encode sequences by motif occurrence counts.
+
+        Parameters
+        ----------
+        X : list[str] or pd.DataFrame
+            Input sequences.
+
+        Returns
+        -------
+        features : pd.DataFrame
+            DataFrame with one column per motif, values are occurrence
+            counts of that motif in each sequence.
+        """
+        sequences = self._to_sequence_list(X)
+        motif_seqs = [m["consensus"] for m in self.motifs_]
+
+        data = {}
+        for motif in motif_seqs:
+            data[f"motif_{motif}"] = [
+                self._count_occurrences(seq, motif) for seq in sequences
+            ]
+        return pd.DataFrame(data)
+
+    def fit_transform(self, X, y=None):
+        """Fit and transform in one step.
+
+        Parameters
+        ----------
+        X : list[str] or pd.DataFrame
+            Input sequences.
+        y : ignored
+
+        Returns
+        -------
+        features : pd.DataFrame
+        """
+        return self.fit(X, y).transform(X)
+
+    def get_pwm(self, motif_idx: int = 0) -> pd.DataFrame:
+        """Get the position weight matrix for a discovered motif.
+
+        Parameters
+        ----------
+        motif_idx : int, optional, default=0
+            Index of the motif in ``motifs_``.
+
+        Returns
+        -------
+        pwm : pd.DataFrame
+            Position weight matrix with positions as rows and
+            nucleotides as columns.
+        """
+        return self.motifs_[motif_idx]["pwm"]
+
+    def _to_sequence_list(self, X):
+        if isinstance(X, pd.DataFrame):
+            return X.iloc[:, 0].tolist()
+        return list(X)
+
+    @staticmethod
+    def _count_kmers(sequences, k):
+        counts = Counter()
+        for seq in sequences:
+            seq_upper = seq.upper()
+            for i in range(len(seq_upper) - k + 1):
+                counts[seq_upper[i : i + k]] += 1
+        return counts
+
+    @staticmethod
+    def _count_occurrences(sequence, motif):
+        count = 0
+        seq_upper = sequence.upper()
+        motif_upper = motif.upper()
+        start = 0
+        while True:
+            idx = seq_upper.find(motif_upper, start)
+            if idx == -1:
+                break
+            count += 1
+            start = idx + 1
+        return count
+
+    def _score_kmers(self, kmer_counts, background, sequences):
+        total_kmers = sum(kmer_counts.values())
+
+        records = []
+        for kmer, count in kmer_counts.items():
+            observed_freq = count / total_kmers
+            expected_freq = 1.0
+            for c in kmer:
+                expected_freq *= background.get(c.upper(), 0.25)
+
+            if expected_freq > 0:
+                score = np.log2(observed_freq / expected_freq)
+            else:
+                score = 0.0
+
+            records.append(
+                {
+                    "kmer": kmer,
+                    "count": count,
+                    "frequency": observed_freq,
+                    "expected_frequency": expected_freq,
+                    "enrichment_score": score,
+                }
+            )
+
+        df = pd.DataFrame(records).set_index("kmer")
+        return df.sort_values("enrichment_score", ascending=False)
+
+    def _build_motifs(self, sequences, chars):
+        top_kmers = self.kmer_scores_.head(self.top_n).index.tolist()
+        motifs = []
+
+        for kmer in top_kmers:
+            windows = []
+            for seq in sequences:
+                seq_upper = seq.upper()
+                start = 0
+                while True:
+                    idx = seq_upper.find(kmer, start)
+                    if idx == -1:
+                        break
+                    windows.append(seq_upper[idx : idx + self.k])
+                    start = idx + 1
+
+            if not windows:
+                continue
+
+            pwm_data = {c: [] for c in chars}
+            for pos in range(self.k):
+                col_counts = Counter(w[pos] for w in windows)
+                total = len(windows)
+                for c in chars:
+                    pwm_data[c].append(col_counts.get(c, 0) / total)
+
+            pwm = pd.DataFrame(pwm_data, index=[f"pos_{i}" for i in range(self.k)])
+
+            consensus = ""
+            for pos in range(self.k):
+                best = max(chars, key=lambda c: pwm_data[c][pos])
+                consensus += best
+
+            info_content = 0.0
+            for pos in range(self.k):
+                for c in chars:
+                    p = pwm_data[c][pos]
+                    if p > 0:
+                        info_content += p * np.log2(p / (1.0 / len(chars)))
+
+            motifs.append(
+                {
+                    "consensus": consensus,
+                    "pwm": pwm,
+                    "info_content": info_content,
+                    "n_occurrences": len(windows),
+                    "score": self.kmer_scores_.loc[kmer, "enrichment_score"],
+                }
+            )
+
+        return motifs

--- a/pyaptamer/motifs/tests/test_motifs.py
+++ b/pyaptamer/motifs/tests/test_motifs.py
@@ -1,0 +1,128 @@
+"""Tests for motif discovery module."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from pyaptamer.motifs import EnrichmentTracker, MotifFinder
+
+
+class TestMotifFinder:
+    """Tests for MotifFinder."""
+
+    @pytest.fixture
+    def sequences(self):
+        return [
+            "ACGTACGTACGT",
+            "TACGTACGTACG",
+            "GACGTACGTACG",
+            "AACGTACGTAAA",
+            "CCACGTACGTCC",
+        ]
+
+    def test_fit_returns_self(self, sequences):
+        finder = MotifFinder(k=4, top_n=3)
+        result = finder.fit(sequences)
+        assert result is finder
+
+    def test_fit_populates_attributes(self, sequences):
+        finder = MotifFinder(k=4, top_n=3)
+        finder.fit(sequences)
+        assert finder.n_sequences_ == 5
+        assert len(finder.kmer_counts_) > 0
+        assert isinstance(finder.kmer_scores_, pd.DataFrame)
+        assert len(finder.motifs_) <= 3
+
+    def test_motif_has_expected_keys(self, sequences):
+        finder = MotifFinder(k=4, top_n=1)
+        finder.fit(sequences)
+        motif = finder.motifs_[0]
+        assert "consensus" in motif
+        assert "pwm" in motif
+        assert "info_content" in motif
+        assert "n_occurrences" in motif
+        assert len(motif["consensus"]) == 4
+
+    def test_transform_returns_dataframe(self, sequences):
+        finder = MotifFinder(k=4, top_n=2)
+        finder.fit(sequences)
+        result = finder.transform(sequences)
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) == 5
+
+    def test_fit_transform(self, sequences):
+        finder = MotifFinder(k=4, top_n=2)
+        result = finder.fit_transform(sequences)
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) == 5
+
+    def test_get_pwm(self, sequences):
+        finder = MotifFinder(k=4, top_n=1)
+        finder.fit(sequences)
+        pwm = finder.get_pwm(0)
+        assert isinstance(pwm, pd.DataFrame)
+        assert pwm.shape == (4, 4)
+        np.testing.assert_allclose(pwm.sum(axis=1).values, 1.0)
+
+    def test_dataframe_input(self, sequences):
+        df = pd.DataFrame({"seq": sequences})
+        finder = MotifFinder(k=4, top_n=2)
+        finder.fit(df)
+        assert finder.n_sequences_ == 5
+
+    def test_rna_alphabet(self):
+        sequences = ["ACGUACGU", "UACGUACG", "GACGUACG"]
+        finder = MotifFinder(k=4, top_n=2, alphabet="RNA")
+        finder.fit(sequences)
+        assert len(finder.motifs_) > 0
+
+    def test_invalid_alphabet(self, sequences):
+        finder = MotifFinder(k=4, alphabet="PROTEIN")
+        with pytest.raises(ValueError, match="Unknown alphabet"):
+            finder.fit(sequences)
+
+
+class TestEnrichmentTracker:
+    """Tests for EnrichmentTracker."""
+
+    @pytest.fixture
+    def rounds(self):
+        return [
+            ["ACGT", "ACGT", "TGCA", "AAAA", "CCCC", "GGGG"],
+            ["ACGT", "ACGT", "ACGT", "TGCA", "AAAA", "ACGT"],
+        ]
+
+    def test_add_round_returns_self(self, rounds):
+        tracker = EnrichmentTracker(min_count=1)
+        result = tracker.add_round(rounds[0])
+        assert result is tracker
+
+    def test_compute_requires_two_rounds(self):
+        tracker = EnrichmentTracker()
+        tracker.add_round(["ACGT"])
+        with pytest.raises(ValueError, match="At least 2 rounds"):
+            tracker.compute()
+
+    def test_compute_returns_dataframe(self, rounds):
+        tracker = EnrichmentTracker(min_count=1)
+        tracker.add_round(rounds[0])
+        tracker.add_round(rounds[1])
+        result = tracker.compute()
+        assert isinstance(result, pd.DataFrame)
+        assert "freq_round_0" in result.columns
+        assert "freq_round_1" in result.columns
+        assert "fold_enrichment_1" in result.columns
+
+    def test_enriched_sequence_ranks_higher(self, rounds):
+        tracker = EnrichmentTracker(min_count=1)
+        tracker.add_round(rounds[0])
+        tracker.add_round(rounds[1])
+        result = tracker.compute()
+        assert result.index[0] == "ACGT"
+
+    def test_top_enriched(self, rounds):
+        tracker = EnrichmentTracker(min_count=1)
+        tracker.add_round(rounds[0])
+        tracker.add_round(rounds[1])
+        top = tracker.top_enriched(n=2)
+        assert len(top) == 2


### PR DESCRIPTION


<!--
Welcome to pyaptamer, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
Fixes #585 


#### What does this implement/fix? Explain your changes.
Adds a new motifs module with two classes:

- MotifFinder: discovers conserved k-mer motifs using frequency analysis and information-theoretic scoring. Builds PWMs, computes enrichment scores, and provides a transform() that encodes sequences by motif occurrence counts. Supports both DNA and RNA alphabets.
- EnrichmentTracker: tracks sequence enrichment across SELEX rounds, computing per-round frequencies and fold-enrichment between consecutive rounds.


#### What should a reviewer concentrate their feedback on?

- [ ]  API design — does MotifFinder fit naturally alongside existing transformers?
- [ ]  Enrichment scoring approach (log2 observed/expected with pseudocounts)
- [ ]  Whether additional motif clustering/alignment logic is needed

#### Did you add any tests for the change?

Yes ,14 tests covering both classes: fit/transform workflows, DataFrame input, RNA alphabet, invalid input handling, enrichment computation, and ranking.


#### Any other comments?
None.


#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
  To run hooks independent of commit, execute `pre-commit run --all-files`

<!--
Thanks for contributing!
-->
