### PR TITLE
[BUG] Add encoder_type validation in AptaTransEncoderLightning

### DIFF
--- a/pyaptamer/aptatrans/_model_lightning.py
+++ b/pyaptamer/aptatrans/_model_lightning.py
@@ -270,6 +270,13 @@ class AptaTransEncoderLightning(AptaTransLightning):
         weight_ssp: float = 1.0,
     ) -> None:
         super().__init__(model, lr, weight_decay, betas)
+
+        _valid_encoder_types = ("apta", "prot")
+        if encoder_type not in _valid_encoder_types:
+            raise ValueError(
+                f"`encoder_type` must be one of {_valid_encoder_types}, "
+                f"got {encoder_type!r}."
+            )
         self.encoder_type = encoder_type
         self.weight_mlm = weight_mlm
         self.weight_ssp = weight_ssp
@@ -319,6 +326,11 @@ class AptaTransEncoderLightning(AptaTransLightning):
         elif self.encoder_type == "prot":
             params = list(self.model.encoder_prot.parameters()) + list(
                 self.model.token_predictor_prot.parameters()
+            )
+        else:
+            raise ValueError(
+                f"`encoder_type` must be one of ('apta', 'prot'), "
+                f"got {self.encoder_type!r}."
             )
 
         optimizer = torch.optim.Adam(


### PR DESCRIPTION
Fixes #652 

**What does this PR do?**

Adds input validation for the `encoder_type` parameter in 
`AptaTransEncoderLightning` to prevent a confusing `NameError` 
crash in `configure_optimizers()`.

**Change summary:**

- Added early validation in `__init__()` that raises `ValueError` 
  if `encoder_type` is not one of `('apta', 'prot')`
- Added a defensive `else` clause in `configure_optimizers()` as 
  a safety net (defense-in-depth)

**Before (buggy):**
```python
# Silently accepted at init
enc = AptaTransEncoderLightning(model, encoder_type="invalid")
# Crashes later with confusing NameError
enc.configure_optimizers()  # NameError: name 'params' is not defined
```

**After (fixed):**
```python
# Fails immediately with clear error message
enc = AptaTransEncoderLightning(model, encoder_type="invalid")
# ValueError: `encoder_type` must be one of ('apta', 'prot'), got 'invalid'.
```

**Testing:**

- All 12 existing lightning tests pass (0 failures)
- Verified valid values ('apta', 'prot') are accepted
- Verified invalid values ('invalid', None) raise ValueError with clear message