### PR TITLE
fix: PositionalEncoding Shape Mismatch on Odd Dimensions

### DIFF
--- a/pyaptamer/aptatrans/layers/_encoder.py
+++ b/pyaptamer/aptatrans/layers/_encoder.py
@@ -61,7 +61,9 @@ class PositionalEncoding(nn.Module):
         )
         pe = torch.zeros(1, max_len, d_model)  # Changed shape to (1, max_len, d_model)
         pe[0, :, 0::2] = torch.sin(position * div_term)  # Changed indexing
-        pe[0, :, 1::2] = torch.cos(position * div_term)  # Changed indexing
+        pe[0, :, 1::2] = torch.cos(
+            position * div_term[: d_model // 2]
+        )  # Changed indexing
         self.register_buffer("pe", pe)
 
     def forward(self, x: Tensor) -> Tensor:

--- a/pyaptamer/aptatrans/tests/test_pe_robustness.py
+++ b/pyaptamer/aptatrans/tests/test_pe_robustness.py
@@ -1,0 +1,32 @@
+import pytest
+
+from pyaptamer.aptatrans.layers._encoder import PositionalEncoding
+
+
+def test_positional_encoding_odd_dimensions():
+    """
+    Test that PositionalEncoding handles odd-numbered model dimensions.
+    Regression test for Issue where odd d_model caused shape mismatch crash.
+    """
+    # Test standard even dimension
+    try:
+        pe_even = PositionalEncoding(d_model=128, max_len=10)
+        assert pe_even.pe.shape == (1, 10, 128)
+    except Exception as e:
+        pytest.fail(f"PositionalEncoding failed on even d_model: {e}")
+
+    # Test odd dimension (previously crashed)
+    try:
+        pe_odd = PositionalEncoding(d_model=127, max_len=10)
+        assert pe_odd.pe.shape == (1, 10, 127)
+    except Exception as e:
+        pytest.fail(f"PositionalEncoding failed on odd d_model: {e}")
+
+
+def test_positional_encoding_small_dimensions():
+    """Test very small dimensions."""
+    pe_1 = PositionalEncoding(d_model=1, max_len=5)
+    assert pe_1.pe.shape == (1, 5, 1)
+
+    pe_2 = PositionalEncoding(d_model=2, max_len=5)
+    assert pe_2.pe.shape == (1, 5, 2)


### PR DESCRIPTION

***

#  Fix: PositionalEncoding Shape Mismatch on Odd Dimensions
fix #607 

## 📖 Summary
This PR resolves a persistent runtime crash in the `PositionalEncoding` layer that occurred whenever the model dimension (`d_model`) was an odd number. The fix ensures that the layer correctly handles arbitrary embedding dimensions, making the `AptaTrans` architecture more flexible and robust.

## 🔍 Technical Root Cause
The `PositionalEncoding` layer generates fixed sinusoids to inject positional information into embeddings. The implementation uses a frequency-divisor vector (`div_term`) that is shared between sine and cosine operations:

1.  **Index Split**: Sine waves are assigned to even indices (`0, 2, 4...`) and cosine waves to odd indices (`1, 3, 5...`).
2.  **The Mismatch**: 
    - The size of `div_term` is calculated based on `torch.arange(0, d_model, 2)`, which has a length of `ceil(d_model / 2)`.
    - If `d_model` is **128** (even): 
        - Even indices: 64 slots
        - Odd indices: 64 slots
        - `div_term`: 64 values (No error)
    - If `d_model` is **127** (odd):
        - Even indices: 64 slots
        - **Odd indices: 63 slots**
        - `div_term`: 64 values
3.  **The Crash**: The assignment `pe[0, :, 1::2] = torch.cos(position * div_term)` fails for odd `d_model` because PyTorch cannot fit 64 values into a tensor with 63 slots.

## 🛠️ Proposed Changes
### 1. Corrected Frequency Mapping
Adjusted the cosine assignment to correctly slice the `div_term` to match the number of available odd-indexed slots.
- **Logic**: Used `div_term[: d_model // 2]` to ensure the number of frequencies exactly matches the number of odd positions, regardless of whether `d_model` is even or odd.

### 2. Dimensionality Regression Tests
Introduced `pyaptamer/aptatrans/tests/test_pe_robustness.py` to safeguard against future regressions:
- **Odd/Even Verification**: Tests both standard (even) and non-standard (odd) dimensions.
- **Extreme Edge Cases**: Verified stability for minimal dimensions (e.g., `d_model=1`).

## ⚠️ Impact & Risks
- **Architectural Flexibility**: Developers can now experiment with any embedding size without the model crashing during the initialization of the Transformer blocks.
- **Stability**: This is a safe change that does not modify the output for existing models where `d_model` is even.

## ✅ Verification Results
- **Unit Tests**: `pytest pyaptamer/aptatrans/tests/test_pe_robustness.py` -> **Passed**.
- **Inference Stability**: Verified that the change preserves identical output values for even-dimension embeddings.
