### PR TITLE
[BUG] Make GreedyEncoder.get_test_params a classmethod

### DIFF
--- a/pyaptamer/trafos/encode/_greedy.py
+++ b/pyaptamer/trafos/encode/_greedy.py
@@ -132,7 +132,8 @@ class GreedyEncoder(BaseTransform):
 
         return result_df
 
-    def get_test_params(self):
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
         """Get test parameters for GreedyEncoder.
 
         Returns

--- a/pyaptamer/trafos/encode/_greedy.py
+++ b/pyaptamer/trafos/encode/_greedy.py
@@ -136,11 +136,21 @@ class GreedyEncoder(BaseTransform):
     def get_test_params(cls, parameter_set="default"):
         """Get test parameters for GreedyEncoder.
 
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the parameter set to return. Only ``"default"`` is supported.
+
         Returns
         -------
-        params : dict
-            Test parameters for GreedyEncoder.
+        list[dict]
+            List of parameter dictionaries for constructing test instances.
         """
+        if parameter_set != "default":
+            raise ValueError(
+                'parameter_set must be "default"; '
+                f"got {parameter_set!r}"
+            )
         param0 = {
             "words": {"A": 1, "C": 2, "G": 3, "U": 4, "AC": 5, "GU": 6},
         }

--- a/pyaptamer/trafos/encode/tests/__init__.py
+++ b/pyaptamer/trafos/encode/tests/__init__.py
@@ -1,0 +1,2 @@
+"""Tests for encoding transformers."""
+

--- a/pyaptamer/trafos/encode/tests/test_greedy_encoder.py
+++ b/pyaptamer/trafos/encode/tests/test_greedy_encoder.py
@@ -1,6 +1,7 @@
 import inspect
 
 import pandas as pd
+import pytest
 
 from pyaptamer.trafos.encode import GreedyEncoder
 
@@ -9,10 +10,17 @@ def test_get_test_params_is_classmethod_and_callable():
     descriptor = inspect.getattr_static(GreedyEncoder, "get_test_params")
     assert isinstance(descriptor, classmethod)
 
+    params_default = GreedyEncoder.get_test_params(parameter_set="default")
     params = GreedyEncoder.get_test_params()
+    assert params == params_default
     assert isinstance(params, list)
     assert len(params) >= 1
     assert all(isinstance(p, dict) for p in params)
+
+
+def test_get_test_params_unknown_parameter_set_raises():
+    with pytest.raises(ValueError, match='parameter_set must be "default"'):
+        GreedyEncoder.get_test_params(parameter_set="not_a_real_set")
 
 
 def test_greedy_encoder_can_construct_from_test_params():

--- a/pyaptamer/trafos/encode/tests/test_greedy_encoder.py
+++ b/pyaptamer/trafos/encode/tests/test_greedy_encoder.py
@@ -1,0 +1,24 @@
+import inspect
+
+import pandas as pd
+
+from pyaptamer.trafos.encode import GreedyEncoder
+
+
+def test_get_test_params_is_classmethod_and_callable():
+    descriptor = inspect.getattr_static(GreedyEncoder, "get_test_params")
+    assert isinstance(descriptor, classmethod)
+
+    params = GreedyEncoder.get_test_params()
+    assert isinstance(params, list)
+    assert len(params) >= 1
+    assert all(isinstance(p, dict) for p in params)
+
+
+def test_greedy_encoder_can_construct_from_test_params():
+    for params in GreedyEncoder.get_test_params():
+        enc = GreedyEncoder(**params)
+        X = pd.DataFrame([["ACGU"], ["A"]])
+        Xt = enc.fit_transform(X)
+        assert Xt.shape[0] == X.shape[0]
+


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #568.

#### What does this implement/fix? Explain your changes.
- Make `GreedyEncoder.get_test_params` a `@classmethod` so it can be called at class-level (skbase estimator testing contract).
- Clarify `get_test_params` docstring return type and validate `parameter_set`.
- Add regression tests covering class-level invocation, parameter validity, and invalid `parameter_set` handling.

#### What should a reviewer concentrate their feedback on?
- API contract alignment with `skbase` expectations for `get_test_params`.
- Test coverage and whether the `parameter_set` validation behavior is appropriate.

#### Did you add any tests for the change?
- [x] Yes, added/updated tests in `pyaptamer/trafos/encode/tests/test_greedy_encoder.py`.

#### Any other comments?
- Ran focused tests locally: `pytest -q pyaptamer/trafos/encode/tests/test_greedy_encoder.py`.

#### PR checklist
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks (or ran equivalent checks locally).