### PR TITLE
# [ENH] Improve Benchmarking API: reusability, metric support, and estimator handling

### DIFF
--- a/examples/benchmarking_enhanced_api.py
+++ b/examples/benchmarking_enhanced_api.py
@@ -1,0 +1,103 @@
+"""
+Example demonstrating the enhanced Benchmarking API.
+
+This example shows:
+1. Reusability: Using the same Benchmarking instance across different datasets
+2. String-based metrics: Using sklearn metric names like "accuracy"
+3. Estimator naming: Handling multiple instances of the same model class
+4. Custom names: Providing custom names for estimators
+"""
+
+import numpy as np
+from sklearn.model_selection import PredefinedSplit
+
+from pyaptamer.aptanet import AptaNetPipeline
+from pyaptamer.benchmarking import Benchmarking
+
+# Sample data
+aptamer_seq = "AGCTTAGCGTACAGCTTAAAAGGGTTTCCCCTGCCCGCGTAC"
+protein_seq = "ACDEFGHIKLMNPQRSTVWYACDEFGHIKLMNPQRSTVWY"
+
+# Example 1: Reusability across different datasets
+print("=" * 60)
+print("Example 1: Reusability across different datasets")
+print("=" * 60)
+
+clf = AptaNetPipeline(k=4)
+bench = Benchmarking(estimators=[clf], metrics=["accuracy"])
+
+# First dataset
+X1 = [(aptamer_seq, protein_seq) for _ in range(40)]
+y1 = np.array([0] * 20 + [1] * 20, dtype=np.float32)
+test_fold1 = np.ones(len(y1), dtype=int) * -1
+test_fold1[-5:] = 0
+cv1 = PredefinedSplit(test_fold1)
+
+print("\nDataset 1 (40 samples):")
+results1 = bench.run(X=X1, y=y1, cv=cv1)
+print(results1)
+
+# Second dataset (reusing the same bench instance)
+X2 = [(aptamer_seq, protein_seq) for _ in range(30)]
+y2 = np.array([1] * 15 + [0] * 15, dtype=np.float32)
+test_fold2 = np.ones(len(y2), dtype=int) * -1
+test_fold2[-3:] = 0
+cv2 = PredefinedSplit(test_fold2)
+
+print("\nDataset 2 (30 samples, reusing same Benchmarking instance):")
+results2 = bench.run(X=X2, y=y2, cv=cv2)
+print(results2)
+
+# Example 2: String-based metrics
+print("\n" + "=" * 60)
+print("Example 2: String-based metrics (sklearn conventions)")
+print("=" * 60)
+
+X = [(aptamer_seq, protein_seq) for _ in range(40)]
+y = np.array([0] * 20 + [1] * 20, dtype=np.float32)
+test_fold = np.ones(len(y), dtype=int) * -1
+test_fold[-5:] = 0
+cv = PredefinedSplit(test_fold)
+
+bench_str = Benchmarking(
+    estimators=[clf],
+    metrics=["accuracy", "f1"]  # String-based metric names
+)
+results = bench_str.run(X=X, y=y, cv=cv)
+print(results)
+
+# Example 3: Handling multiple instances of the same model class
+print("\n" + "=" * 60)
+print("Example 3: Automatic naming for multiple instances")
+print("=" * 60)
+
+clf1 = AptaNetPipeline(k=3)
+clf2 = AptaNetPipeline(k=4)
+clf3 = AptaNetPipeline(k=5)
+
+bench_multi = Benchmarking(
+    estimators=[clf1, clf2, clf3],
+    metrics=["accuracy"]
+)
+results = bench_multi.run(X=X, y=y, cv=cv)
+print(results)
+print("\nNote: Estimators are automatically named to avoid collisions:")
+print(results.index.get_level_values("estimator").unique().tolist())
+
+# Example 4: Custom estimator names
+print("\n" + "=" * 60)
+print("Example 4: Custom estimator names")
+print("=" * 60)
+
+bench_custom = Benchmarking(
+    estimators=[
+        ("k=3", AptaNetPipeline(k=3)),
+        ("k=4", AptaNetPipeline(k=4)),
+        ("k=5", AptaNetPipeline(k=5)),
+    ],
+    metrics=["accuracy"]
+)
+results = bench_custom.run(X=X, y=y, cv=cv)
+print(results)
+print("\nCustom names used:")
+print(results.index.get_level_values("estimator").unique().tolist())

--- a/pyaptamer/benchmarking/_base.py
+++ b/pyaptamer/benchmarking/_base.py
@@ -14,7 +14,7 @@ class Benchmarking:
     You can:
 
     - pass `X, y` (feature matrix and labels/targets) along with `cv`
-      to use any cross-validation strategy;
+      to the `run()` method to use any cross-validation strategy;
     - if you want a fixed train/test split, pass a `PredefinedSplit`
       object as `cv`.
 
@@ -22,16 +22,10 @@ class Benchmarking:
     ----------
     estimators : list[estimator] | estimator
         List of sklearn-like estimators implementing `fit` and `predict`.
-    metrics : list[callable] | callable
-        List of callables with signature `(y_true, y_pred) -> float`.
-    X : array-like
-        Feature matrix.
-    y : array-like
-        Target vector.
-    cv : int, CV splitter, or None, default=None
-        Cross-validation strategy. If `None`, defaults to 5-fold CV.
-        If you want to use an explicit train/test split, pass a
-        `PredefinedSplit` object.
+        Can also be a list of tuples (name, estimator) for custom naming.
+    metrics : list[callable | str] | callable | str
+        List of callables with signature `(y_true, y_pred) -> float`,
+        or string names compatible with sklearn (e.g., "accuracy", "f1").
 
     Attributes
     ----------
@@ -66,33 +60,54 @@ class Benchmarking:
     >>> bench = Benchmarking(
     ...     estimators=[clf],
     ...     metrics=[accuracy_score],
-    ...     X=X,
-    ...     y=y,
-    ...     cv=cv,
     ... )
-    >>> summary = bench.run()  # doctest: +SKIP
+    >>> summary = bench.run(X=X, y=y, cv=cv)  # doctest: +SKIP
     """
 
-    def __init__(self, estimators, metrics, X, y, cv=None):
-        self.estimators = estimators if isinstance(estimators, list) else [estimators]
+    def __init__(self, estimators, metrics):
+        # Handle estimators: can be list of estimators or list of (name, estimator) tuples
+        if not isinstance(estimators, list):
+            estimators = [estimators]
+        
+        self.estimators = []
+        self.estimator_names = []
+        
+        for est in estimators:
+            if isinstance(est, tuple) and len(est) == 2:
+                # (name, estimator) tuple
+                name, estimator = est
+                self.estimator_names.append(name)
+                self.estimators.append(estimator)
+            else:
+                # Just an estimator
+                self.estimators.append(est)
+                self.estimator_names.append(None)  # Will be auto-generated
+        
+        # Handle metrics: can be callables or strings
         self.metrics = metrics if isinstance(metrics, list) else [metrics]
-        self.X = X
-        self.y = y
-        self.cv = cv
         self.results = None
 
     def _to_scorers(self, metrics):
-        """Convert metric callables to a dict of scorers."""
+        """Convert metric callables or strings to a dict of scorers."""
+        from sklearn.metrics import get_scorer
+        
         scorers = {}
         for metric in metrics:
-            if not callable(metric):
-                raise ValueError("Each metric should be a callable.")
-            name = (
-                metric.__name__
-                if hasattr(metric, "__name__")
-                else metric.__class__.__name__
-            )
-            scorers[name] = make_scorer(metric)
+            if isinstance(metric, str):
+                # String-based metric name (e.g., "accuracy", "f1")
+                scorers[metric] = metric
+            elif callable(metric):
+                # Callable metric
+                name = (
+                    metric.__name__
+                    if hasattr(metric, "__name__")
+                    else metric.__class__.__name__
+                )
+                scorers[name] = make_scorer(metric)
+            else:
+                raise ValueError(
+                    "Each metric should be a callable or a string metric name."
+                )
         return scorers
 
     def _to_df(self, results):
@@ -108,9 +123,20 @@ class Benchmarking:
         index = pd.MultiIndex.from_tuples(index, names=["estimator", "metric"])
         return pd.DataFrame(records, index=index, columns=["train", "test"])
 
-    def run(self):
+    def run(self, X, y, cv=None):
         """
         Train each estimator and evaluate with cross-validation.
+
+        Parameters
+        ----------
+        X : array-like
+            Feature matrix.
+        y : array-like
+            Target vector.
+        cv : int, CV splitter, or None, default=None
+            Cross-validation strategy. If `None`, defaults to 5-fold CV.
+            If you want to use an explicit train/test split, pass a
+            `PredefinedSplit` object.
 
         Returns
         -------
@@ -127,15 +153,35 @@ class Benchmarking:
         """
         self.scorers_ = self._to_scorers(self.metrics)
         results = {}
+        
+        # Generate unique estimator names, handling collisions
+        used_names = {}
+        final_names = []
+        
+        for i, (estimator, custom_name) in enumerate(zip(self.estimators, self.estimator_names)):
+            if custom_name is not None:
+                # Use custom name provided by user
+                est_name = custom_name
+            else:
+                # Auto-generate name from class
+                est_name = estimator.__class__.__name__
+            
+            # Handle name collisions by appending a counter
+            if est_name in used_names:
+                used_names[est_name] += 1
+                est_name = f"{est_name}_{used_names[est_name]}"
+            else:
+                used_names[est_name] = 0
+            
+            final_names.append(est_name)
 
-        for estimator in self.estimators:
-            est_name = estimator.__class__.__name__
-
+        # Run cross-validation for each estimator
+        for estimator, est_name in zip(self.estimators, final_names):
             cv_results = cross_validate(
                 estimator,
-                self.X,
-                self.y,
-                cv=self.cv,
+                X,
+                y,
+                cv=cv,
                 scoring=self.scorers_,
                 return_train_score=True,
             )

--- a/pyaptamer/benchmarking/tests/test_benchmarking.py
+++ b/pyaptamer/benchmarking/tests/test_benchmarking.py
@@ -31,11 +31,8 @@ def test_benchmarking_with_predefined_split_classification(aptamer_seq, protein_
     bench = Benchmarking(
         estimators=[clf],
         metrics=[accuracy_score],
-        X=X_raw,
-        y=y,
-        cv=cv,
     )
-    summary = bench.run()
+    summary = bench.run(X=X_raw, y=y, cv=cv)
 
     assert "train" in summary.columns
     assert "test" in summary.columns
@@ -59,12 +56,125 @@ def test_benchmarking_with_predefined_split_regression(aptamer_seq, protein_seq)
     bench = Benchmarking(
         estimators=[reg],
         metrics=[mean_squared_error],
-        X=X_raw,
-        y=y,
-        cv=cv,
     )
-    summary = bench.run()
+    summary = bench.run(X=X_raw, y=y, cv=cv)
 
     assert "train" in summary.columns
     assert "test" in summary.columns
     assert (reg.__class__.__name__, "mean_squared_error") in summary.index
+
+
+@pytest.mark.parametrize("aptamer_seq, protein_seq", params)
+def test_benchmarking_reusability(aptamer_seq, protein_seq):
+    """
+    Test that the same Benchmarking instance can be reused across different datasets.
+    """
+    clf = AptaNetPipeline()
+    
+    bench = Benchmarking(
+        estimators=[clf],
+        metrics=[accuracy_score],
+    )
+    
+    # First dataset
+    X1 = [(aptamer_seq, protein_seq) for _ in range(40)]
+    y1 = np.array([0] * 20 + [1] * 20, dtype=np.float32)
+    test_fold1 = np.ones(len(y1), dtype=int) * -1
+    test_fold1[-2:] = 0
+    cv1 = PredefinedSplit(test_fold1)
+    
+    summary1 = bench.run(X=X1, y=y1, cv=cv1)
+    assert summary1 is not None
+    
+    # Second dataset (reusing the same bench instance)
+    X2 = [(aptamer_seq, protein_seq) for _ in range(30)]
+    y2 = np.array([1] * 15 + [0] * 15, dtype=np.float32)
+    test_fold2 = np.ones(len(y2), dtype=int) * -1
+    test_fold2[-3:] = 0
+    cv2 = PredefinedSplit(test_fold2)
+    
+    summary2 = bench.run(X=X2, y=y2, cv=cv2)
+    assert summary2 is not None
+    assert summary1 is not summary2  # Different results
+
+
+@pytest.mark.parametrize("aptamer_seq, protein_seq", params)
+def test_benchmarking_string_metrics(aptamer_seq, protein_seq):
+    """
+    Test Benchmarking with string-based metric names.
+    """
+    X_raw = [(aptamer_seq, protein_seq) for _ in range(40)]
+    y = np.array([0] * 20 + [1] * 20, dtype=np.float32)
+
+    clf = AptaNetPipeline()
+
+    test_fold = np.ones(len(y), dtype=int) * -1
+    test_fold[-2:] = 0
+    cv = PredefinedSplit(test_fold)
+
+    bench = Benchmarking(
+        estimators=[clf],
+        metrics=["accuracy"],  # String-based metric
+    )
+    summary = bench.run(X=X_raw, y=y, cv=cv)
+
+    assert "train" in summary.columns
+    assert "test" in summary.columns
+    assert (clf.__class__.__name__, "accuracy") in summary.index
+
+
+@pytest.mark.parametrize("aptamer_seq, protein_seq", params)
+def test_benchmarking_estimator_name_collision(aptamer_seq, protein_seq):
+    """
+    Test that multiple instances of the same estimator class get unique names.
+    """
+    X_raw = [(aptamer_seq, protein_seq) for _ in range(40)]
+    y = np.array([0] * 20 + [1] * 20, dtype=np.float32)
+
+    clf1 = AptaNetPipeline(k=3)
+    clf2 = AptaNetPipeline(k=4)
+    clf3 = AptaNetPipeline(k=5)
+
+    test_fold = np.ones(len(y), dtype=int) * -1
+    test_fold[-2:] = 0
+    cv = PredefinedSplit(test_fold)
+
+    bench = Benchmarking(
+        estimators=[clf1, clf2, clf3],
+        metrics=[accuracy_score],
+    )
+    summary = bench.run(X=X_raw, y=y, cv=cv)
+
+    # Check that all three estimators have unique names
+    estimator_names = summary.index.get_level_values("estimator").unique()
+    assert len(estimator_names) == 3
+    assert "AptaNetPipeline" in estimator_names
+    assert "AptaNetPipeline_1" in estimator_names
+    assert "AptaNetPipeline_2" in estimator_names
+
+
+@pytest.mark.parametrize("aptamer_seq, protein_seq", params)
+def test_benchmarking_custom_estimator_names(aptamer_seq, protein_seq):
+    """
+    Test Benchmarking with custom estimator names using (name, estimator) tuples.
+    """
+    X_raw = [(aptamer_seq, protein_seq) for _ in range(40)]
+    y = np.array([0] * 20 + [1] * 20, dtype=np.float32)
+
+    clf1 = AptaNetPipeline(k=3)
+    clf2 = AptaNetPipeline(k=4)
+
+    test_fold = np.ones(len(y), dtype=int) * -1
+    test_fold[-2:] = 0
+    cv = PredefinedSplit(test_fold)
+
+    bench = Benchmarking(
+        estimators=[("k3_model", clf1), ("k4_model", clf2)],
+        metrics=[accuracy_score],
+    )
+    summary = bench.run(X=X_raw, y=y, cv=cv)
+
+    # Check that custom names are used
+    estimator_names = summary.index.get_level_values("estimator").unique()
+    assert "k3_model" in estimator_names
+    assert "k4_model" in estimator_names


### PR DESCRIPTION
This PR enhances the `Benchmarking` class to improve flexibility, reusability, and alignment with scikit-learn conventions.

Closes #444

## Changes

### 1. Move `X`, `y`, `cv` to `run()` method
- Enables reusing the same benchmarking configuration across different datasets
- Separates configuration from execution

**Before:**
```python
bench = Benchmarking(estimators=[clf], metrics=[accuracy_score], X=X, y=y, cv=cv)
results = bench.run()
```

**After:**
```python
bench = Benchmarking(estimators=[clf], metrics=["accuracy"])
results1 = bench.run(X=X1, y=y1, cv=cv1)
results2 = bench.run(X=X2, y=y2, cv=cv2)  # Reusable!
```

### 2. String-based metric support
- Accepts sklearn metric names like `"accuracy"`, `"f1"`, `"roc_auc"`
- Aligned with scikit-learn conventions

```python
bench = Benchmarking(estimators=[clf], metrics=["accuracy", "f1"])
```

### 3. Estimator naming with collision handling
- Automatically handles multiple instances of the same model class
- Supports custom names via `(name, estimator)` tuples
- Fixes #237

```python
# Automatic naming
bench = Benchmarking(
    estimators=[AptaNetPipeline(k=3), AptaNetPipeline(k=4), AptaNetPipeline(k=5)],
    metrics=["accuracy"]
)
# Results: "AptaNetPipeline", "AptaNetPipeline_1", "AptaNetPipeline_2"

# Custom naming
bench = Benchmarking(
    estimators=[("k=3", clf1), ("k=4", clf2), ("k=5", clf3)],
    metrics=["accuracy"]
)
```

## Files Changed

- `pyaptamer/benchmarking/_base.py` - Core implementation
- `pyaptamer/benchmarking/tests/test_benchmarking.py` - Updated tests + 4 new test cases
- `examples/benchmarking_enhanced_api.py` - Usage examples

## Testing

New tests:
- `test_benchmarking_reusability`
- `test_benchmarking_string_metrics`
- `test_benchmarking_estimator_name_collision`
- `test_benchmarking_custom_estimator_names`

## Breaking Change

⚠️ **Yes** - `X`, `y`, `cv` must now be passed to `run()` instead of `__init__()`

## Migration

```python
# Old
bench = Benchmarking(estimators=[clf], metrics=[metric], X=X, y=y, cv=cv)
results = bench.run()

# New
bench = Benchmarking(estimators=[clf], metrics=[metric])
results = bench.run(X=X, y=y, cv=cv)
```
