### PR TITLE
[CRASH] Fix: add ValueError for invalid encoder_type and None input_dim

### DIFF
--- a/pyaptamer/aptanet/_aptanet_nn.py
+++ b/pyaptamer/aptanet/_aptanet_nn.py
@@ -87,7 +87,11 @@ class AptaNetMLP(nn.Module):
         use_lazy=True,
     ):
         super().__init__()
-
+        if not use_lazy and input_dim is None:
+            raise ValueError(
+                "input_dim is required when use_lazy=False. "
+                "Either provide input_dim or set use_lazy=True."
+            )
         first_lazy = use_lazy and (input_dim is None)
 
         layers = [aptanet_layer(input_dim, hidden_dim, dropout, lazy=first_lazy)]

--- a/pyaptamer/aptanet/tests/test_aptanet.py
+++ b/pyaptamer/aptanet/tests/test_aptanet.py
@@ -6,6 +6,7 @@ import pytest
 from sklearn.utils.estimator_checks import parametrize_with_checks
 
 from pyaptamer.aptanet import AptaNetClassifier, AptaNetPipeline, AptaNetRegressor
+from pyaptamer.aptanet._aptanet_nn import AptaNetMLP
 
 params = [
     (
@@ -81,3 +82,13 @@ def test_sklearn_compatible_estimator(estimator, check):
     Run scikit-learn's compatibility checks on the AptaNetClassifier.
     """
     check(estimator)
+
+
+def test_aptanet_mlp_no_input_dim_raises():
+    """Check that AptaNetMLP raises ValueError when use_lazy=False and input_dim=None.
+
+    Previously this silently passed None to nn.Linear, causing a confusing
+    TypeError deep inside PyTorch with no pointer to the real cause. Fixes #611.
+    """
+    with pytest.raises(ValueError, match="input_dim is required when use_lazy=False"):
+        AptaNetMLP(use_lazy=False, input_dim=None)

--- a/pyaptamer/aptatrans/_model_lightning.py
+++ b/pyaptamer/aptatrans/_model_lightning.py
@@ -320,7 +320,12 @@ class AptaTransEncoderLightning(AptaTransLightning):
             params = list(self.model.encoder_prot.parameters()) + list(
                 self.model.token_predictor_prot.parameters()
             )
-
+        else:
+            raise ValueError(
+                f"Invalid encoder_type '{self.encoder_type}'. "
+                "Expected one of: 'apta', 'prot'."
+            )
+            
         optimizer = torch.optim.Adam(
             params,
             lr=self.lr,

--- a/pyaptamer/aptatrans/tests/test_aptatrans_lightning.py
+++ b/pyaptamer/aptatrans/tests/test_aptatrans_lightning.py
@@ -128,3 +128,14 @@ class TestAptaTransEncoderLightning:
         assert isinstance(loss, torch.Tensor)
         assert loss.dim() == 0
         assert loss.item() >= 0
+
+    def test_configure_optimizers_invalid_encoder_type_raises(self, mock_model):
+        """Check that an invalid encoder_type raises ValueError in configure_optimizers.
+
+        Previously, any encoder_type other than 'apta' or 'prot' left `params`
+        undefined, causing a silent NameError at training time. Fixes #610.
+        """
+        model = AptaTransEncoderLightning(mock_model, encoder_type="invalid")
+
+        with pytest.raises(ValueError, match="Invalid encoder_type 'invalid'"):
+            model.configure_optimizers()


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #610. Fixes #611.

#### What does this implement/fix? Explain your changes.

**Fix 1 : `_model_lightning.py` (`AptaTransEncoderLightning.configure_optimizers`)**
The `if/elif` chain for `encoder_type` had no `else` branch. Any value other than
`"apta"` or `"prot"` left `params` undefined, causing a silent
`NameError: name 'params' is not defined` at training time with no hint of the actual
cause. Added an `else` branch that raises a clear `ValueError` listing the valid options.

**Fix 2 : `_aptanet_nn.py` (`AptaNetMLP.__init__`)**
When `use_lazy=False` and `input_dim=None`, the guard
`first_lazy = use_lazy and (input_dim is None)` evaluated to `False`, causing
`nn.Linear(None, hidden_dim)` to be constructed and raising a confusing `TypeError`
deep inside PyTorch with no pointer to the real cause. Added an explicit guard that
raises `ValueError` immediately with an actionable message.

#### What should a reviewer concentrate their feedback on?
- The `else` branch in `configure_optimizers` in `_model_lightning.py` , confirm the
  error message lists all valid `encoder_type` values exhaustively.
- The guard placement in `_aptanet_nn.py` , confirm it sits before `first_lazy`
  assignment so no partial construction occurs.

#### Did you add any tests for the change?
Yes, one test per fix:
- `test_aptatrans_lightning.py` : `test_configure_optimizers_invalid_encoder_type_raises`:
  confirms `AptaTransEncoderLightning(model, encoder_type="invalid")` raises `ValueError`.
- `test_aptanet.py` : `test_aptanet_mlp_no_input_dim_raises`:
  confirms `AptaNetMLP(use_lazy=False, input_dim=None)` raises `ValueError`.

#### Any other comments?
Both are crash-level bugs with no workaround short of patching source. The fixes are
minimal and self-contained, one `else` branch and one `if` guard.

> LLM Assisted, by Claude (Anthropic), reviewed and submitted by DZDasherKTB