### PR TITLE
[BUG] Fix clean_protein_seq replacing invalid AAs with Asparagine (N)

### DIFF
--- a/pyaptamer/utils/_pseaac_utils.py
+++ b/pyaptamer/utils/_pseaac_utils.py
@@ -11,15 +11,18 @@ is used for efficient membership testing.
 Functions
 ---------
 clean_protein_seq(seq)
-    Replaces invalid amino acids with "N" and warn the user.
+    Remove invalid amino acids from the sequence and warn the user.
 """
 
 AMINO_ACIDS = list("ACDEFGHIKLMNPQRSTVWY")
 
 
 def clean_protein_seq(seq):
-    """
-    Replace invalid amino acids with "N" and warn the user.
+    """Remove invalid amino acids from the sequence and warn the user.
+
+    Invalid characters (i.e. characters that are not one of the 20 standard
+    amino acid one-letter codes) are stripped from the sequence. A
+    ``UserWarning`` is issued whenever at least one character is removed.
 
     Parameters
     ----------
@@ -29,8 +32,7 @@ def clean_protein_seq(seq):
     Returns
     -------
     str
-        Cleaned protein sequence where all invalid characters have been replaced
-        with "N".
+        Cleaned protein sequence with all invalid characters removed.
     """
     import warnings
 
@@ -41,12 +43,12 @@ def clean_protein_seq(seq):
         if aa in AMINO_ACIDS:
             cleaned.append(aa)
         else:
-            cleaned.append("N")
             invalid_found = True
 
     if invalid_found:
         warnings.warn(
-            "Invalid amino acid(s) found in sequence. Replaced with 'N'.",
+            "Invalid amino acid(s) found in sequence. "
+            "These characters have been removed.",
             UserWarning,
             stacklevel=2,
         )


### PR DESCRIPTION

Fixes #648

**What does this PR do?**

`clean_protein_seq()` was replacing invalid amino acid characters with `"N"`, 
but `"N"` is the IUPAC one-letter code for Asparagine a real amino acid 
already in the `AMINO_ACIDS` list. This silently corrupted protein sequences 
by turning unknown characters into a valid amino acid, producing incorrect 
PSeAAC feature vectors downstream.

**Change summary:**

- Removed `cleaned.append("N")` so invalid characters are filtered out 
  instead of replaced with Asparagine
- Updated the warning message from "Replaced with 'N'" to 
  "These characters have been removed"
- Updated the docstring to reflect the new behavior

**Before (buggy):**
```python
clean_protein_seq("ACXD")  # Returns "ACND" X became Asparagine!
```

**After (fixed):**
```python
clean_protein_seq("ACXD")  # Returns "ACD" X removed, warning issued
```

**Testing:**

- All 144 existing tests pass (0 failures)
- Verified manually:
  - Valid sequences pass through unchanged
  - Invalid characters are removed (not replaced)
  - `N` (Asparagine) is correctly preserved
  - Warning is emitted when invalid characters are found
  - Empty input returns empty string