### PR TITLE
[DOC] Add Jupyter Notebook Tutorial for sktime Benchmarking

### DIFF
--- a/examples/benchmarking_tutorial.ipynb
+++ b/examples/benchmarking_tutorial.ipynb
@@ -235,6 +235,69 @@
    "metadata": {},
    "outputs": [],
    "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3. Integrating with `sktime` for statistical significance testing\n",
+    "By passing `return_raw=True` to `Benchmarking.run()`, we can extract the raw, per-fold MultiIndex DataFrame. \n",
+    "This raw output is specifically formatted to be fully compatible with `sktime`'s `Evaluator` class, allowing \n",
+    "for advanced statistical significance testing (like the Friedman test) and the generation of Critical Difference (CD) diagrams."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Run benchmarking with return_raw=True\n",
+    "bench_sktime = Benchmarking(\n",
+    "    estimators=[aptanet_estimator],\n",
+    "    metrics=[accuracy_score],\n",
+    "    X=X,\n",
+    "    y=y,\n",
+    "    cv=cv,\n",
+    ")\n",
+    "results_sktime, raw_results = bench_sktime.run(return_raw=True)\n",
+    "print(\"Raw results MultiIndex DataFrame:\")\n",
+    "print(raw_results.head())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can now pass `raw_results` directly into `sktime`.\n",
+    "\n",
+    "*Note: The following cell requires `sktime` to be installed (`pip install sktime`).*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from sktime.benchmarking.evaluation import Evaluator\n",
+    "\n",
+    "    # Initialize the sktime Evaluator with our raw results\n",
+    "    evaluator = Evaluator(raw_results)\n",
+    "\n",
+    "    # Rank the estimators (lower rank is better)\n",
+    "    ranks = evaluator.rank()\n",
+    "    print(\"\\nEstimator Ranks:\")\n",
+    "    print(ranks)\n",
+    "\n",
+    "    # You can also generate statistical plots!\n",
+    "    # For example, to generate a Critical Difference diagram:\n",
+    "    # evaluator.plot_boxplots()\n",
+    "    # fig, ax = evaluator.plot_critical_difference()\n",
+    "except ImportError:\n",
+    "    print(\"sktime is not installed. Run `pip install sktime` to run this cell.\")"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
This PR adds a comprehensive tutorial section to examples/benchmarking_tutorial.ipynb to demonstrate how to leverage the newly integrated return_raw=True parameter in Benchmarking.run().

While the core functionality was introduced in #601, this documentation update closes the loop for end-users. It provides a copy-pasteable workflow showing how to extract the generated MultiIndex DataFrame and pass it directly into sktime.benchmarking.evaluation.Evaluator. This allows researchers to easily perform advanced statistical significance testing (such as Friedman tests) and generate Critical Difference (CD) diagrams for their aptamer models.

Review Focus
Clarity and accuracy of the new Markdown explanations.
Correctness of the conditional sktime code block.