### PR TITLE
[BUG] Fix filter_words RuntimeWarning on empty input

### DIFF
--- a/pyaptamer/utils/_base.py
+++ b/pyaptamer/utils/_base.py
@@ -1,7 +1,5 @@
 __author__ = ["nennomp"]
-__all__ = [
-    "filter_words",
-]
+__all__ = ["filter_words"]
 
 import numpy as np
 
@@ -18,9 +16,15 @@ def filter_words(words: dict[str, float]) -> dict[str, int]:
     -------
     dict[str, int]
         A dictionary mapping filtered words to unique integer indices.
+
+    Raises
+    ------
+    ValueError
+        If ``words`` is empty.
     """
+    if not words:
+        raise ValueError("`words` must not be empty.")
     mean_freq = np.mean(list(words.values()))
     words = [seq for seq, freq in words.items() if freq > mean_freq]
     words = {word: i + 1 for i, word in enumerate(words)}
-
     return words

--- a/pyaptamer/utils/tests/test_base.py
+++ b/pyaptamer/utils/tests/test_base.py
@@ -1,6 +1,8 @@
 """Test suite for the base generic utilities."""
 
-__author__ = ["nennomp"]
+__author__ = ["nennomp", "Ishiezz"]
+
+import pytest
 
 from pyaptamer.utils._base import filter_words
 
@@ -38,3 +40,9 @@ def test_filter_words_preserves_order():
     # indices should reflect order of iteration over dict
     expected = {"zebra": 1, "alpha": 2}
     assert result == expected
+
+
+def test_filter_words_empty_dict():
+    """Check that an empty dict raises a ValueError."""
+    with pytest.raises(ValueError, match="`words` must not be empty"):
+        filter_words({})


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #629 

#### What does this implement/fix?

`filter_words` in `pyaptamer/utils/_base.py` silently emitted a `RuntimeWarning` 
when called with an empty dictionary, instead of failing with a clear `ValueError`.

**Before this fix:**
```python
filter_words({})
# RuntimeWarning: Mean of empty slice
# RuntimeWarning: invalid value encountered in scalar divide
# silently returns {} — no error raised
```

**After this fix:**
```python
filter_words({})
# ValueError: `words` must not be empty.
```

**Changes made:**

- Added an empty dict guard in `pyaptamer/utils/_base.py`:
```python
  if not words:
      raise ValueError("`words` must not be empty.")
```
- Added `Raises` section to the `filter_words` docstring
- Added `test_filter_words_empty_dict` to 
  `pyaptamer/utils/tests/test_base.py`

This is consistent with how other functions in the codebase handle invalid 
inputs — `rna2vec`, `MCTS`, and `PSeAAC` all raise `ValueError` for bad inputs.

#### Did you add any tests?

Yes. Added `test_filter_words_empty_dict` to cover the empty input case.
All 4 tests in `pyaptamer/utils/tests/test_base.py` pass.

#### PR checklist
- [x] The PR title starts with `[BUG]`
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing