### PR TITLE
[MNT] Remove GitHub Pages deployment from docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,13 +9,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
-
-# Allow one concurrent deployment, cancelling older in-progress runs.
-concurrency:
-  group: pages
-  cancel-in-progress: true
 
 jobs:
   build:
@@ -33,19 +26,8 @@ jobs:
       - name: Build HTML
         run: sphinx-build -b html docs/source docs/build/html
 
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+      - name: Upload built docs as artifact
+        uses: actions/upload-artifact@v4
         with:
+          name: docs-html
           path: docs/build/html
-
-  deploy:
-    needs: build
-    if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Resolves #685 

## Why

The `gc-os-ai` org already serves its site on GitHub Pages via the `gcos.ai` custom domain. The docs workflow added in #683 deployed the project docs to Pages, which published them at `gcos.ai/pyaptamer` and clashed with the org's setup. Docs are hosted on **Read the Docs**, so Pages deployment is not needed.

## What changed

- Removed the `deploy` job and the `pages: write` / `id-token: write` permissions from `.github/workflows/docs.yml`.
- Removed the `concurrency` Pages group and the `upload-pages-artifact` step.
- The workflow now **only builds** the HTML (validating that the docs compile on PRs and pushes) and uploads it as a regular CI artifact. No deployment.

## Also done outside this PR

GitHub Pages has already been **disabled** for this repository (`DELETE /repos/gc-os-ai/pyaptamer/pages`), so the live site at `gcos.ai/pyaptamer` is taken down. This change prevents it from being republished on the next push to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)