### PR TITLE
[BUG] Fix MCTS.run() docstring and add __repr__ for inspectability

### DIFF
--- a/pyaptamer/mcts/_algorithm.py
+++ b/pyaptamer/mcts/_algorithm.py
@@ -70,7 +70,7 @@ class MCTS(BaseObject):
     >>> experiment = AptamerEvalAptaTrans(target, model, device, prot_words)
     >>> mcts = MCTS(depth=5, n_iterations=2, experiment=experiment)
     >>> candidate = mcts.run(verbose=False)
-    >>> candidate["candidate"]  # the reconstructed aptamer string
+    >>> seq = candidate["candidate"]  # the reconstructed aptamer string
     """
 
     def __init__(

--- a/pyaptamer/mcts/_algorithm.py
+++ b/pyaptamer/mcts/_algorithm.py
@@ -70,6 +70,7 @@ class MCTS(BaseObject):
     >>> experiment = AptamerEvalAptaTrans(target, model, device, prot_words)
     >>> mcts = MCTS(depth=5, n_iterations=2, experiment=experiment)
     >>> candidate = mcts.run(verbose=False)
+    >>> candidate["candidate"]  # the reconstructed aptamer string  # doctest: +SKIP
     """
 
     def __init__(
@@ -111,6 +112,14 @@ class MCTS(BaseObject):
         )
         self.base = ""
         self.candidate = ""
+
+    def __repr__(self) -> str:
+        """Return a human-readable representation of the MCTS configuration."""
+        return (
+            f"MCTS(depth={self.depth}, n_iterations={self.n_iterations}, "
+            f"n_states={len(self.states)}, "
+            f"experiment={self.experiment.__class__.__name__ if self.experiment else None})"
+        )
 
     def _reset(self) -> None:
         """Reset the MCTS algorithm to its initial state."""
@@ -281,18 +290,24 @@ class MCTS(BaseObject):
     def run(self, verbose: bool = True) -> dict:
         """
         Perform a full recommendation run consisting of `self.n_iterations` rounds of
-        (selection -> expansion -> simulation -> backpropagation)
+        (selection -> expansion -> simulation -> backpropagation).
 
         Parameters
         ----------
         verbose : bool, optional, default=True
-            Whether to print progress information.
+            Whether to log progress information via ``logger.debug``.
+            Messages are only emitted when the logger level is ``DEBUG``.
 
         Returns
         -------
         dict
-            Dictionary containing the final candidate sequence (`candidate`) and its
-            score (`score`).
+            A dictionary with the following keys:
+
+            - ``"candidate"`` (*str*) — The reconstructed aptamer sequence.
+            - ``"sequence"`` (*str*) — The raw encoded sequence with direction
+              markers (underscores), before reconstruction.
+            - ``"score"`` (*float*) — The score of the candidate as evaluated
+              by ``self.experiment``.
         """
         self._reset()
 

--- a/pyaptamer/mcts/_algorithm.py
+++ b/pyaptamer/mcts/_algorithm.py
@@ -115,11 +115,12 @@ class MCTS(BaseObject):
 
     def __repr__(self) -> str:
         """Return a human-readable representation of the MCTS configuration."""
+        exp_name = self.experiment.__class__.__name__ if self.experiment else None
         return (
             f"MCTS(depth={self.depth}, "
             f"n_iterations={self.n_iterations}, "
             f"n_states={len(self.states)}, "
-            f"experiment={self.experiment.__class__.__name__ if self.experiment else None})"
+            f"experiment={exp_name})"
         )
 
     def _reset(self) -> None:

--- a/pyaptamer/mcts/_algorithm.py
+++ b/pyaptamer/mcts/_algorithm.py
@@ -70,7 +70,7 @@ class MCTS(BaseObject):
     >>> experiment = AptamerEvalAptaTrans(target, model, device, prot_words)
     >>> mcts = MCTS(depth=5, n_iterations=2, experiment=experiment)
     >>> candidate = mcts.run(verbose=False)
-    >>> candidate["candidate"]  # the reconstructed aptamer string  # doctest: +SKIP
+    >>> candidate["candidate"]  # the reconstructed aptamer string
     """
 
     def __init__(
@@ -116,7 +116,8 @@ class MCTS(BaseObject):
     def __repr__(self) -> str:
         """Return a human-readable representation of the MCTS configuration."""
         return (
-            f"MCTS(depth={self.depth}, n_iterations={self.n_iterations}, "
+            f"MCTS(depth={self.depth}, "
+            f"n_iterations={self.n_iterations}, "
             f"n_states={len(self.states)}, "
             f"experiment={self.experiment.__class__.__name__ if self.experiment else None})"
         )
@@ -303,11 +304,11 @@ class MCTS(BaseObject):
         dict
             A dictionary with the following keys:
 
-            - ``"candidate"`` (*str*) — The reconstructed aptamer sequence.
-            - ``"sequence"`` (*str*) — The raw encoded sequence with direction
+            - `candidate` (*str*) — The reconstructed aptamer sequence.
+            - `sequence` (*str*) — The raw encoded sequence with direction
               markers (underscores), before reconstruction.
-            - ``"score"`` (*float*) — The score of the candidate as evaluated
-              by ``self.experiment``.
+            - `score` (*float*) — The score of the candidate as evaluated
+              by `self.experiment`.
         """
         self._reset()
 

--- a/pyaptamer/mcts/tests/test_mcts.py
+++ b/pyaptamer/mcts/tests/test_mcts.py
@@ -360,3 +360,28 @@ class TestMCTS:
         # length of sequence should be 2 * 5 (i.e., 2 * 5) as it still contains
         # the underscores
         assert len(candidate["sequence"]) == 10
+
+    def test_run_return_dict_keys(self, mcts):
+        """Verify that run() returns exactly the three documented keys."""
+        result = mcts.run(verbose=False)
+        assert set(result.keys()) == {"candidate", "sequence", "score"}
+        assert isinstance(result["candidate"], str)
+        assert isinstance(result["sequence"], str)
+
+    def test_repr(self):
+        """Verify __repr__ includes configuration details."""
+        mcts = MCTS(depth=10, n_iterations=500)
+        r = repr(mcts)
+        assert "MCTS(" in r
+        assert "depth=10" in r
+        assert "n_iterations=500" in r
+        assert "n_states=8" in r
+        assert "experiment=None" in r
+
+    def test_repr_with_experiment(self, mcts):
+        """Verify __repr__ shows experiment class name."""
+        r = repr(mcts)
+        assert "MCTS(" in r
+        assert "experiment=" in r
+        assert "None" not in r
+

--- a/pyaptamer/mcts/tests/test_mcts.py
+++ b/pyaptamer/mcts/tests/test_mcts.py
@@ -368,20 +368,20 @@ class TestMCTS:
         assert isinstance(result["candidate"], str)
         assert isinstance(result["sequence"], str)
 
-    def test_repr(self):
-        """Verify __repr__ includes configuration details."""
-        mcts = MCTS(depth=10, n_iterations=500)
-        r = repr(mcts)
-        assert "MCTS(" in r
-        assert "depth=10" in r
-        assert "n_iterations=500" in r
-        assert "n_states=8" in r
-        assert "experiment=None" in r
+    def test_repr(self, mcts):
+        """Verify __repr__ includes configuration details and handles experiment correctly."""
+        # Test without experiment
+        mcts_no_exp = MCTS(depth=10, n_iterations=500)
+        r_no_exp = repr(mcts_no_exp)
+        assert "MCTS(" in r_no_exp
+        assert "depth=10" in r_no_exp
+        assert "n_iterations=500" in r_no_exp
+        assert "n_states=8" in r_no_exp
+        assert "experiment=None" in r_no_exp
 
-    def test_repr_with_experiment(self, mcts):
-        """Verify __repr__ shows experiment class name."""
-        r = repr(mcts)
-        assert "MCTS(" in r
-        assert "experiment=" in r
-        assert "None" not in r
+        # Test with experiment (using fixture)
+        r_with_exp = repr(mcts)
+        assert "MCTS(" in r_with_exp
+        assert "experiment=" in r_with_exp
+        assert "None" not in r_with_exp
 

--- a/pyaptamer/mcts/tests/test_mcts.py
+++ b/pyaptamer/mcts/tests/test_mcts.py
@@ -369,7 +369,7 @@ class TestMCTS:
         assert isinstance(result["sequence"], str)
 
     def test_repr(self, mcts):
-        """Verify __repr__ includes configuration details and handles experiment correctly."""
+        """Verify __repr__ config details and handles experiment."""
         # Test without experiment
         mcts_no_exp = MCTS(depth=10, n_iterations=500)
         r_no_exp = repr(mcts_no_exp)

--- a/pyaptamer/mcts/tests/test_mcts.py
+++ b/pyaptamer/mcts/tests/test_mcts.py
@@ -384,4 +384,3 @@ class TestMCTS:
         assert "MCTS(" in r_with_exp
         assert "experiment=" in r_with_exp
         assert "None" not in r_with_exp
-


### PR DESCRIPTION
LLM generated content, by Antigravity (for PR description only)

#### Reference Issues/PRs
Fixes #622 

#### What does this implement/fix? Explain your changes.
Fixed documentation and UX issues in the MCTS module:
- Updated `run()` docstring to explicitly list all return dictionary keys (`candidate`, `sequence`, `score`).
- Fixed `verbose` description to clarify it logs via `logger.debug`.
- Added `__repr__` for `MCTS` class to show key hyperparameters (depth, iterations).

#### What should a reviewer concentrate their feedback on?
- [x] Completeness of the dictionary key documentation.
- [x] Informative value of the `__repr__` output.

#### Did you add any tests for the change?
Yes, added tests for the return dictionary structure and the repr string output in `test_mcts.py`.

#### Any other comments?
N/A

#### PR checklist
- [x] The PR title starts with [BUG]
- [x] Added/modified tests
- [x] Used pre-commit hooks
