### PR TITLE
[BUG] Fix GreedyEncoder crash and silent failure on empty words dict

### DIFF
--- a/pyaptamer/trafos/encode/_greedy.py
+++ b/pyaptamer/trafos/encode/_greedy.py
@@ -37,6 +37,11 @@ class GreedyEncoder(BaseTransform):
         Maximum length of words to consider during tokenization.
         If None, defaults to the length of the longest word in ``words``.
 
+    Raises
+    ------
+    ValueError
+        If ``words`` is empty.
+
     Examples
     --------
     >>> from pyaptamer.trafos.encode import GreedyEncoder
@@ -63,6 +68,8 @@ class GreedyEncoder(BaseTransform):
         max_len: int = None,
         word_max_len: int = None,
     ):
+        if not words:
+            raise ValueError("`words` must not be empty.")
         self.words = words
         self.max_len = max_len
         self.word_max_len = word_max_len

--- a/pyaptamer/trafos/encode/tests/test_greedy_encoder.py
+++ b/pyaptamer/trafos/encode/tests/test_greedy_encoder.py
@@ -1,0 +1,85 @@
+"""Test suite for the GreedyEncoder."""
+
+__author__ = ["Ishiezz"]
+
+import pandas as pd
+import pytest
+
+from pyaptamer.trafos.encode._greedy import GreedyEncoder
+
+
+def _make_df(sequences):
+    """Helper to create input DataFrame."""
+    return pd.DataFrame({"seq": [list(seq) for seq in sequences]})
+
+
+def test_greedy_encoder_basic():
+    """Check basic encoding with single-character words."""
+    words = {"A": 1, "C": 2, "G": 3, "U": 4}
+    enc = GreedyEncoder(words=words, max_len=4)
+    X = _make_df(["ACGU"])
+    result = enc.fit_transform(X)
+
+    assert result.shape == (1, 4)
+    assert list(result.iloc[0]) == [1, 2, 3, 4]
+
+
+def test_greedy_encoder_longest_match():
+    """Check greedy longest-match preference."""
+    words = {"A": 1, "AC": 2, "G": 3}
+    enc = GreedyEncoder(words=words, max_len=3)
+    X = _make_df(["ACG"])
+    result = enc.fit_transform(X)
+
+    # "AC" should be matched over "A"
+    assert list(result.iloc[0]) == [2, 3, 0]
+
+
+def test_greedy_encoder_unknown_token():
+    """Check that unknown characters produce token 0."""
+    words = {"A": 1, "C": 2}
+    enc = GreedyEncoder(words=words, max_len=4)
+    X = _make_df(["AXCX"])
+    result = enc.fit_transform(X)
+
+    assert list(result.iloc[0]) == [1, 0, 2, 0]
+
+
+def test_greedy_encoder_padding():
+    """Check that sequences shorter than max_len are zero-padded."""
+    words = {"A": 1, "C": 2}
+    enc = GreedyEncoder(words=words, max_len=5)
+    X = _make_df(["AC"])
+    result = enc.fit_transform(X)
+
+    assert result.shape == (1, 5)
+    assert list(result.iloc[0]) == [1, 2, 0, 0, 0]
+
+
+def test_greedy_encoder_truncation():
+    """Check that sequences longer than max_len are truncated."""
+    words = {"A": 1, "C": 2, "G": 3, "U": 4}
+    enc = GreedyEncoder(words=words, max_len=2)
+    X = _make_df(["ACGU"])
+    result = enc.fit_transform(X)
+
+    assert result.shape == (1, 2)
+    assert list(result.iloc[0]) == [1, 2]
+
+
+def test_greedy_encoder_multiple_sequences():
+    """Check encoding of multiple sequences."""
+    words = {"A": 1, "C": 2, "G": 3, "U": 4}
+    enc = GreedyEncoder(words=words, max_len=3)
+    X = _make_df(["ACG", "UAC"])
+    result = enc.fit_transform(X)
+
+    assert result.shape == (2, 3)
+    assert list(result.iloc[0]) == [1, 2, 3]
+    assert list(result.iloc[1]) == [4, 1, 2]
+
+
+def test_greedy_encoder_empty_words():
+    """Check that empty words dict raises ValueError at init."""
+    with pytest.raises(ValueError, match="`words` must not be empty"):
+        GreedyEncoder(words={})


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #631

#### What does this implement/fix?

`GreedyEncoder` had two failure modes when initialized with an empty `words` dict:

**Mode 1 — Confusing crash (default, `word_max_len=None`):**
```python
GreedyEncoder(words={}).fit_transform(X)
# ValueError: max() iterable argument is empty  ← no indication words={} is wrong
```

**Mode 2 — Silent all-zeros output (when `word_max_len` is set):**
```python
GreedyEncoder(words={}, word_max_len=3).fit_transform(X)
# Returns all-zero DataFrame silently — no error, no warning
```

**After fix:**
```python
GreedyEncoder(words={})
# ValueError: `words` must not be empty.
```

Also added `Raises` section to the docstring.

#### Did you add any tests?

Yes. Created `pyaptamer/trafos/encode/tests/test_greedy_encoder.py` —
there was no test file or tests directory for `GreedyEncoder` before this PR.
Also added `pyaptamer/trafos/encode/tests/__init__.py` to make the new
tests directory a proper Python package.
Added 7 tests covering basic encoding, longest-match, unknown tokens,
padding, truncation, multiple sequences, and the empty words guard.
All 7 pass.

#### PR checklist
- [x] The PR title starts with `[BUG]`
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing