### PR TITLE
[ENH] Redesign MoleculeLoader as a lazy 2D DataFrame container

### DIFF
--- a/pyaptamer/data/loader.py
+++ b/pyaptamer/data/loader.py
@@ -3,6 +3,7 @@
 __all__ = ["MoleculeLoader"]
 __author__ = ["fkiraly", "satvshr", "siddharth7113"]
 
+from itertools import product
 from pathlib import Path
 
 import pandas as pd
@@ -10,121 +11,384 @@ from Bio import SeqIO
 
 
 class MoleculeLoader:
-    """Molecule data connector.
+    """Lazy 2D container for molecule data and binding tables.
 
-    This loader extracts primary amino-acid sequences from molecule files.
+    Holds tabular data whose cells may be file references (FASTA, PDB,
+    FASTQ, ...) or in-memory values (sequence strings, numbers). Files are
+    not parsed until ``to_dataframe`` is called.
 
     Parameters
     ----------
-    path : str, Path, or list
-        File location(s) of molecule files. One row is returned per file.
-    index : list, or pandas.Index coercible, optional
-        Row index for the resulting DataFrame; if None, a MultiIndex of
-        (path, chain_id) is used.
-    columns : list, optional
-        column names for the structure; if None, defaults to ["sequence"]
+    data : dict, list of lists, or pandas.DataFrame
+        2D data coercible by ``pandas.DataFrame``. Keys (or columns) become
+        column names; cells hold file paths, sequence strings, or primitives.
+    tiling : str, default="bag"
+        How multi-sequence files are materialized. One of ``"bag"``,
+        ``"features"``, ``"samples"``, ``"samples_product"``, ``"first"``,
+        ``"concat"``.
+    indexing : str, default="preserve"
+        What happens to file-internal IDs (PDB chain IDs, FASTA headers).
+        One of ``"new"``, ``"preserve"``, ``"keep_as_column"``.
+    multiindex : str, default="flatten"
+        Row-index shape after sequences expand into rows. One of
+        ``"flatten"``, ``"multiindex"``, ``"auto"``.
+    ignore_duplicates : bool, default=False
+        If True, deduplicate identical sequences within each file before
+        tiling is applied.
 
-    ignore_duplicates : bool, optional, default=False
-        if True, removes duplicate sequences (keeping the first occurrence).
+    Notes
+    -----
+    Supported file formats are anything :func:`Bio.SeqIO.parse` can read
+    (FASTA, GenBank, EMBL, FASTQ, ...); PDB files are read through the
+    ``pdb-seqres`` parser. The format is inferred from the file suffix.
 
-    Supported file types
-    --------------------
-    The loader determines the type from the file extension by default, but a
-    format override can be provided to force a specific loader:
+    Examples
+    --------
+    Build a table from in-memory paired sequences and binding values. With
+    sequences already in memory, ``to_dataframe`` is a no-op:
 
-    - ``fmt="pdb"`` -> handled by :func:`pdb_to_aaseq` (PDB SEQRES extraction)
-    - any other format string (e.g. ``"fasta"``, ``"genbank"``) -> passed to
-      :mod:`Bio.SeqIO` for parsing
-
-    Thus, all formats supported by :func:`Bio.SeqIO.parse` are accepted,
-    including FASTA, GenBank, EMBL, FASTQ, and many more.
-
-    For the full list of supported formats, see:
-
-    - https://biopython.org/docs/latest/api/Bio.SeqIO.html#file-formats
-    - https://biopython.org/wiki/SeqIO
+    >>> from pyaptamer.data.loader import MoleculeLoader
+    >>> loader = MoleculeLoader(
+    ...     data={"target": ["ACGT", "TTGG"], "binding": [0.4, 0.6]}
+    ... )
+    >>> df = loader.to_dataframe()
+    >>> list(df.columns)
+    ['target', 'binding']
+    >>> df["target"].tolist()
+    ['ACGT', 'TTGG']
     """
 
     def __init__(
-        self, path, index=None, columns=None, ignore_duplicates=False, fmt=None
+        self,
+        data,
+        tiling="bag",
+        indexing="preserve",
+        multiindex="flatten",
+        ignore_duplicates=False,
     ):
-        self.path = path
-        self.index = index
-        self.columns = columns
-        self.ignore_duplicates = ignore_duplicates
-        self.fmt = fmt
-        if isinstance(path, str):
-            path = [Path(path)]
-            self._path = path
-        elif isinstance(path, Path):
-            self._path = [path]
-        elif isinstance(path, list):
-            self._path = [Path(p) if isinstance(p, str) else p for p in path]
-        else:
-            raise TypeError("path must be a str, Path, or list of str/Path")
+        valid_tilings = {
+            "bag",
+            "concat",
+            "first",
+            "features",
+            "samples",
+            "samples_product",
+        }
+        if tiling not in valid_tilings:
+            raise ValueError(
+                f"tiling must be one of {sorted(valid_tilings)}, got {tiling!r}"
+            )
 
-    def to_df_seq(self):
-        """Return a pd.DataFrame of sequences with MultiIndex (path, chain_id).
+        valid_indexings = {"new", "preserve", "keep_as_column"}
+        if indexing not in valid_indexings:
+            raise ValueError(
+                f"indexing must be one of {sorted(valid_indexings)}, got {indexing!r}"
+            )
+
+        valid_multiindex = {"flatten", "multiindex", "auto"}
+        if multiindex not in valid_multiindex:
+            raise ValueError(
+                f"multiindex must be one of {sorted(valid_multiindex)}, "
+                f"got {multiindex!r}"
+            )
+
+        self.data = data
+        self.tiling = tiling
+        self.indexing = indexing
+        self.multiindex = multiindex
+        self.ignore_duplicates = ignore_duplicates
+
+    def to_dataframe(self):
+        """Materialize the loader into a :class:`pandas.DataFrame`.
+
+        File-path cells are parsed and reshaped according to ``tiling``,
+        ``indexing`` and ``multiindex``.
 
         Returns
+        -------
+        pandas.DataFrame
+            The materialized table. Its exact shape depends on ``tiling``.
+
+        Examples
         --------
-        pd.DataFrame
-            sequences in self in a pd.DataFrame;
-            index is a MultiIndex (path, chain_id);
-            has single column "sequence";
-            each row contains one primary amino-acid sequence
+        A multi-chain PDB under ``tiling="bag"`` becomes a list-valued cell,
+        while a single-chain file stays a plain string:
+
+        >>> loader = MoleculeLoader(data={"target": ["1gnh.pdb"]})
+        >>> loader.to_dataframe()["target"].iloc[0]  # doctest: +SKIP
+        ['QTDMSRK...', 'QTDMSRK...', ...]
+
+        A SELEX FASTQ explodes to one row per read with ``tiling="samples"``:
+
+        >>> loader = MoleculeLoader(data={"selex": ["round5.fastq"]}, tiling="samples")
+        >>> loader.to_dataframe()  # doctest: +SKIP
+
+        For comprehensive, file-based walkthroughs across formats (PDB, FASTA,
+        FASTQ) and tilings, see the tutorial notebooks in ``examples/``.
         """
+        df = pd.DataFrame(self.data)
 
-        index_tuples = []
-        sequences = []
+        if self.tiling in {"bag", "concat", "first"}:
+            return df.map(self._materialize_cell)
+        if self.tiling == "features":
+            return self._tile_features(df)
+        return self._tile_samples(df, product_mode=self.tiling == "samples_product")
 
-        for path in self._path:
-            seq_df = self._load_dispatch(path)
+    def _cell_records(self, value):
+        """Normalize a cell to ``(is_file, [(chain_id, sequence), ...])``.
+
+        Non-path cells return ``(False, [(None, value)])`` so callers can
+        treat literals uniformly. Path cells are parsed and, when
+        ``ignore_duplicates`` is set, deduplicated by sequence (first
+        occurrence wins).
+
+        Parameters
+        ----------
+        value : object
+            A single DataFrame cell.
+
+        Returns
+        -------
+        tuple of (bool, list of (object, str))
+            Whether the cell was a file, and its (chain_id, sequence) records.
+        """
+        if not self._is_path_like(value):
+            return False, [(None, value)]
+
+        loaded = self._load_dispatch(Path(value))
+        records = list(
+            zip(
+                loaded["chain_id"].tolist(),
+                loaded["sequence"].tolist(),
+                strict=True,
+            )
+        )
+
+        if self.ignore_duplicates:
             seen = set()
-
-            for _, row in seq_df.iterrows():
-                seq = row["sequence"]
-                if self.ignore_duplicates and seq in seen:
+            unique = []
+            for chain_id, seq in records:
+                if seq in seen:
                     continue
                 seen.add(seq)
-                index_tuples.append((path, row["chain_id"]))
-                sequences.append(seq)
+                unique.append((chain_id, seq))
+            records = unique
 
-        index = pd.MultiIndex.from_tuples(index_tuples, names=["path", "chain_id"])
+        return True, records
 
-        columns = ["sequence"] if self.columns is None else self.columns
+    def _materialize_cell(self, value):
+        """Render one cell for the per-cell tilings ``bag``/``concat``/``first``.
 
-        df = pd.DataFrame(sequences, index=index, columns=columns)
+        Non-path values are returned unchanged. For path cells:
 
-        if self.index is not None:
-            df.index = self.index
+        - ``bag``: a plain ``str`` for a single-sequence file, else a
+          ``list[str]``.
+        - ``concat``: all sequences joined into one string, ordered
+          alphabetically by chain id (no separator).
+        - ``first``: the first sequence only.
 
-        return df
+        Parameters
+        ----------
+        value : object
+            A single DataFrame cell.
+
+        Returns
+        -------
+        object
+            The original value, or the rendered sequence(s).
+        """
+        is_file, records = self._cell_records(value)
+        if not is_file:
+            return value
+
+        sequences = [seq for _, seq in records]
+
+        if self.tiling == "first":
+            return sequences[0]
+        if self.tiling == "concat":
+            ordered = sorted(records, key=lambda rec: str(rec[0]))
+            return "".join(seq for _, seq in ordered)
+        # bag
+        return sequences[0] if len(sequences) == 1 else sequences
+
+    def _is_path_like(self, value):
+        """Return True if ``value`` looks like a file reference.
+
+        A cell is treated as a file when it is a string with a non-empty
+        suffix (e.g. ``"1gnh.pdb"``). Sequence strings such as ``"ACGT"`` have
+        no suffix and are left untouched.
+
+        Notes
+        -----
+        Failure mode: a sequence string that happens to contain a dot would be
+        misread as a path. Biological sequences do not contain dots, so this
+        heuristic is acceptable for the initial implementation.
+        """
+        return isinstance(value, str) and Path(value).suffix != ""
+
+    def _tile_features(self, df):
+        """Expand multi-sequence file cells into multiple columns.
+
+        A column whose cells hold multi-sequence files is spread into
+        ``<col>_0``, ``<col>_1``, ... (one column per sequence). Single-
+        sequence columns keep their name. Rows with fewer sequences are
+        padded with ``None``.
+        """
+        new_data = {}
+        for col in df.columns:
+            loaded = [self._cell_records(v) for v in df[col]]
+            if not any(is_file for is_file, _ in loaded):
+                new_data[col] = list(df[col])
+                continue
+
+            max_n = max((len(recs) for is_file, recs in loaded if is_file), default=1)
+            if max_n == 1:
+                new_data[col] = [
+                    recs[0][1] if is_file else value
+                    for (is_file, recs), value in zip(loaded, df[col], strict=True)
+                ]
+                continue
+
+            for i in range(max_n):
+                column = []
+                for (is_file, recs), value in zip(loaded, df[col], strict=True):
+                    if is_file:
+                        column.append(recs[i][1] if i < len(recs) else None)
+                    else:
+                        column.append(value if i == 0 else None)
+                new_data[f"{col}_{i}"] = column
+
+        return pd.DataFrame(new_data, index=df.index)
+
+    def _tile_samples(self, df, product_mode):
+        """Explode file cells into rows (``samples`` / ``samples_product``).
+
+        Each file cell contributes one row per sequence. Literal columns are
+        repeated. With several file columns in a row, ``samples`` zips them
+        (and requires matching counts), while ``samples_product`` takes their
+        cartesian product.
+        """
+        rows = []
+        parents = []
+        seq_ids = []
+        chain_id_cols = {col: [] for col in df.columns}
+        expanded = False
+
+        for pos, (_, row) in enumerate(df.iterrows()):
+            col_recs = {col: self._cell_records(row[col]) for col in df.columns}
+            file_cols = [col for col in df.columns if col_recs[col][0]]
+
+            if not file_cols:
+                rows.append({col: row[col] for col in df.columns})
+                parents.append(pos)
+                seq_ids.append(None)
+                for col in df.columns:
+                    chain_id_cols[col].append(None)
+                continue
+
+            recs_per_col = [col_recs[col][1] for col in file_cols]
+            if product_mode:
+                combos = list(product(*recs_per_col))
+            elif len(file_cols) > 1:
+                raise ValueError(
+                    "tiling='samples' cannot expand more than one file column "
+                    f"in the same row (columns {file_cols}). A multi-sequence "
+                    "file such as a multi-chain PDB is one molecule, not parallel "
+                    "samples, so pairing columns by position would be meaningless. "
+                    "Combine such columns with tiling='concat' first, or use "
+                    "per-column tiling (planned)."
+                )
+            else:
+                combos = list(zip(*recs_per_col, strict=True))
+
+            if len(combos) > 1:
+                expanded = True
+
+            for combo in combos:
+                new_row = {}
+                cid_map = {}
+                for col in df.columns:
+                    if col in file_cols:
+                        chain_id, seq = combo[file_cols.index(col)]
+                        new_row[col] = seq
+                        cid_map[col] = chain_id
+                    else:
+                        new_row[col] = row[col]
+                        cid_map[col] = None
+                rows.append(new_row)
+                parents.append(pos)
+                if len(file_cols) == 1:
+                    seq_ids.append(cid_map[file_cols[0]])
+                else:
+                    seq_ids.append(tuple(cid_map[col] for col in file_cols))
+                for col in df.columns:
+                    chain_id_cols[col].append(cid_map[col])
+
+        out = pd.DataFrame(rows, columns=list(df.columns))
+        return self._finalize_index(
+            out, df.index, parents, seq_ids, chain_id_cols, expanded
+        )
+
+    def _finalize_index(
+        self, out, orig_index, parents, seq_ids, chain_id_cols, expanded
+    ):
+        """Apply ``indexing`` and ``multiindex`` to an exploded frame."""
+        if self.indexing == "keep_as_column":
+            for col, cids in chain_id_cols.items():
+                if any(cid is not None for cid in cids):
+                    out[f"{col}_chain_id"] = cids
+            out.index = pd.RangeIndex(len(out))
+            return out
+
+        if self.indexing == "new":
+            out.index = pd.RangeIndex(len(out))
+            return out
+
+        parent_labels = [orig_index[p] for p in parents]
+
+        norm_ids = []
+        for sid in seq_ids:
+            if sid is None:
+                norm_ids.append("")
+            elif isinstance(sid, tuple):
+                norm_ids.append("_".join(str(x) for x in sid))
+            else:
+                norm_ids.append(str(sid))
+
+        use_multi = self.multiindex == "multiindex" or (
+            self.multiindex == "auto" and expanded
+        )
+
+        if use_multi:
+            out.index = pd.MultiIndex.from_arrays(
+                [parent_labels, norm_ids], names=["row", "sequence"]
+            )
+        else:
+            out.index = [
+                f"{label}__{sid}" if sid != "" else f"{label}"
+                for label, sid in zip(parent_labels, norm_ids, strict=True)
+            ]
+        return out
 
     def _determine_type(self, path):
-        """Return file type inferred from suffix or from the instance `fmt` override.
+        """Return the format string inferred from the file suffix.
 
         Parameters
         ----------
         path : Path
-            Path to a file (used only when no fmt override is provided).
+            Path to a file.
 
         Returns
         -------
-        str
-            Format string such as "pdb", "fasta", "genbank", etc.
+        str or None
+            Format string such as "pdb", "fasta", "genbank"; ``None`` when the
+            path has no suffix.
         """
-        # If user provided a format override, use it
-        if self.fmt is not None:
-            return self.fmt
-
-        # Fallback to suffix-based inference
         suffix = path.suffix.lower()
-        # strip leading dot; if no suffix, return None to indicate unknown
         return suffix.lstrip(".") if suffix else None
 
     def _load_dispatch(self, path):
-        """Dispatch loader based on file type.
+        """Dispatch the loader based on file type.
 
         Returns
         -------
@@ -134,11 +398,7 @@ class MoleculeLoader:
         fmt = self._determine_type(path)
 
         if fmt is None:
-            # no suffix and no format override -> error
-            raise ValueError(
-                f"Could not determine file format for '{path}'."
-                "Provide a 'fmt' argument."
-            )
+            raise ValueError(f"Could not determine file format for '{path}'.")
 
         if fmt == "pdb":
             return self._load_pdb_seq(path)
@@ -149,12 +409,12 @@ class MoleculeLoader:
         """Load a PDB file and extract the amino-acid sequences.
 
         Parameters
-        -----------
+        ----------
         path : Path
             path to PDB file
 
         Returns
-        --------
+        -------
         pandas.DataFrame
             DataFrame with columns ``["chain_id", "sequence"]``.
         """

--- a/pyaptamer/data/tests/test_loader.py
+++ b/pyaptamer/data/tests/test_loader.py
@@ -1,64 +1,243 @@
-"""Molecule data loading module tests."""
+"""Tests for the MoleculeLoader lazy data container."""
 
 from pathlib import Path
 
+import pandas as pd
 import pytest
 
 from pyaptamer.data.loader import MoleculeLoader
 
-# dataset paths relative to pyaptamer root
-VALID_DATA_PATHS = [
-    "datasets/data/1gnh.pdb",
-    "datasets/data/1brq.pdb",
-    "datasets/data/5nu7.pdb",
-]
-
-INVALID_NO_SEQRES_PATH = "datasets/data/1gnh_no_seqres.pdb"
+DATA_DIR = Path(__file__).parent.parent.parent / "datasets" / "data"
+PDB_MULTI = str(DATA_DIR / "1gnh.pdb")  # 10 chains A-J, all identical sequence
+PDB_SINGLE = str(DATA_DIR / "1brq.pdb")  # 1 chain A
+PDB_NO_SEQRES = str(DATA_DIR / "1gnh_no_seqres.pdb")
 
 
-def test_string_path():
-    """Test that MoleculeLoader works with string paths."""
-    root_path = Path(__file__).parent.parent.parent
-    full_paths = [str(root_path / p) for p in VALID_DATA_PATHS]
+# --------------------------------------------------------------------------- #
+# in-memory data
+# --------------------------------------------------------------------------- #
+def test_in_memory_data_is_noop():
+    """In-memory sequences/primitives round-trip into columns unchanged."""
+    proteins = ["ASCJNBDSFBWUJBCW", "SDUWEIPBNVNEWVUBW", "IOJVDPOIJWIDNVIVNV"]
+    aptamers = ["AAACTAATATAAAATAAT", "CTCTAGGGGGGGGGG", "GGGGCAAAAAACCC"]
+    bindings = [0.4, 0.5, 0.6]
 
-    loader = MoleculeLoader(full_paths)
-    df = loader.to_df_seq()
+    loader = MoleculeLoader(
+        data={"target": proteins, "ligand": aptamers, "binding": bindings}
+    )
+    df = loader.to_dataframe()
 
-    # column contract unchanged
-    assert list(df.columns) == ["sequence"]
-
-    # MultiIndex contract
-    assert df.index.nlevels == 2
-    assert df.index.names == ["path", "chain_id"]
-
-    # all sequences are strings
-    assert df["sequence"].map(type).eq(str).all()
-
-    # at least one known sequence exists
-    assert any(seq.startswith("QTDMSRK") for seq in df["sequence"])
+    assert isinstance(df, pd.DataFrame)
+    assert list(df.columns) == ["target", "ligand", "binding"]
+    assert df["target"].to_list() == proteins
+    assert df["ligand"].to_list() == aptamers
+    assert df["binding"].to_list() == bindings
 
 
-def test_pathlib_path():
-    """Test that MoleculeLoader works with pathlib.Path paths."""
-    root_path = Path(__file__).parent.parent.parent
-    full_paths = [root_path / p for p in VALID_DATA_PATHS]
+# --------------------------------------------------------------------------- #
+# tiling: bag
+# --------------------------------------------------------------------------- #
+def test_bag_tiling_str_vs_list():
+    """bag: a multi-chain file -> list[str]; a single-chain file -> str."""
+    loader = MoleculeLoader(data={"target": [PDB_MULTI, PDB_SINGLE]}, tiling="bag")
+    df = loader.to_dataframe()
 
-    loader = MoleculeLoader(full_paths)
-    df = loader.to_df_seq()
+    multi = df["target"].iloc[0]
+    single = df["target"].iloc[1]
 
-    assert list(df.columns) == ["sequence"]
-    assert df.index.nlevels == 2
-    assert df.index.names == ["path", "chain_id"]
-    assert df["sequence"].map(type).eq(str).all()
-    assert any(seq.startswith("QTDMSRK") for seq in df["sequence"])
+    assert isinstance(multi, list)
+    assert len(multi) == 10
+    assert all(isinstance(seq, str) for seq in multi)
+    assert isinstance(single, str)
+
+
+def test_bag_ignore_duplicates_collapses_to_str():
+    """bag + ignore_duplicates: 10 identical chains dedup to 1 -> plain str."""
+    loader = MoleculeLoader(
+        data={"target": [PDB_MULTI]}, tiling="bag", ignore_duplicates=True
+    )
+    chain = loader.to_dataframe()["target"].iloc[0]
+
+    assert isinstance(chain, str)
+    assert chain.startswith("QTDMSRK")
+
+
+# --------------------------------------------------------------------------- #
+# tiling: concat / first
+# --------------------------------------------------------------------------- #
+def test_concat_joins_sequences():
+    """concat: all chains joined into one string (length scales with count)."""
+    plain = MoleculeLoader(data={"target": [PDB_MULTI]}, tiling="concat")
+    deduped = MoleculeLoader(
+        data={"target": [PDB_MULTI]}, tiling="concat", ignore_duplicates=True
+    )
+
+    full = plain.to_dataframe()["target"].iloc[0]
+    one = deduped.to_dataframe()["target"].iloc[0]
+
+    assert isinstance(full, str) and isinstance(one, str)
+    # 10 identical chains -> concat is 10x the length of the deduped single one
+    assert len(full) == 10 * len(one)
+
+
+def test_first_keeps_only_first_sequence():
+    """first: replace a multi-chain file with just its first sequence."""
+    loader = MoleculeLoader(data={"target": [PDB_MULTI]}, tiling="first")
+    chain = loader.to_dataframe()["target"].iloc[0]
+
+    assert isinstance(chain, str)
+    assert chain.startswith("QTDMSRK")
+
+
+# --------------------------------------------------------------------------- #
+# tiling: samples / samples_product
+# --------------------------------------------------------------------------- #
+def test_samples_explodes_to_rows():
+    """samples: one multi-chain file becomes one row per chain."""
+    loader = MoleculeLoader(data={"target": [PDB_MULTI]}, tiling="samples")
+    df = loader.to_dataframe()
+
+    assert len(df) == 10
+    assert df["target"].map(type).eq(str).all()
+
+
+def test_samples_multiple_file_columns_raise():
+    """samples: expanding two file columns in one row is rejected as ambiguous."""
+    loader = MoleculeLoader(
+        data={"target": [PDB_MULTI], "ligand": [PDB_SINGLE]}, tiling="samples"
+    )
+    with pytest.raises(ValueError, match="more than one file column"):
+        loader.to_dataframe()
+
+
+def test_samples_product_is_cartesian():
+    """samples_product: two 10-chain files in a row -> 100 rows (10 x 10)."""
+    crossed = MoleculeLoader(
+        data={"a": [PDB_MULTI], "b": [PDB_MULTI]}, tiling="samples_product"
+    )
+
+    assert len(crossed.to_dataframe()) == 100  # cartesian product
+
+
+# --------------------------------------------------------------------------- #
+# tiling: features
+# --------------------------------------------------------------------------- #
+def test_features_expands_to_columns():
+    """features: a 10-chain file spreads into target_0 ... target_9."""
+    loader = MoleculeLoader(data={"target": [PDB_MULTI]}, tiling="features")
+    df = loader.to_dataframe()
+
+    assert len(df) == 1
+    assert list(df.columns) == [f"target_{i}" for i in range(10)]
+
+
+# --------------------------------------------------------------------------- #
+# indexing
+# --------------------------------------------------------------------------- #
+def test_indexing_new_gives_rangeindex():
+    """indexing='new': discard chain IDs, use a clean RangeIndex."""
+    loader = MoleculeLoader(
+        data={"target": [PDB_MULTI]}, tiling="samples", indexing="new"
+    )
+    df = loader.to_dataframe()
+
+    assert isinstance(df.index, pd.RangeIndex)
+    assert df.index.tolist() == list(range(10))
+
+
+def test_indexing_preserve_flatten():
+    """indexing='preserve' + multiindex='flatten': index is 'row__chain'."""
+    loader = MoleculeLoader(
+        data={"target": [PDB_MULTI]}, tiling="samples", indexing="preserve"
+    )
+    df = loader.to_dataframe()
+
+    assert df.index.tolist() == [f"0__{c}" for c in "ABCDEFGHIJ"]
+
+
+def test_indexing_keep_as_column():
+    """indexing='keep_as_column': chain IDs become a <col>_chain_id column."""
+    loader = MoleculeLoader(
+        data={"target": [PDB_MULTI]}, tiling="samples", indexing="keep_as_column"
+    )
+    df = loader.to_dataframe()
+
+    assert "target_chain_id" in df.columns
+    assert df["target_chain_id"].tolist() == list("ABCDEFGHIJ")
+    assert isinstance(df.index, pd.RangeIndex)
+
+
+# --------------------------------------------------------------------------- #
+# multiindex
+# --------------------------------------------------------------------------- #
+def test_multiindex_real():
+    """multiindex='multiindex': a real two-level (row, sequence) index."""
+    loader = MoleculeLoader(
+        data={"target": [PDB_MULTI]}, tiling="samples", multiindex="multiindex"
+    )
+    df = loader.to_dataframe()
+
+    assert isinstance(df.index, pd.MultiIndex)
+    assert df.index.names == ["row", "sequence"]
+    assert df.index.get_level_values("sequence").tolist() == list("ABCDEFGHIJ")
+
+
+def test_multiindex_auto_stays_flat_without_expansion():
+    """multiindex='auto': single-sequence file does not trigger a MultiIndex."""
+    loader = MoleculeLoader(
+        data={"target": [PDB_SINGLE]}, tiling="samples", multiindex="auto"
+    )
+    df = loader.to_dataframe()
+
+    assert not isinstance(df.index, pd.MultiIndex)
+
+
+# --------------------------------------------------------------------------- #
+# format coverage: FASTA via SeqIO
+# --------------------------------------------------------------------------- #
+def test_fasta_multi_record_bag(tmp_path):
+    """A non-PDB format (FASTA) is parsed via SeqIO; 2 records -> list of 2."""
+    fasta = tmp_path / "library.fasta"
+    fasta.write_text(">seq1\nACGTACGT\n>seq2\nTTTTGGGG\n")
+
+    loader = MoleculeLoader(data={"aptamer": [str(fasta)]}, tiling="bag")
+    cell = loader.to_dataframe()["aptamer"].iloc[0]
+
+    assert cell == ["ACGTACGT", "TTTTGGGG"]
+
+
+def test_fastq_is_sequence_only(tmp_path):
+    """FASTQ is read sequence-only (quality dropped); reads explode to rows."""
+    fastq = tmp_path / "selex.fastq"
+    fastq.write_text("@read1\nACGTACGT\n+\nIIIIIIII\n@read2\nTTTTGGGG\n+\nIIIIIIII\n")
+
+    loader = MoleculeLoader(data={"selex": [str(fastq)]}, tiling="samples")
+    df = loader.to_dataframe()
+
+    assert df["selex"].tolist() == ["ACGTACGT", "TTTTGGGG"]
+    # sequence-only: per-base quality is dropped, so no quality column appears
+    assert list(df.columns) == ["selex"]
+
+
+# --------------------------------------------------------------------------- #
+# validation / errors
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"tiling": "nonsense"},
+        {"indexing": "nonsense"},
+        {"multiindex": "nonsense"},
+    ],
+)
+def test_invalid_options_raise(kwargs):
+    """Unknown tiling/indexing/multiindex values are rejected at construction."""
+    with pytest.raises(ValueError):
+        MoleculeLoader(data={"target": [PDB_SINGLE]}, **kwargs)
 
 
 def test_no_seqres_pdb_raises():
-    """PDB files without SEQRES should raise."""
-    root_path = Path(__file__).parent.parent.parent
-    path = root_path / INVALID_NO_SEQRES_PATH
-
-    loader = MoleculeLoader(path)
-
+    """A PDB file without SEQRES records raises on materialization."""
+    loader = MoleculeLoader(data={"target": [PDB_NO_SEQRES]})
     with pytest.raises(ValueError, match="No sequences found"):
-        loader.to_df_seq()
+        loader.to_dataframe()


### PR DESCRIPTION
#### Reference Issues/PRs

Part of #682. First of a planned series reworking molecule loading.

#### What does this implement/fix? Explain your changes.

Rewrites `MoleculeLoader` (`pyaptamer/data/loader.py`) into a lazy, DataFrame-style container.

Before: took file paths and eagerly returned a long-format `MultiIndex` DataFrame via `to_df_seq()`.
Now: takes 2D `data` (dict, list of lists, or DataFrame) whose cells hold file paths, sequence strings, or plain values, and parses files only when `to_dataframe()` is called.

```python
MoleculeLoader(data, tiling="bag", indexing="preserve",
               multiindex="flatten", ignore_duplicates=False)
```

- **tiling** — how a file with several sequences is shaped: `bag` (list per cell), `concat` (one joined string), `first`, `features` (spread to columns), `samples` / `samples_product` (explode to rows).
- **indexing** — per-file IDs (PDB chain IDs, FASTA headers): `preserve` (row index), `new` (drop), `keep_as_column`.
- **multiindex** — row labels after exploding: `flatten`, `multiindex`, `auto`.
- **ignore_duplicates** — drop duplicate sequences within a file.

Files are read with Biopython: PDB via `pdb-seqres`, FASTA/FASTQ/GenBank/EMBL via `SeqIO`. FASTQ reads the sequence only.

This replaces the old `to_df_seq()` / `path=` API. Consumers (transforms, encoders, AptaTrans/AptaNet pipelines) are migrated in follow-up PRs and will fail until then.

#### What should a reviewer concentrate their feedback on?

- [ ] `samples` raises when a row has more than one file column (pairing chains to sequences by position is meaningless). Per-column behavior is a planned follow-up — is raising the right interim choice?
- [ ] `features` names columns positionally (`target_0`, `target_1`); `keep_as_column` adds a `<col>_chain_id` column and resets the index; `preserve` + `flatten` gives labels like `0__A`.
- [ ] `bag`: a single-sequence file becomes a `str`, a multi-sequence file a `list[str]`.

#### Did you add any tests for the change?

20 unit tests + 2 doctests, all passing; `ruff` clean. Cover in-memory data, every tiling, indexing/multiindex variants, `ignore_duplicates`, FASTA and FASTQ, and error paths.

#### Any other comments?

`samples_product` keeps its cartesian-product behavior. GenBank/EMBL tests come later with the tutorial notebooks.

#### PR checklist

- [x] PR title starts with `[ENH]`.
- [x] Added/modified tests.
- [x] Ran pre-commit hooks.