### PR TITLE
[ENH] Add validate_sequence utility for DNA/RNA/protein input validation

### DIFF
--- a/pyaptamer/utils/_validate.py
+++ b/pyaptamer/utils/_validate.py
@@ -1,0 +1,115 @@
+"""Sequence validation utilities for DNA, RNA, and protein sequences."""
+
+__author__ = ["Vaishnav88sk"]
+__all__ = ["validate_sequence", "is_valid_sequence"]
+
+_VALID_CHARS = {
+    "dna": set("ACGTacgt"),
+    "rna": set("ACGUacgu"),
+    "protein": set("ACDEFGHIKLMNPQRSTVWYacdefghiklmnpqrstvwy"),
+}
+
+_MOLECULE_TYPES = tuple(_VALID_CHARS.keys())
+
+
+def validate_sequence(sequence, molecule_type="rna"):
+    """Validate that a sequence contains only valid characters.
+
+    Checks every character in ``sequence`` against the allowed alphabet
+    for the given ``molecule_type`` and raises a clear error listing
+    invalid characters and their positions.
+
+    Parameters
+    ----------
+    sequence : str
+        The nucleotide or amino-acid sequence to validate.
+    molecule_type : str, optional, default="rna"
+        Type of molecule. Must be one of ``"dna"``, ``"rna"``, or
+        ``"protein"``.
+
+    Returns
+    -------
+    str
+        The original sequence (unchanged) if validation passes.
+
+    Raises
+    ------
+    TypeError
+        If ``sequence`` is not a string.
+    ValueError
+        If ``molecule_type`` is not one of the supported types.
+    ValueError
+        If ``sequence`` contains characters not in the allowed alphabet.
+
+    Examples
+    --------
+    >>> from pyaptamer.utils._validate import validate_sequence
+    >>> validate_sequence("AUGCUAGC", molecule_type="rna")
+    'AUGCUAGC'
+    >>> validate_sequence("ATGCTAGC", molecule_type="dna")
+    'ATGCTAGC'
+    """
+    if not isinstance(sequence, str):
+        raise TypeError(
+            f"sequence must be a string, got {type(sequence).__name__}."
+        )
+
+    molecule_type = molecule_type.lower()
+    if molecule_type not in _VALID_CHARS:
+        raise ValueError(
+            f"molecule_type must be one of {_MOLECULE_TYPES}, "
+            f"got '{molecule_type}'."
+        )
+
+    valid = _VALID_CHARS[molecule_type]
+    invalid_positions = []
+    invalid_chars = []
+
+    for i, char in enumerate(sequence):
+        if char not in valid:
+            invalid_positions.append(i)
+            invalid_chars.append(char)
+
+    if invalid_chars:
+        unique_invalid = sorted(set(invalid_chars))
+        raise ValueError(
+            f"Invalid characters {unique_invalid} found at positions "
+            f"{invalid_positions} in {molecule_type.upper()} sequence. "
+            f"Allowed characters: {''.join(sorted(valid & set('ACDEFGHIKLMNPQRSTUVWY')))}"
+        )
+
+    return sequence
+
+
+def is_valid_sequence(sequence, molecule_type="rna"):
+    """Check whether a sequence contains only valid characters.
+
+    This is a non-raising alternative to :func:`validate_sequence`.
+
+    Parameters
+    ----------
+    sequence : str
+        The nucleotide or amino-acid sequence to check.
+    molecule_type : str, optional, default="rna"
+        Type of molecule. Must be one of ``"dna"``, ``"rna"``, or
+        ``"protein"``.
+
+    Returns
+    -------
+    bool
+        ``True`` if every character in ``sequence`` belongs to the
+        allowed alphabet, ``False`` otherwise.
+
+    Examples
+    --------
+    >>> from pyaptamer.utils._validate import is_valid_sequence
+    >>> is_valid_sequence("AUGC", molecule_type="rna")
+    True
+    >>> is_valid_sequence("ATXG", molecule_type="dna")
+    False
+    """
+    try:
+        validate_sequence(sequence, molecule_type)
+        return True
+    except (TypeError, ValueError):
+        return False

--- a/pyaptamer/utils/tests/test_validate.py
+++ b/pyaptamer/utils/tests/test_validate.py
@@ -1,0 +1,90 @@
+"""Tests for sequence validation utilities."""
+
+import pytest
+
+from pyaptamer.utils._validate import is_valid_sequence, validate_sequence
+
+
+class TestValidateSequence:
+    """Tests for validate_sequence()."""
+
+    def test_valid_rna(self):
+        """Valid RNA sequence passes."""
+        assert validate_sequence("AUGCUAGC", "rna") == "AUGCUAGC"
+
+    def test_valid_dna(self):
+        """Valid DNA sequence passes."""
+        assert validate_sequence("ATGCTAGC", "dna") == "ATGCTAGC"
+
+    def test_valid_protein(self):
+        """Valid protein sequence passes."""
+        assert validate_sequence("ACDEFGHIKLMNPQRSTVWY", "protein") == "ACDEFGHIKLMNPQRSTVWY"
+
+    def test_case_insensitive(self):
+        """Lowercase characters are accepted."""
+        assert validate_sequence("augc", "rna") == "augc"
+
+    def test_invalid_rna_with_t(self):
+        """T is not valid in RNA."""
+        with pytest.raises(ValueError, match="Invalid characters"):
+            validate_sequence("AUTGC", "rna")
+
+    def test_invalid_dna_with_u(self):
+        """U is not valid in DNA."""
+        with pytest.raises(ValueError, match="Invalid characters"):
+            validate_sequence("AUGC", "dna")
+
+    def test_invalid_chars_shows_positions(self):
+        """Error message includes positions of invalid characters."""
+        with pytest.raises(ValueError, match="positions"):
+            validate_sequence("AX1C", "rna")
+
+    def test_non_string_input(self):
+        """Non-string input raises TypeError."""
+        with pytest.raises(TypeError, match="must be a string"):
+            validate_sequence(12345, "rna")
+
+    def test_invalid_molecule_type(self):
+        """Invalid molecule_type raises ValueError."""
+        with pytest.raises(ValueError, match="molecule_type must be"):
+            validate_sequence("AUGC", "lipid")
+
+    def test_empty_sequence(self):
+        """Empty string is valid (no invalid characters)."""
+        assert validate_sequence("", "rna") == ""
+
+    def test_single_valid_char(self):
+        """Single valid character passes."""
+        assert validate_sequence("A", "rna") == "A"
+
+    def test_protein_invalid_chars(self):
+        """Numbers are not valid in protein sequences."""
+        with pytest.raises(ValueError, match="Invalid characters"):
+            validate_sequence("ACD123", "protein")
+
+    def test_molecule_type_case_insensitive(self):
+        """molecule_type should be case-insensitive."""
+        assert validate_sequence("AUGC", "RNA") == "AUGC"
+        assert validate_sequence("ATGC", "DNA") == "ATGC"
+
+
+class TestIsValidSequence:
+    """Tests for is_valid_sequence()."""
+
+    def test_valid_returns_true(self):
+        assert is_valid_sequence("AUGC", "rna") is True
+
+    def test_invalid_returns_false(self):
+        assert is_valid_sequence("AXGC", "rna") is False
+
+    def test_non_string_returns_false(self):
+        assert is_valid_sequence(None, "rna") is False
+
+    def test_invalid_molecule_type_returns_false(self):
+        assert is_valid_sequence("AUGC", "lipid") is False
+
+    def test_dna_valid(self):
+        assert is_valid_sequence("ATGC", "dna") is True
+
+    def test_protein_valid(self):
+        assert is_valid_sequence("ACDEFGHIKLMNPQRSTVWY", "protein") is True


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #619 

#### What does this implement/fix? Explain your changes.
Introduces a centralized validation module `pyaptamer/utils/_validate.py` to ensure input sequence integrity across the library.
- `validate_sequence(sequence, molecule_type)`: Raises `ValueError` with positions of invalid characters.
- `is_valid_sequence(sequence, molecule_type)`: Boolean check.
Supports DNA, RNA, and the 20 standard amino acids.

#### What should a reviewer concentrate their feedback on?
- [x] Alphabet completeness for standard proteins.
- [x] Usefulness of the error message format.

#### Did you add any tests for the change?
Yes, added `pyaptamer/utils/tests/test_validate.py` with 17 tests covering all molecule types and invalid inputs.

#### Any other comments?
N/A

#### PR checklist
- [x] The PR title starts with [ENH]
- [x] Added/modified tests
- [x] Used pre-commit hooks
