### PR TITLE
[MNT] Rename 'type' parameter to 'output_type' in aa_props()

### DIFF
--- a/pyaptamer/pseaac/_props.py
+++ b/pyaptamer/pseaac/_props.py
@@ -5,7 +5,7 @@ import numpy as np
 import pandas as pd
 
 
-def aa_props(prop_indices=None, type="numpy", normalize=True):
+def aa_props(prop_indices=None, output_type="numpy", normalize=True):
     """
     Amino acid physicochemical property matrix for PSeAAC.
 
@@ -71,7 +71,7 @@ def aa_props(prop_indices=None, type="numpy", normalize=True):
     prop_indices : list of int, optional
         List of indices (0-based) of properties to include (e.g., [0, 4, 7]).
         If None, returns all 21 properties.
-    type : {'numpy', 'pandas'}, default='numpy'
+    output_type : {'numpy', 'pandas'}, default='numpy'
         If 'pandas', returns a DataFrame with amino acid and property labels.
         If 'numpy', returns a numpy array.
     normalize : bool, default=True
@@ -83,7 +83,7 @@ def aa_props(prop_indices=None, type="numpy", normalize=True):
 
     Returns
     -------
-    props : numpy.ndarray or pandas.DataFrame (depending on `type`)
+    props : numpy.ndarray or pandas.DataFrame (depending on `output_type`)
 
         - Rows: standard amino acids (A, C, D, ..., Y)
         - Columns: physicochemical properties of the standard amino acids.
@@ -93,7 +93,7 @@ def aa_props(prop_indices=None, type="numpy", normalize=True):
     --------
     >>> from pyaptamer.pseaac._props import aa_props
     >>> df = aa_props()
-    >>> arr = aa_props(type="numpy", normalize=True)
+    >>> arr = aa_props(output_type="numpy", normalize=True)
     """
     aa_order = [
         "A",
@@ -1082,9 +1082,9 @@ def aa_props(prop_indices=None, type="numpy", normalize=True):
     else:
         selected_names = prop_names
 
-    if type == "pandas":
+    if output_type == "pandas":
         return pd.DataFrame(props, index=aa_order, columns=selected_names)
-    elif type == "numpy":
+    elif output_type == "numpy":
         return props
     else:
-        raise ValueError("type must be 'numpy' or 'pandas'")
+        raise ValueError("`output_type` must be 'numpy' or 'pandas'")

--- a/pyaptamer/pseaac/_pseaac_aptanet.py
+++ b/pyaptamer/pseaac/_pseaac_aptanet.py
@@ -101,7 +101,7 @@ class AptaNetPSeAAC:
         self.weight = weight
 
         # Load normalized property matrix (20x21, rows=AA, cols=NP1-NP21)
-        self.np_matrix = aa_props(type="numpy", normalize=True)
+        self.np_matrix = aa_props(output_type="numpy", normalize=True)
         # Each prop_group is a tuple of 3 columns (property indices)
         self.prop_groups = [
             (0, 1, 2),

--- a/pyaptamer/pseaac/_pseaac_general.py
+++ b/pyaptamer/pseaac/_pseaac_general.py
@@ -131,7 +131,7 @@ class PSeAAC:
             )
 
         self.np_matrix = aa_props(
-            prop_indices=prop_indices, type="numpy", normalize=True
+            prop_indices=prop_indices, output_type="numpy", normalize=True
         )
         self._n_cols = self.np_matrix.shape[1]  # The number of properties selected
 

--- a/pyaptamer/pseaac/tests/test_pseaac.py
+++ b/pyaptamer/pseaac/tests/test_pseaac.py
@@ -17,8 +17,8 @@ def test_normalized_values():
     This test targets the common `aa_props` normalization and therefore uses
     the package-level `aa_props` implementation.
     """
-    original_df = aa_props(type="pandas", normalize=False)
-    normalized_df = aa_props(type="pandas", normalize=True)
+    original_df = aa_props(output_type="pandas", normalize=False)
+    normalized_df = aa_props(output_type="pandas", normalize=True)
 
     manual_norm = (original_df - original_df.mean()) / original_df.std(ddof=0)
     manual_norm = manual_norm.round(3)


### PR DESCRIPTION
Fixes #656 

**What does this PR do?**

Renames the `type` parameter of `aa_props()` to `output_type` to 
avoid shadowing Python's builtin `type()` function.

**Change summary:**

- **`_props.py`**: Renamed parameter in signature, docstring, examples, 
  and internal usage (`if type ==` → `if output_type ==`)
- **`_pseaac_aptanet.py`**: Updated call site `type="numpy"` → `output_type="numpy"`
- **`_pseaac_general.py`**: Updated call site `type="numpy"` → `output_type="numpy"`
- **`test_pseaac.py`**: Updated call sites `type="pandas"` → `output_type="pandas"`

**Note:** This is a breaking change for any external code calling 
`aa_props(type=...)` with a keyword argument. Since the API is currently 
unstable (version `0.1.0a1`), this is the right time to fix it.

**Testing:**

- All 13 PSeAAC tests pass (0 failures)