### PR TITLE
[ENH] Add standard deviation columns to Benchmarking results

### DIFF
--- a/pyaptamer/benchmarking/_base.py
+++ b/pyaptamer/benchmarking/_base.py
@@ -119,10 +119,12 @@ class Benchmarking:
             - Index: pandas.MultiIndex with two levels (names shown in parentheses)
                 - level 0 "estimator": estimator name
                 - level 1 "metric": evaluator name
-            - Columns: ["train", "test"] (both floats)
-            - Cell values: mean scores (float) computed across CV folds:
+            - Columns: ["train", "test", "train_std", "test_std"] (all floats)
+            - Cell values: scores (float) computed across CV folds:
                 - "train" = mean of cross_validate(...)[f"train_{metric}"]
                 - "test"  = mean of cross_validate(...)[f"test_{metric}"]
+                - "train_std" = std of cross_validate(...)[f"train_{metric}"]
+                - "test_std"  = std of cross_validate(...)[f"test_{metric}"]
 
         """
         self.scorers_ = self._to_scorers(self.metrics)
@@ -140,12 +142,14 @@ class Benchmarking:
                 return_train_score=True,
             )
 
-            # average across folds
+            # average and std across folds
             est_scores = {}
             for metric in self.scorers_.keys():
                 est_scores[metric] = {
                     "train": float(np.mean(cv_results[f"train_{metric}"])),
                     "test": float(np.mean(cv_results[f"test_{metric}"])),
+                    "train_std": float(np.std(cv_results[f"train_{metric}"])),
+                    "test_std": float(np.std(cv_results[f"test_{metric}"])),
                 }
 
             results[est_name] = est_scores

--- a/pyaptamer/benchmarking/tests/test_benchmarking.py
+++ b/pyaptamer/benchmarking/tests/test_benchmarking.py
@@ -68,3 +68,74 @@ def test_benchmarking_with_predefined_split_regression(aptamer_seq, protein_seq)
     assert "train" in summary.columns
     assert "test" in summary.columns
     assert (reg.__class__.__name__, "mean_squared_error") in summary.index
+
+
+# ---------- Tests for standard deviation columns ----------
+
+
+class TestBenchmarkingStdScores:
+    """Tests for the train_std and test_std columns."""
+
+    def test_std_columns_present(self):
+        """Results DataFrame should contain train_std and test_std columns."""
+        from sklearn.dummy import DummyClassifier
+
+        X = np.array([[1, 0], [0, 1], [1, 1], [0, 0]] * 5)
+        y = np.array([1, 0, 1, 0] * 5)
+        test_fold = np.ones(len(y)) * -1
+        test_fold[-4:] = 0
+        cv = PredefinedSplit(test_fold)
+
+        bench = Benchmarking(
+            estimators=[DummyClassifier(strategy="most_frequent")],
+            metrics=[accuracy_score],
+            X=X, y=y, cv=cv,
+        )
+        results = bench.run()
+
+        assert "train_std" in results.columns
+        assert "test_std" in results.columns
+
+    def test_std_values_non_negative(self):
+        """Standard deviation must be >= 0."""
+        from sklearn.dummy import DummyClassifier
+
+        X = np.array([[1, 0], [0, 1], [1, 1], [0, 0]] * 5)
+        y = np.array([1, 0, 1, 0] * 5)
+        test_fold = np.ones(len(y)) * -1
+        test_fold[-4:] = 0
+        cv = PredefinedSplit(test_fold)
+
+        bench = Benchmarking(
+            estimators=[DummyClassifier(strategy="most_frequent")],
+            metrics=[accuracy_score],
+            X=X, y=y, cv=cv,
+        )
+        results = bench.run()
+
+        assert (results["train_std"] >= 0).all()
+        assert (results["test_std"] >= 0).all()
+
+    def test_std_columns_with_multiple_metrics(self):
+        """Std columns should work with multiple metrics."""
+        from sklearn.dummy import DummyClassifier
+        from sklearn.metrics import precision_score
+
+        X = np.array([[1, 0], [0, 1], [1, 1], [0, 0]] * 5)
+        y = np.array([1, 0, 1, 0] * 5)
+        test_fold = np.ones(len(y)) * -1
+        test_fold[-4:] = 0
+        cv = PredefinedSplit(test_fold)
+
+        bench = Benchmarking(
+            estimators=[DummyClassifier(strategy="most_frequent")],
+            metrics=[accuracy_score, precision_score],
+            X=X, y=y, cv=cv,
+        )
+        results = bench.run()
+
+        assert results.shape[0] == 2  # 2 metrics
+        assert "train_std" in results.columns
+        assert "test_std" in results.columns
+        assert results.shape[1] == 4  # train, test, train_std, test_std
+


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #620 

#### What does this implement/fix? Explain your changes.
Extends the output of `Benchmarking.run()` to include standard deviation metrics across cross-validation folds.
- Added `train_std` and `test_std` columns to the results DataFrame.
- Allows researchers to assess the stability and variance of different estimators.

#### What should a reviewer concentrate their feedback on?
- [x] Column naming consistency.
- [x] Backward compatibility (no changes to existing columns).

#### Did you add any tests for the change?
Yes, added tests in `test_benchmarking.py` ensuring std columns are present and contain valid (non-negative) values.

#### Any other comments?
N/A

#### PR checklist
- [x] The PR title starts with [ENH]
- [x] Added/modified tests
- [x] Used pre-commit hooks
