### PR TITLE
[BUG] GreedyEncoder silently truncates sequences exceeding max_len without warning

### DIFF
--- a/pyaptamer/trafos/encode/_greedy.py
+++ b/pyaptamer/trafos/encode/_greedy.py
@@ -117,7 +117,7 @@ class GreedyEncoder(BaseTransform):
                 # stop if we've reached max_len tokens
                 if max_len is not None and len(tokens) >= max_len:
                     tokens = tokens[:max_len]
-                    warnings.warn("One or more sequence exceeds maimum length and was truncted ",
+                    warnings.warn("One or more sequence exceeds maximum length and was truncted ",
                                   UserWarning,
                                   stacklevel=2)
                     break

--- a/pyaptamer/trafos/encode/_greedy.py
+++ b/pyaptamer/trafos/encode/_greedy.py
@@ -117,6 +117,9 @@ class GreedyEncoder(BaseTransform):
                 # stop if we've reached max_len tokens
                 if max_len is not None and len(tokens) >= max_len:
                     tokens = tokens[:max_len]
+                    warnings.warn("One or more sequence exceeds maimum length and was truncted ",
+                                  UserWarning,
+                                  stacklevel=2)
                     break
 
             encoded_seqs.append(tokens)

--- a/pyaptamer/trafos/encode/_greedy.py
+++ b/pyaptamer/trafos/encode/_greedy.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import pandas as pd
+import warnings
 
 from pyaptamer.trafos.base import BaseTransform
 

--- a/pyaptamer/trafos/encode/_greedy.py
+++ b/pyaptamer/trafos/encode/_greedy.py
@@ -1,8 +1,9 @@
 """Base transformation class."""
 
+import warnings
+
 import numpy as np
 import pandas as pd
-import warnings
 
 from pyaptamer.trafos.base import BaseTransform
 
@@ -117,9 +118,11 @@ class GreedyEncoder(BaseTransform):
                 # stop if we've reached max_len tokens
                 if max_len is not None and len(tokens) >= max_len:
                     tokens = tokens[:max_len]
-                    warnings.warn("One or more sequence exceeds maximum length and was truncted ",
-                                  UserWarning,
-                                  stacklevel=2)
+                    warnings.warn(
+                        "One or more sequence exceeds maximum length and was truncted ",
+                        UserWarning,
+                        stacklevel=2,
+                    )
                     break
 
             encoded_seqs.append(tokens)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #669 

#### What does this implement/fix? Explain your changes.

`GreedyEncoder` in `pyaptamer/trafos/encode/_greedy.py` was silently truncating sequences that exceeded `max_len` with no indication to the user. This is inconsistent with how `clean_protein_seq` in `_pseaac_utils.py` handles sequence modification — it issues a `UserWarning` whenever it changes a sequence. From a chemistry standpoint this is also risky since aptamer sequences fold into specific 3D structures like stem-loops and G-quadruplexes that are length dependent, so a silent truncation could cause a sequence to encode a structurally different conformation without the researcher knowing.

The fix adds a `UserWarning` when truncation occurs, following the exact same pattern already established by `clean_protein_seq`.

#### What should a reviewer concentrate their feedback on?

- The placement of `warnings.warn()` inside `_transform()` and whether `stacklevel=2` is correct for this call depth
- Whether the warning message is clear enough for end users

#### Did you add any tests for the change?

No new tests were added. The fix is a single warning call that follows the existing pattern in the codebase.

#### Any other comments?

This was discussed with @satvshr on Discord who confirmed the fix is welcome.

#### PR checklist
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
- [ ] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
  To run hooks independent of commit, execute `pre-commit run --all-files`