### PR TITLE
[DOC] Add Sphinx documentation site for AptaNet and AptaTrans

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,51 @@
+name: docs
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment, cancelling older in-progress runs.
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install package and docs dependencies
+        run: pip install ".[docs]"
+
+      - name: Build HTML
+        run: sphinx-build -b html docs/source docs/build/html
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/build/html
+
+  deploy:
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -203,5 +203,8 @@ pyaptamer/datasets/data/proteins-shin2023.csv
 # Model weights files
 pyaptamer/aptatrans/weights/pretrained.pt
 
+# Sphinx autosummary generated stubs
+docs/source/generated/
+
 # For macOS
 .DS_Store

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,23 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html
+
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+
+sphinx:
+  configuration: docs/source/conf.py
+  # fail_on_warning: true
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs
+
+# HTML only; no PDF or ePub output.
+formats: []

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,14 @@
+# Minimal makefile for Sphinx documentation
+
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,31 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found.
+	echo.Install Sphinx, then set the SPHINXBUILD environment variable
+	echo.to point to the full path of the 'sphinx-build' executable.
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/source/_templates/autosummary/class.rst
+++ b/docs/source/_templates/autosummary/class.rst
@@ -1,0 +1,49 @@
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+{% set base_members = [
+   "get_params", "set_params", "score", "get_metadata_routing",
+   "clone", "reset", "get_config", "set_config",
+   "get_class_tag", "get_class_tags", "get_tag", "get_tags",
+   "set_tags", "clone_tags", "get_test_params", "create_test_instance",
+   "create_test_instances_and_names", "get_fitted_params", "is_composite",
+   "get_param_names", "get_param_defaults", "save",
+   "load_from_path", "load_from_serial",
+] %}
+
+.. autoclass:: {{ objname }}
+
+   {% block methods %}
+   {% set ns = namespace(public=[]) %}
+   {% for item in methods %}
+   {% if not item.startswith('_') and not item.endswith('_request') and item not in base_members %}
+   {% set ns.public = ns.public + [item] %}
+   {% endif %}
+   {% endfor %}
+   {% if ns.public %}
+   .. rubric:: {{ _('Methods') }}
+
+   .. autosummary::
+   {% for item in ns.public %}
+      ~{{ name }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block attributes %}
+   {% set ns2 = namespace(public=[]) %}
+   {% for item in attributes %}
+   {% if not item.startswith('_') and item not in base_members %}
+   {% set ns2.public = ns2.public + [item] %}
+   {% endif %}
+   {% endfor %}
+   {% if ns2.public %}
+   .. rubric:: {{ _('Attributes') }}
+
+   .. autosummary::
+   {% for item in ns2.public %}
+      ~{{ name }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}

--- a/docs/source/api_reference.md
+++ b/docs/source/api_reference.md
@@ -1,0 +1,127 @@
+# API reference
+
+This page documents the public API. Names not listed here are internal and may
+change without notice.
+
+## AptaNet
+
+```{eval-rst}
+.. currentmodule:: pyaptamer.aptanet
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   AptaNetPipeline
+   AptaNetClassifier
+   AptaNetRegressor
+```
+
+## AptaTrans
+
+```{eval-rst}
+.. currentmodule:: pyaptamer.aptatrans
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   AptaTransPipeline
+   AptaTrans
+   AptaTransLightning
+   AptaTransEncoderLightning
+   EncoderPredictorConfig
+```
+
+## Monte Carlo Tree Search
+
+```{eval-rst}
+.. currentmodule:: pyaptamer.mcts
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   MCTS
+```
+
+## Experiments
+
+Scoring functions that connect a model to the search.
+
+```{eval-rst}
+.. currentmodule:: pyaptamer.experiments
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   AptamerEvalAptaNet
+   AptamerEvalAptaTrans
+```
+
+## Encodings
+
+```{eval-rst}
+.. currentmodule:: pyaptamer.pseaac
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   PSeAAC
+   AptaNetPSeAAC
+```
+
+## Datasets
+
+```{eval-rst}
+.. currentmodule:: pyaptamer.datasets
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   load_aptacom_full
+   load_aptacom_x_y
+   load_csv_dataset
+   load_from_rcsb
+   load_hf_to_dataset
+   load_1brq
+   load_1gnh
+   load_5nu7
+   load_li2014
+   load_pfoa
+```
+
+## Benchmarking
+
+```{eval-rst}
+.. currentmodule:: pyaptamer.benchmarking
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   Benchmarking
+```
+
+## Utilities
+
+```{eval-rst}
+.. currentmodule:: pyaptamer.utils
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   aa_str_to_letter
+   dna2rna
+   encode_rna
+   generate_nplets
+   rna2vec
+   pdb_to_struct
+   struct_to_aaseq
+   pdb_to_seq_uniprot
+   pdb_to_aaseq
+```

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,108 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For a full list of options see:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+from importlib.metadata import version as get_version
+
+# -- Project information -----------------------------------------------------
+
+project = "pyaptamer"
+copyright = "2026, German Center for Open Source AI"
+author = "German Center for Open Source AI"
+
+release = get_version("pyaptamer")
+version = ".".join(release.split(".")[:2])
+
+# -- General configuration ---------------------------------------------------
+
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.viewcode",
+    "numpydoc",
+    "myst_parser",
+    "sphinx_copybutton",
+]
+
+templates_path = ["_templates"]
+exclude_patterns = []
+
+source_suffix = {
+    ".rst": "restructuredtext",
+    ".md": "markdown",
+}
+
+# -- Autodoc / autosummary ---------------------------------------------------
+
+autosummary_generate = True
+autodoc_default_options = {
+    "members": True,
+    "undoc-members": True,
+    "inherited-members": False,
+    "show-inheritance": True,
+}
+autodoc_typehints = "none"
+add_module_names = False
+
+# numpydoc renders the docstrings; let autosummary build the member tables.
+numpydoc_show_class_members = False
+numpydoc_class_members_toctree = False
+
+# -- Intersphinx -------------------------------------------------------------
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
+    "sklearn": ("https://scikit-learn.org/stable/", None),
+    "torch": ("https://pytorch.org/docs/stable/", None),
+}
+
+# -- MyST --------------------------------------------------------------------
+
+myst_enable_extensions = ["colon_fence", "deflist"]
+
+# -- HTML output -------------------------------------------------------------
+
+html_theme = "pydata_sphinx_theme"
+html_title = "pyaptamer"
+html_logo = "../assets/pyaptamer_banner.png"
+html_favicon = "../assets/pyaptamer_icon.png"
+
+html_theme_options = {
+    "icon_links": [
+        {
+            "name": "GitHub",
+            "url": "https://github.com/gc-os-ai/pyaptamer",
+            "icon": "fa-brands fa-github",
+        },
+        {
+            "name": "PyPI",
+            "url": "https://pypi.org/project/pyaptamer/",
+            "icon": "fa-solid fa-box",
+        },
+    ],
+    "show_prev_next": False,
+    "navigation_with_keys": False,
+}
+
+html_context = {
+    "github_user": "gc-os-ai",
+    "github_repo": "pyaptamer",
+    "github_version": "main",
+    "doc_path": "docs/source",
+}
+
+
+# -- Skip scikit-learn metadata-routing boilerplate -------
+
+
+def _skip_member(app, what, name, obj, skip, options):
+    if name == "get_metadata_routing" or name.endswith("_request"):
+        return True
+    return None
+
+
+def setup(app):
+    app.connect("autodoc-skip-member", _skip_member)

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -1,0 +1,54 @@
+# PyAptamer
+
+Python library for aptamer design.
+
+`pyaptamer` provides aptamer-protein interaction models and aptamer candidate
+generation behind a `scikit-learn`-style API. Two algorithms are available today:
+
+:::{list-table}
+:header-rows: 1
+:widths: 20 80
+
+* - Algorithm
+  - Use
+* - {doc}`AptaNet <user_guide/aptanet>`
+  - Predict whether an aptamer and a protein interact, from sequence pairs.
+* - {doc}`AptaTrans <user_guide/aptatrans>`
+  - Score aptamer-protein interaction and recommend candidate aptamers for a target.
+:::
+
+The package is in early development. The public API is unstable and may change
+between releases.
+
+## Install
+
+```bash
+pip install pyaptamer
+```
+
+See {doc}`installation` for development installs and optional extras.
+
+## Quick start
+
+```python
+import numpy as np
+from pyaptamer.aptanet import AptaNetPipeline
+
+aptamer = "AGCTTAGCGTACAGCTTAAAAGGGTTTCCCCTGCCCGCGTAC"
+protein = "ACDEFGHIKLMNPQRSTVWYACDEFGHIKLMNPQRSTVWY"
+
+X = [(aptamer, protein) for _ in range(40)]
+y = np.array([0] * 20 + [1] * 20, dtype=np.float32)
+
+pipe = AptaNetPipeline().fit(X, y)
+pipe.predict(X[:5])
+```
+
+```{toctree}
+:hidden:
+:maxdepth: 1
+
+installation
+user_guide/index
+api_reference
+```

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -1,0 +1,37 @@
+# Installation
+
+`pyaptamer` requires Python 3.10 or newer.
+
+## From PyPI
+
+```bash
+pip install pyaptamer
+```
+
+The current release is a prerelease. To pin it explicitly:
+
+```bash
+pip install pyaptamer==0.1.0a1
+```
+
+## Development install
+
+Clone the repository and install in editable mode:
+
+```bash
+git clone https://github.com/gc-os-ai/pyaptamer.git
+cd pyaptamer
+pip install -e ".[dev]"
+```
+
+The `dev` extra adds `ruff`, `pytest`, and `pre-commit`.
+
+## Building the documentation
+
+```bash
+pip install -e ".[docs]"
+cd docs
+make html
+```
+
+The rendered site is written to `docs/build/html`.

--- a/docs/source/user_guide/aptanet.md
+++ b/docs/source/user_guide/aptanet.md
@@ -1,0 +1,70 @@
+# AptaNet
+
+AptaNet predicts whether an aptamer and a protein interact. It takes
+`(aptamer, protein)` sequence pairs, derives numeric features from each sequence,
+selects features with a random forest, and classifies with a multi-layer
+perceptron. The estimator follows the `scikit-learn` `fit` / `predict` API.
+
+The entry point is {class}`~pyaptamer.aptanet.AptaNetPipeline`.
+
+## Predicting interactions
+
+```python
+import numpy as np
+from pyaptamer.aptanet import AptaNetPipeline
+
+aptamers = [
+    "GGGAGGACGAAGACGACUCGAGACAGGCUAGGGAGGGA",
+    "AAGCGUCGGAUCUACACGUGCGAUAGCUCAGUACGCGGU",
+    "CGGUAUCGAGUACAGGAGUCCGACGGAUAGUCCGGAGC",
+]
+protein = "ACDEFGHIKLMNPQRSTVWYACDEFGHIKLMNPQRSTVWY"
+
+X = [(a, protein) for a in aptamers] * 10
+y = np.array([0, 1, 0] * 10, dtype=np.float32)
+
+pipe = AptaNetPipeline()
+pipe.fit(X, y)
+
+labels = pipe.predict(X[:3])
+probabilities = pipe.predict_proba(X[:3])
+```
+
+`X` is a list of `(aptamer, protein)` string pairs. `y` is a float array of binary
+labels. `predict` returns class labels and `predict_proba` returns class
+probabilities.
+
+The `k` argument sets the aptamer k-mer size used for feature extraction:
+
+```python
+pipe = AptaNetPipeline(k=5)
+```
+
+## Loading protein sequences
+
+Protein sequences can come from a PDB structure through the dataset loaders:
+
+```python
+from pyaptamer.datasets import load_1gnh
+
+protein = load_1gnh().to_df_seq()["sequence"].tolist()[0]
+```
+
+## Swapping the estimator
+
+`AptaNetPipeline` runs {class}`~pyaptamer.aptanet.AptaNetClassifier` by default.
+Pass any `scikit-learn` compatible classifier to replace it:
+
+```python
+from sklearn.ensemble import GradientBoostingClassifier
+
+pipe = AptaNetPipeline(estimator=GradientBoostingClassifier())
+```
+
+For regression targets, use {class}`~pyaptamer.aptanet.AptaNetRegressor` directly.
+
+## Reference
+
+- Emami, N., Ferdousi, R. AptaNet as a deep learning approach for
+  aptamer-protein interaction prediction. *Scientific Reports* 11, 6074 (2021).
+  <https://doi.org/10.1038/s41598-021-85629-0>

--- a/docs/source/user_guide/aptatrans.md
+++ b/docs/source/user_guide/aptatrans.md
@@ -1,0 +1,100 @@
+# AptaTrans
+
+AptaTrans is a transformer model for aptamer-protein interaction. It does two
+things: it scores how strongly a candidate aptamer interacts with a target
+protein, and it recommends new candidate aptamers for a target using a Monte
+Carlo Tree Search guided by that score.
+
+The entry point is {class}`~pyaptamer.aptatrans.AptaTransPipeline`. The search
+itself is exposed separately as {class}`~pyaptamer.mcts.MCTS`.
+
+## Building a pipeline
+
+`AptaTransPipeline` wraps an {class}`~pyaptamer.aptatrans.AptaTrans` model. The
+model is configured with one {class}`~pyaptamer.aptatrans.EncoderPredictorConfig`
+per encoder (aptamer and protein). `prot_words` maps protein subsequences to
+integer ids and should come from the dataset used to pretrain the protein
+encoder.
+
+```python
+import torch
+from pyaptamer.aptatrans import (
+    AptaTrans,
+    AptaTransPipeline,
+    EncoderPredictorConfig,
+)
+
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+apta_embedding = EncoderPredictorConfig(128, 16, max_len=100)
+prot_embedding = EncoderPredictorConfig(128, 16, max_len=100)
+model = AptaTrans(apta_embedding, prot_embedding)
+
+prot_words = {"DHR": 0.5, "AIQ": 0.5, "AAG": 0.2}
+pipeline = AptaTransPipeline(
+    device, model, prot_words, depth=5, n_iterations=5
+)
+```
+
+`depth` sets the length of generated candidates and the search tree depth.
+`n_iterations` sets the number of MCTS iterations per candidate.
+
+## Scoring an interaction
+
+```python
+target = "DHRNENIAIQ"
+aptamer = "ACGUA"
+
+score = pipeline.predict(aptamer, target)
+interaction_map = pipeline.get_interaction_map(aptamer, target)
+```
+
+`predict` returns an interaction score tensor. `get_interaction_map` returns the
+position-by-position interaction tensor between the two sequences.
+
+## Recommending candidates
+
+```python
+candidates = pipeline.recommend(target, n_candidates=3, verbose=False)
+```
+
+`recommend` returns a set of `(candidate, sequence, score)` tuples. Search runs
+until `n_candidates` unique candidates are found.
+
+## Running the search directly
+
+To use the search without the pipeline, drive {class}`~pyaptamer.mcts.MCTS`
+yourself with an experiment that scores sequences:
+
+```python
+import torch
+from pyaptamer.aptatrans import AptaTrans, EncoderPredictorConfig
+from pyaptamer.experiments import AptamerEvalAptaTrans
+from pyaptamer.mcts import MCTS
+
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+model = AptaTrans(
+    EncoderPredictorConfig(128, 16, max_len=128),
+    EncoderPredictorConfig(128, 16, max_len=128),
+).to(device)
+
+experiment = AptamerEvalAptaTrans(
+    target="DHRNE",
+    model=model,
+    device=device,
+    prot_words={"DHR": 1, "RNE": 2, "NE": 3},
+)
+mcts = MCTS(depth=5, n_iterations=2, experiment=experiment)
+
+result = mcts.run(verbose=False)
+candidate = result["candidate"]
+```
+
+## References
+
+- Shin, I., et al. AptaTrans: a deep neural network for predicting
+  aptamer-protein interaction using pretrained encoders. *BMC Bioinformatics*
+  24, 447 (2023).
+- Lee, G., et al. Predicting aptamer sequences that interact with target proteins
+  using an aptamer-protein interaction classifier and a Monte Carlo tree search
+  approach. *PLoS ONE* 16, e0253760 (2021).

--- a/docs/source/user_guide/index.md
+++ b/docs/source/user_guide/index.md
@@ -1,0 +1,16 @@
+# User guide
+
+The two algorithms in `pyaptamer` cover the two ends of an aptamer workflow:
+scoring a known aptamer-protein pair, and generating new candidates for a target.
+
+```{toctree}
+:maxdepth: 1
+
+aptanet
+aptatrans
+```
+
+| Algorithm | Input | Output | API entry point |
+| --- | --- | --- | --- |
+| AptaNet | aptamer-protein sequence pairs | interaction label and probability | {class}`~pyaptamer.aptanet.AptaNetPipeline` |
+| AptaTrans | target protein sequence | interaction score, candidate aptamers | {class}`~pyaptamer.aptatrans.AptaTransPipeline` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,13 @@ dev = [
     "pytest>=9.0.3",
     "pre-commit",
 ]
+docs = [
+    "sphinx>=7.0",
+    "pydata-sphinx-theme>=0.15",
+    "numpydoc>=1.6",
+    "myst-parser>=2.0",
+    "sphinx-copybutton>=0.5",
+]
 
 [tool.ruff]
 line-length = 88


### PR DESCRIPTION
## What

Scaffolds a Sphinx documentation site as a starting point for users of the two implemented algorithms, **AptaNet** and **AptaTrans**.

## Contents

- **Landing page**, **installation guide**, and per-algorithm **user guides** with runnable examples for `AptaNetPipeline` and `AptaTransPipeline`.
- **API reference** covering the public API only (via `autosummary`).
- `pydata-sphinx-theme` with the existing project logo and favicon.
- A custom autosummary template and an `autodoc-skip-member` hook that hide inherited scikit-learn and skbase infrastructure methods (`set_*_request`, `get_metadata_routing`, `get_params`, `get_tags`, and similar) so each class page shows only its own API.
- A `docs` optional-dependencies extra for reproducible builds.
- **Read the Docs** config (`.readthedocs.yaml`, HTML only, no PDF) and a **GitHub Pages** deploy workflow (`.github/workflows/docs.yml`).

## Build locally

```bash
pip install -e ".[docs]"
cd docs && make html   # output in docs/build/html
```

## Notes

- Narrative pages are MyST markdown; the API reference uses `eval-rst` blocks where reStructuredText directives are needed.
- Documents the public API only. `MOLECULELOADER_DESIGN` is intentionally excluded.
- The build succeeds. Remaining Sphinx warnings all originate from pre-existing docstrings in the source code (unindented reference lists in `mcts`, `aptatrans`, `pseaac`), not from these doc pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)