### PR TITLE
[BUG] Replace assert with ValueError in PositionalEncoding.forward()

### DIFF
--- a/pyaptamer/aptatrans/layers/_encoder.py
+++ b/pyaptamer/aptatrans/layers/_encoder.py
@@ -78,9 +78,11 @@ class PositionalEncoding(nn.Module):
             Output tensor of shape (batch_size, seq_len, n_features (`d_model`)), with
             positional encodings applied.
         """
-        assert x.shape[1] <= self.max_len, (
-            f"Input sequence length {x.shape[1]} exceeds maximum length {self.max_len}."
-        )
+        if x.shape[1] > self.max_len:
+            raise ValueError(
+                f"Input sequence length {x.shape[1]} exceeds maximum length"
+                f" {self.max_len}."
+            )
 
         out = x + self.pe[:, : x.shape[1], :]
         if self.dropout:


### PR DESCRIPTION
## Summary

Fixes #353

`PositionalEncoding.forward()` used a bare `assert` to validate that the input sequence length does not exceed `max_len`:

```python
assert x.shape[1] <= self.max_len, (
    f"Input sequence length {x.shape[1]} exceeds maximum length {self.max_len}."
)
```

`assert` statements are silently stripped when Python runs with the `-O` (optimise) flag, meaning this guard disappears entirely in optimised environments. The fix replaces it with an explicit `ValueError`, which is always raised regardless of interpreter flags and is the correct exception type for invalid input values.

## Changes

- `pyaptamer/aptatrans/layers/_encoder.py`: `assert` → `raise ValueError` in `PositionalEncoding.forward()`

## Test plan

- [ ] Existing AptaTrans test suite passes
- [ ] `ValueError` is raised (not `AssertionError`) when sequence length exceeds `max_len`