### PR TITLE
fix: make GreedyEncoder.get_test_params a classmethod

### DIFF
--- a/pyaptamer/trafos/encode/_greedy.py
+++ b/pyaptamer/trafos/encode/_greedy.py
@@ -132,7 +132,8 @@ class GreedyEncoder(BaseTransform):
 
         return result_df
 
-    def get_test_params(self):
+    @classmethod
+    def get_test_params(cls):
         """Get test parameters for GreedyEncoder.
 
         Returns


### PR DESCRIPTION
## Summary
- Add `@classmethod` decorator to `GreedyEncoder.get_test_params`
- Rename `self` to `cls` to match parent class signature

## Changes
`GreedyEncoder.get_test_params` was defined as a regular instance method, but its parent class `BaseTransform` (via `skbase.base.BaseEstimator`) defines it as a `@classmethod`. This caused a `TypeError` when calling `GreedyEncoder.get_test_params()` at the class level.

## Fixes
Fixes #568