### PR TITLE
[BUG] Remove global np.random.seed() from AptaNetClassifier/Regressor.fit()

### DIFF
--- a/pyaptamer/aptanet/_feature_classifier.py
+++ b/pyaptamer/aptanet/_feature_classifier.py
@@ -119,7 +119,6 @@ class AptaNetClassifier(ClassifierMixin, BaseEstimator):
             )
 
         if self.random_state is not None:
-            np.random.seed(self.random_state)
             torch.manual_seed(self.random_state)
 
         self.classes_, y = np.unique(y, return_inverse=True)
@@ -303,7 +302,6 @@ class AptaNetRegressor(RegressorMixin, BaseEstimator):
         y = y.reshape(-1, 1)
 
         if self.random_state is not None:
-            np.random.seed(self.random_state)
             torch.manual_seed(self.random_state)
 
         self.pipeline_ = self._build_pipeline()


### PR DESCRIPTION
Fixes #650

**What does this PR do?**

Removes `np.random.seed(self.random_state)` from `AptaNetClassifier.fit()` 
and `AptaNetRegressor.fit()`. This call mutated the **global** NumPy random 
state, causing unintended side effects on user code.

**Why is this safe to remove?**

- The `RandomForestClassifier`/`RandomForestRegressor` already receives 
  `random_state=self.random_state` via `_build_pipeline()`, so the global 
  seed was redundant for pipeline reproducibility.
- `torch.manual_seed()` is kept since PyTorch has no local seed alternative 
this is standard practice.
- Setting global seeds is explicitly discouraged by scikit-learn conventions.

**Change summary:**

- Removed `np.random.seed(self.random_state)` from `AptaNetClassifier.fit()` (line 122)
- Removed `np.random.seed(self.random_state)` from `AptaNetRegressor.fit()` (line 306)
- Kept `torch.manual_seed(self.random_state)` (no local PyTorch alternative)

**Testing:**

- All 114 existing tests pass (0 failures, 2 skipped)
- Verified that `fit()` no longer mutates the global NumPy random state