### PR TITLE
[DOC] Document sequence key returned by MCTS.run

### DIFF
--- a/pyaptamer/mcts/_algorithm.py
+++ b/pyaptamer/mcts/_algorithm.py
@@ -291,8 +291,8 @@ class MCTS(BaseObject):
         Returns
         -------
         dict
-            Dictionary containing the final candidate sequence (`candidate`) and its
-            score (`score`).
+            Dictionary containing the reconstructed candidate sequence (`candidate`),
+            the raw encoded sequence (`sequence`), and its score (`score`).
         """
         self._reset()
 


### PR DESCRIPTION
## Summary
- document the `sequence` key returned by `MCTS.run()`
- clarify that `candidate` is the reconstructed sequence while `sequence` is the raw encoded sequence
- keep runtime behavior unchanged

## Verification
- `python -m compileall pyaptamer/mcts/_algorithm.py`
- `python -c "from pyaptamer.mcts._algorithm import MCTS; import inspect; print(inspect.getdoc(MCTS.run))"`
- `git diff --check`

Fixes #352.