### PR TITLE
[BUG] Use ValueError instead of AssertionError for input validation in AptaTrans

### DIFF
--- a/pyaptamer/aptatrans/_model.py
+++ b/pyaptamer/aptatrans/_model.py
@@ -107,12 +107,12 @@ class AptaTrans(nn.Module):
         """
         Raises
         -------
-        AssertionError
+        ValueError
             If the input dimension is not divisible by the number of heads.
         """
         super().__init__()
         if in_dim % n_heads != 0:
-            raise AssertionError(
+            raise ValueError(
                 f"Input dimension {in_dim} must be divisible by number of heads "
                 f"{n_heads}."
             )

--- a/pyaptamer/aptatrans/tests/test_aptatrans.py
+++ b/pyaptamer/aptatrans/tests/test_aptatrans.py
@@ -27,11 +27,11 @@ class TestAptaTransModel:
         embeddings: tuple[EncoderPredictorConfig, EncoderPredictorConfig],
     ):
         """
-        Check that an AssertionError is raised if input dimension is not divisible by
+        Check that a ValueError is raised if input dimension is not divisible by
         the number of heads.
         """
         with pytest.raises(
-            AssertionError,
+            ValueError,
             match="Input dimension 128 must be divisible by number of heads 3.",
         ):
             AptaTrans(


### PR DESCRIPTION
Fixes #658 

**What does this PR do?**

Changes the exception type from `AssertionError` to `ValueError` in 
`AptaTrans.__init__()` when `in_dim` is not divisible by `n_heads`. 
This is user-facing input validation, not an internal assertion.

**Change summary:**

- **`_model.py`**: Changed `raise AssertionError(...)` to `raise ValueError(...)`; 
  updated docstring from `AssertionError` to `ValueError`
- **`test_aptatrans.py`**: Updated `pytest.raises(AssertionError, ...)` to 
  `pytest.raises(ValueError, ...)`; updated test docstring

**Testing:**

- All 37 aptatrans tests pass (0 failures, 1 skipped)