### PR TITLE
MNT: Expose PositionalEncoding and TokenPredictor in aptatrans layers

### DIFF
--- a/pyaptamer/aptatrans/layers/__init__.py
+++ b/pyaptamer/aptatrans/layers/__init__.py
@@ -1,6 +1,10 @@
 """Architectural components for AptaTrans' deep neural network."""
 
 __author__ = ["nennomp"]
-__all__ = ["EncoderPredictorConfig"]
+__all__ = ["EncoderPredictorConfig", "PositionalEncoding", "TokenPredictor"]
 
-from pyaptamer.aptatrans.layers._encoder import EncoderPredictorConfig
+from pyaptamer.aptatrans.layers._encoder import (
+    EncoderPredictorConfig,
+    PositionalEncoding,
+    TokenPredictor,
+)


### PR DESCRIPTION
Fixes #675

This PR exposes `PositionalEncoding` and `TokenPredictor` in `aptatrans/layers/__init__.py` for better API consistency as requested.