### PR TITLE
ENH: Move pairs_to_features and generate_kmer_vecs to transformer interface (#174)

### DIFF
--- a/pyaptamer/aptanet/_pipeline.py
+++ b/pyaptamer/aptanet/_pipeline.py
@@ -5,11 +5,10 @@ __required__ = ["python>=3.10"]
 from skbase.base import BaseObject
 from sklearn.base import BaseEstimator, clone
 from sklearn.pipeline import Pipeline
-from sklearn.preprocessing import FunctionTransformer
 from sklearn.utils.validation import check_is_fitted
 
 from pyaptamer.aptanet import AptaNetClassifier
-from pyaptamer.utils._aptanet_utils import pairs_to_features
+from pyaptamer.trafos.features import AptaNetFeatures
 
 
 class AptaNetPipeline(BaseObject, BaseEstimator):
@@ -69,23 +68,28 @@ class AptaNetPipeline(BaseObject, BaseEstimator):
         self.estimator = estimator
 
     def _build_pipeline(self):
-        transformer = FunctionTransformer(
-            func=pairs_to_features,
-            kw_args={"k": self.k},
-            validate=False,
-        )
+        transformer = AptaNetFeatures(k=self.k)
         self._estimator = self.estimator or AptaNetClassifier()
         return Pipeline([("features", transformer), ("clf", clone(self._estimator))])
 
     def fit(self, X, y):
+        import pandas as pd
+        if not isinstance(X, pd.DataFrame):
+            X = pd.DataFrame(X, columns=["aptamer", "protein"])
         self.pipeline_ = self._build_pipeline()
         self.pipeline_.fit(X, y)
         return self
 
     def predict_proba(self, X):
         check_is_fitted(self)
+        import pandas as pd
+        if not isinstance(X, pd.DataFrame):
+            X = pd.DataFrame(X, columns=["aptamer", "protein"])
         return self.pipeline_.predict_proba(X)
 
     def predict(self, X):
         check_is_fitted(self)
+        import pandas as pd
+        if not isinstance(X, pd.DataFrame):
+            X = pd.DataFrame(X, columns=["aptamer", "protein"])
         return self.pipeline_.predict(X)

--- a/pyaptamer/trafos/__init__.py
+++ b/pyaptamer/trafos/__init__.py
@@ -1,1 +1,5 @@
 """Transformations."""
+
+from pyaptamer.trafos.features import AptaNetFeatures, KMerFeatures
+
+__all__ = ["AptaNetFeatures", "KMerFeatures"]

--- a/pyaptamer/trafos/features/__init__.py
+++ b/pyaptamer/trafos/features/__init__.py
@@ -1,0 +1,6 @@
+"""Features generation."""
+
+from pyaptamer.trafos.features._aptanet import AptaNetFeatures
+from pyaptamer.trafos.features._kmer import KMerFeatures
+
+__all__ = ["AptaNetFeatures", "KMerFeatures"]

--- a/pyaptamer/trafos/features/_aptanet.py
+++ b/pyaptamer/trafos/features/_aptanet.py
@@ -1,0 +1,85 @@
+"""AptaNet features generation."""
+
+import numpy as np
+import pandas as pd
+
+from pyaptamer.pseaac import AptaNetPSeAAC
+from pyaptamer.trafos.base import BaseTransform
+from pyaptamer.trafos.features._kmer import KMerFeatures
+
+
+class AptaNetFeatures(BaseTransform):
+    """
+    Convert (aptamer_sequence, protein_sequence) pairs into feature vectors.
+
+    This function generates feature vectors for each (aptamer, protein) pair using:
+    - k-mer representation of the aptamer sequence
+    - Pseudo amino acid composition (PSeAAC) representation of the protein sequence
+
+    Parameters
+    ----------
+    k : int, optional
+        The k-mer size used to generate the k-mer vector from the aptamer sequence.
+        Default is 4.
+    """
+
+    _tags = {
+        "authors": ["satvshr"],
+        "maintainers": ["satvshr"],
+        "output_type": "numeric",
+        "property:fit_is_empty": True,
+        "capability:multivariate": True,
+    }
+
+    def __init__(self, k=4):
+        self.k = k
+        super().__init__()
+
+    def _transform(self, X):
+        """Transform the data.
+
+        Parameters
+        ----------
+        X : pd.DataFrame
+            Input data to transform. Expected to have 'aptamer' and 'protein' columns.
+
+        Returns
+        -------
+        X : pd.DataFrame, shape (n_samples, n_features_transformed)
+            Transformed data.
+        """
+        pseaac = AptaNetPSeAAC()
+        kmer_encoder = KMerFeatures(k=self.k)
+
+        if "aptamer" in X.columns and "protein" in X.columns:
+            aptamer_seqs = X["aptamer"]
+            protein_seqs = X["protein"]
+        elif X.shape[1] >= 2:
+            aptamer_seqs = X.iloc[:, 0]
+            protein_seqs = X.iloc[:, 1]
+        else:
+            raise ValueError(
+                "X must have at least two columns: 'aptamer' and 'protein'."
+            )
+
+        # process kmers
+        kmer_df = pd.DataFrame({"aptamer": aptamer_seqs})
+        kmer_features = kmer_encoder.transform(kmer_df).values
+
+        # process pseaac
+        pseaac_features = []
+        for protein_seq in protein_seqs:
+            if not isinstance(protein_seq, str):
+                protein_seq = ""
+            pseaac_features.append(pseaac.transform(protein_seq))
+
+        pseaac_features = np.vstack(pseaac_features)
+
+        feats = np.concatenate([kmer_features, pseaac_features], axis=1)
+
+        return pd.DataFrame(feats.astype(np.float32), index=X.index)
+
+    def get_test_params(self):
+        """Get test parameters for AptaNetFeatures."""
+        param0 = {"k": 4}
+        return [param0]

--- a/pyaptamer/trafos/features/_kmer.py
+++ b/pyaptamer/trafos/features/_kmer.py
@@ -1,0 +1,87 @@
+"""K-mer feature generation."""
+
+from itertools import product
+
+import numpy as np
+import pandas as pd
+
+from pyaptamer.trafos.base import BaseTransform
+
+
+class KMerFeatures(BaseTransform):
+    """
+    Generate normalized k-mer frequency vectors for aptamer sequences.
+
+    For all possible k-mers from length 1 to k, count their occurrences in the sequence
+    and normalize to form a frequency vector.
+
+    Parameters
+    ----------
+    k : int, optional
+        Maximum k-mer length (default is 4).
+    """
+
+    _tags = {
+        "authors": ["satvshr"],
+        "maintainers": ["satvshr"],
+        "output_type": "numeric",
+        "property:fit_is_empty": True,
+        "capability:multivariate": False,
+    }
+
+    def __init__(self, k=4):
+        self.k = k
+        super().__init__()
+
+    def _transform(self, X):
+        """Transform the data.
+
+        Parameters
+        ----------
+        X : pd.DataFrame
+            Input data to transform. Expected to have a single column containing strings.
+
+        Returns
+        -------
+        X : pd.DataFrame, shape (n_samples, n_features_transformed)
+            Transformed data.
+        """
+        k = self.k
+        DNA_BASES = list("ACGT")
+
+        all_kmers = []
+        for i in range(1, k + 1):
+            all_kmers.extend(["".join(p) for p in product(DNA_BASES, repeat=i)])
+
+        raw_sequences = X.values[:, 0].tolist()
+
+        result_np = []
+        for aptamer_sequence in raw_sequences:
+            if not isinstance(aptamer_sequence, str):
+                aptamer_sequence = ""
+            kmer_counts = dict.fromkeys(all_kmers, 0)
+            seq_len = len(aptamer_sequence)
+            for i in range(seq_len):
+                for j in range(1, k + 1):
+                    if i + j <= seq_len:
+                        kmer = aptamer_sequence[i : i + j]
+                        if kmer in kmer_counts:
+                            kmer_counts[kmer] += 1
+
+            total_kmers = sum(kmer_counts.values())
+            kmer_freq = np.array(
+                [
+                    kmer_counts[kmer] / total_kmers if total_kmers > 0 else 0
+                    for kmer in all_kmers
+                ]
+            )
+            result_np.append(kmer_freq)
+
+        result_df = pd.DataFrame(np.vstack(result_np), index=X.index)
+        return result_df
+
+    def get_test_params(self):
+        """Get test parameters for KMerFeatures."""
+        param0 = {"k": 4}
+        param1 = {"k": 3}
+        return [param0, param1]

--- a/pyaptamer/utils/_aptanet_utils.py
+++ b/pyaptamer/utils/_aptanet_utils.py
@@ -2,6 +2,7 @@ __author__ = "satvshr"
 __all__ = ["generate_kmer_vecs", "pairs_to_features"]
 
 from itertools import product
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -29,6 +30,12 @@ def generate_kmer_vecs(aptamer_sequence, k=4):
         1D numpy array of normalized frequency vector for all possible k-mers from
         length 1 to k.
     """
+    warnings.warn(
+        "`generate_kmer_vecs` is deprecated and will be removed in a future version. "
+        "Please use `pyaptamer.trafos.features.KMerFeatures` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     DNA_BASES = list("ACGT")
 
     # Generate all possible k-mers from 1 to k
@@ -83,6 +90,12 @@ def pairs_to_features(X, k=4):
         A 2D NumPy array where each row corresponds to the concatenated feature vector
         for a given (aptamer, protein) pair.
     """
+    warnings.warn(
+        "`pairs_to_features` is deprecated and will be removed in a future version. "
+        "Please use `pyaptamer.trafos.features.AptaNetFeatures` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     pseaac = AptaNetPSeAAC()
     feats = []
 


### PR DESCRIPTION
Closes #174.

### Overview
This PR addresses the "Redesigning the Public and Internal API" roadmap project by moving `generate_kmer_vecs` and `pairs_to_features` to the proper `BaseTransform` interface, standardizing their behavior with the rest of the `trafos` module (following the `GreedyEncoder` template).

### Changes Made
1. **New Transformers**: 
   - Added `KMerFeatures` in `pyaptamer/trafos/features/_kmer.py`.
   - Added `AptaNetFeatures` in `pyaptamer/trafos/features/_aptanet.py`.
   - Both inherit from `BaseTransform` and return Pandas DataFrames.
2. **Pipeline Integration**: 
   - Updated `AptaNetPipeline` to use `AptaNetFeatures` instead of `FunctionTransformer`. 
   - Added automated input coercion to ensure legacy `list of tuples` inputs from users still work transparently.
3. **Deprecations**: 
   - Added `DeprecationWarning`s to `pairs_to_features` and `generate_kmer_vecs` in `_aptanet_utils.py`, directing users to the new `trafos.features` classes.

This sets up a much cleaner architectural foundation for future `trafos` feature extractors.
