### PR TITLE
[MNT] Fix BaseTransform abstract method exception types and add missing module-level attributes

### DIFF
--- a/pyaptamer/trafos/base/_base.py
+++ b/pyaptamer/trafos/base/_base.py
@@ -1,5 +1,8 @@
 """Base transformation class."""
 
+__author__ = ["nennomp", "fkiraly"]
+__all__ = ["BaseTransform"]
+
 import pandas as pd
 from skbase.base import BaseEstimator
 
@@ -61,7 +64,7 @@ class BaseTransform(BaseEstimator):
         self : object
             Returns self.
         """
-        raise ValueError(
+        raise NotImplementedError(
             "abstract method _fit called, this should be implemented in the subclass"
         )
 
@@ -98,7 +101,7 @@ class BaseTransform(BaseEstimator):
         if self.get_tag("property:elementwise", False):
             return X.map(self._transform_element)
 
-        raise ValueError(
+        raise NotImplementedError(
             "abstract method _transform called, "
             "this should be implemented in the subclass"
         )
@@ -118,7 +121,7 @@ class BaseTransform(BaseEstimator):
         X : array-like, shape (n_samples, n_features_transformed)
             Transformed data.
         """
-        raise ValueError(
+        raise NotImplementedError(
             "abstract method _transform_element called, "
             "since tag 'property:elementwise' is True, "
             "this should be implemented in the subclass"


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #636 

#### What does this implement/fix?

Three maintenance fixes in `pyaptamer/trafos/base/_base.py`:

**1. Abstract methods now raise `NotImplementedError` instead of `ValueError`**

`_fit`, `_transform`, and `_transform_element` raised `ValueError` when called
directly. `NotImplementedError` is the correct Python convention for unimplemented
abstract methods — and is consistent with `skbase.BaseEstimator` which
`BaseTransform` inherits from.

**2. Added `__author__` tag**

Consistent with every other module in pyaptamer.

**3. Added `__all__` tag**

Consistent with every other public module in pyaptamer.

#### Did you add any tests?

No new tests needed — the existing `GreedyEncoder` tests in
`pyaptamer/trafos/encode/tests/test_greedy_encoder.py` exercise `BaseTransform`
through inheritance and continue to pass.

#### PR checklist
- [x] The PR title starts with `[MNT]`
- [x] Used pre-commit hooks when committing