### PR TITLE
fix: rna2vec case-insensitivity for secondary structures

### DIFF
--- a/pyaptamer/utils/_rna.py
+++ b/pyaptamer/utils/_rna.py
@@ -141,6 +141,7 @@ def rna2vec(
 
     result = []
     for sequence in sequence_list:
+        sequence = sequence.upper()  # ensure case-insensitivity
         # convert DNA to RNA only for RNA sequences
         if sequence_type == "rna":
             sequence = dna2rna(sequence)

--- a/pyaptamer/utils/tests/test_rna2vec_robustness.py
+++ b/pyaptamer/utils/tests/test_rna2vec_robustness.py
@@ -1,0 +1,19 @@
+import numpy as np
+
+from pyaptamer.utils import rna2vec
+
+
+def test_rna2vec_case_insensitivity():
+    """
+    Test that rna2vec handles secondary structures in a case-insensitive way.
+    Regression test for Issue where lowercase 'ss' inputs returned zero vectors.
+    """
+    sequences_upper = ["SSHH"]
+    sequences_lower = ["sshh"]
+
+    result_upper = rna2vec(sequences_upper, sequence_type="ss", max_sequence_length=10)
+    result_lower = rna2vec(sequences_lower, sequence_type="ss", max_sequence_length=10)
+
+    # Both should be identical and non-zero
+    assert np.array_equal(result_upper, result_lower)
+    assert np.any(result_upper != 0)


### PR DESCRIPTION

#  Fix: Silent Data Corruption in `rna2vec` due to Case Sensitivity
fix #606 

## 📖 Summary
This PR resolves a critical bug in the `rna2vec` utility function where secondary structure sequences were processed in a case-sensitive manner. This caused any lowercase input to fail triplet matching silently, returning vectors populated entirely by zeros.

## 🔍 Technical Root Cause
The `rna2vec` function transforms biological sequences into numerical representations by extracting overlapping triplets and mapping them to indices via a pre-generated vocabulary. 

- **The Discrepancy**: While RNA sequences were normalized through `dna2rna()`, secondary structure (SS) sequences were taken directly from the input.
- **The Failure**: The internal triplet dictionary is generated using uppercase characters (`S, H, M, I, B, X, E`). When a user provided a lowercase sequence like `"sshh"`, the triplet lookup `triplets.get("ssh", 0)` would fail to find a match and default to `0` (the padding index).
- **The Consequence**: Instead of a meaningful numerical representation, the model would receive an all-zero vector, effectively "masking" valid data without warning the user.

## 🛠️ Proposed Changes
### 1. Robust Normalization
Updated the core loop in `pyaptamer/utils/_rna.py` to enforce `.upper()` normalization on every sequence at the start of the iteration. This ensures that:
- RNA sequences remain robust.
- Secondary structure sequences are now case-insensitive.
- Future sequence types added to the loop will inherit this safety by default.

### 2. Regression Testing
Introduced a new test file: `pyaptamer/utils/tests/test_rna2vec_robustness.py`.
- **Test Case**: Specifically validates that uppercase (`SSHH`) and lowercase (`sshh`) inputs yield identical, non-zero NumPy arrays.
- **Verification**: This ensures that valid structural information is correctly encoded regardless of the input's casing.

## ⚠️ Impact & Risks
- **Data Integrity**: This fix prevents "silent failures" where models appear to be training but are actually receiving empty data.
- **Backward Compatibility**: This is a non-breaking change. It only affects cases that were previously failing/returning zeros.

## ✅ Verification Results
- **Unit Tests**: `pytest pyaptamer/utils/tests/test_rna2vec_robustness.py` -> **Passed**.
- **Existing Suite**: `pytest pyaptamer/utils/tests/test_rna.py` -> **Passed**.
- **Manual Verification**: Confirmed that lowercase structural strings now map to their correct triplet indices in the vocabulary.

