### PR TITLE
[ENH] Decouple AptaNetPipeline from raw pairs via a MoleculeLoader transform

### DIFF
--- a/pyaptamer/aptanet/__init__.py
+++ b/pyaptamer/aptanet/__init__.py
@@ -2,5 +2,11 @@
 
 from pyaptamer.aptanet._feature_classifier import AptaNetClassifier, AptaNetRegressor
 from pyaptamer.aptanet._pipeline import AptaNetPipeline
+from pyaptamer.aptanet._transforms import PairsToFeatures
 
-__all__ = ["AptaNetPipeline", "AptaNetClassifier", "AptaNetRegressor"]
+__all__ = [
+    "AptaNetPipeline",
+    "AptaNetClassifier",
+    "AptaNetRegressor",
+    "PairsToFeatures",
+]

--- a/pyaptamer/aptanet/_pipeline.py
+++ b/pyaptamer/aptanet/_pipeline.py
@@ -1,15 +1,14 @@
-__author__ = ["nennomp", "satvshr"]
+__author__ = ["nennomp", "satvshr", "siddharth7113"]
 __all__ = ["AptaNetPipeline"]
 __required__ = ["python>=3.10"]
 
 from skbase.base import BaseObject
 from sklearn.base import BaseEstimator, clone
 from sklearn.pipeline import Pipeline
-from sklearn.preprocessing import FunctionTransformer
 from sklearn.utils.validation import check_is_fitted
 
 from pyaptamer.aptanet import AptaNetClassifier
-from pyaptamer.utils._aptanet_utils import pairs_to_features
+from pyaptamer.aptanet._transforms import PairsToFeatures
 
 
 class AptaNetPipeline(BaseObject, BaseEstimator):
@@ -21,15 +20,18 @@ class AptaNetPipeline(BaseObject, BaseEstimator):
     multi-layer perceptron to predict whether an aptamer and a protein interact
     (binary classification).
 
-    The pipeline starts from string pairs, converts them into numeric features
-    (aptamer k-mer frequencies + protein PSeAAC), applies tree-based feature
-    selection, and feeds the result into the estimator.
+    The pipeline takes a MoleculeLoader of aptamer/protein pairs, converts them
+    into numeric features (aptamer k-mer frequencies + protein PSeAAC), applies
+    tree-based feature selection, and feeds the result into the estimator.
 
     Parameters
     ----------
     k : int, optional, default=4
         The k-mer size used to generate aptamer k-mer vectors.
-
+    aptamer_col : str, optional, default="aptamer"
+        Name of the MoleculeLoader column holding aptamer sequences.
+    protein_col : str, optional, default="protein"
+        Name of the MoleculeLoader column holding protein sequences.
     estimator : sklearn-compatible estimator or None, default=None
         Estimator applied after feature selection. If None, uses `AptaNetClassifier`.
 
@@ -51,28 +53,37 @@ class AptaNetPipeline(BaseObject, BaseEstimator):
     Examples
     --------
     >>> from pyaptamer.aptanet import AptaNetPipeline
+    >>> from pyaptamer.data import MoleculeLoader
     >>> import numpy as np
     >>> pipe = AptaNetPipeline()
     >>> aptamer_seq = "AGCTTAGCGTACAGCTTAAAAGGGTTTCCCCTGCCCGCGTAC"
     >>> protein_seq = "ACDEFGHIKLMNPQRSTVWYACDEFGHIKLMNPQRSTVWY"
-    >>> X_train_pairs = [(aptamer_seq, protein_seq) for _ in range(40)]
+    >>> X_train = MoleculeLoader(
+    ...     data={"aptamer": [aptamer_seq] * 40, "protein": [protein_seq] * 40}
+    ... )
     >>> y_train = np.array([0] * 20 + [1] * 20, dtype=np.float32)
-    >>> X_test_pairs = [(aptamer_seq, protein_seq) for _ in range(10)]
-    >>> pipe.fit(X_train_pairs, y_train)  # doctest: +ELLIPSIS
+    >>> X_test = MoleculeLoader(
+    ...     data={"aptamer": [aptamer_seq] * 10, "protein": [protein_seq] * 10}
+    ... )
+    >>> pipe.fit(X_train, y_train)  # doctest: +ELLIPSIS
     AptaNetPipeline(...)
-    >>> preds = pipe.predict(X_test_pairs)
-    >>> proba = pipe.predict_proba(X_test_pairs)
+    >>> preds = pipe.predict(X_test)
+    >>> proba = pipe.predict_proba(X_test)
     """
 
-    def __init__(self, k=4, estimator=None):
+    def __init__(
+        self, k=4, aptamer_col="aptamer", protein_col="protein", estimator=None
+    ):
         self.k = k
+        self.aptamer_col = aptamer_col
+        self.protein_col = protein_col
         self.estimator = estimator
 
     def _build_pipeline(self):
-        transformer = FunctionTransformer(
-            func=pairs_to_features,
-            kw_args={"k": self.k},
-            validate=False,
+        transformer = PairsToFeatures(
+            k=self.k,
+            aptamer_col=self.aptamer_col,
+            protein_col=self.protein_col,
         )
         self._estimator = self.estimator or AptaNetClassifier()
         return Pipeline([("features", transformer), ("clf", clone(self._estimator))])

--- a/pyaptamer/aptanet/_transforms.py
+++ b/pyaptamer/aptanet/_transforms.py
@@ -1,0 +1,96 @@
+"""Feature-extraction transforms for the AptaNet algorithm."""
+
+__author__ = ["siddharth7113"]
+__all__ = ["PairsToFeatures"]
+
+import numpy as np
+import pandas as pd
+
+from pyaptamer.data import MoleculeLoader
+from pyaptamer.pseaac import AptaNetPSeAAC
+from pyaptamer.trafos.base import BaseTransform
+from pyaptamer.utils._aptanet_utils import generate_kmer_vecs
+
+
+class PairsToFeatures(BaseTransform):
+    """Transform (aptamer, protein) sequence pairs into AptaNet feature vectors.
+
+    Each row is encoded as the concatenation of:
+
+    - normalized k-mer frequencies of the aptamer sequence, and
+    - pseudo amino-acid composition (PSeAAC) of the protein sequence.
+
+    Input must be a :class:`~pyaptamer.data.loader.MoleculeLoader`
+
+    Parameters
+    ----------
+    k : int, default=4
+        Maximum k-mer length used for the aptamer k-mer frequency vector.
+    aptamer_col : str, default="aptamer"
+        Name of the column holding aptamer sequences.
+    protein_col : str, default="protein"
+        Name of the column holding protein sequences.
+
+    Examples
+    --------
+    >>> from pyaptamer.aptanet import PairsToFeatures
+    >>> from pyaptamer.data import MoleculeLoader
+    >>> X = MoleculeLoader(
+    ...     data={
+    ...         "aptamer": ["AGCTTAGCGTACAGCTTAAAAGGGTTTCCCCTGCCCGCGTAC"],
+    ...         "protein": ["ACDEFGHIKLMNPQRSTVWYACDEFGHIKLMNPQRSTVWY"],
+    ...     }
+    ... )
+    >>> Xt = PairsToFeatures().fit_transform(X)
+    >>> len(Xt)
+    1
+    """
+
+    _tags = {
+        "capability:multivariate": True,
+        "property:fit_is_empty": True,
+        "output_type": "numeric",
+    }
+
+    def __init__(self, k=4, aptamer_col="aptamer", protein_col="protein"):
+        self.k = k
+        self.aptamer_col = aptamer_col
+        self.protein_col = protein_col
+        super().__init__()
+
+    def _check_X_y(self, X, y):  # noqa: N802
+        """Require a MoleculeLoader, then defer to the base coercion/checks."""
+        if not isinstance(X, MoleculeLoader):
+            raise TypeError(
+                f"{type(self).__name__} accepts only a MoleculeLoader as input, "
+                f"got {type(X).__name__}."
+            )
+        return super()._check_X_y(X, y)
+
+    def _transform(self, X):
+        """Encode each (aptamer, protein) row into a feature vector.
+
+        Parameters
+        ----------
+        X : pandas.DataFrame
+            Contains the ``aptamer_col`` and ``protein_col`` columns.
+
+        Returns
+        -------
+        pandas.DataFrame
+            One row per input row; columns are the concatenated k-mer + PSeAAC
+            features (``float32``), indexed like ``X``.
+        """
+        pseaac = AptaNetPSeAAC()
+        feats = [
+            np.concatenate(
+                [
+                    generate_kmer_vecs(aptamer_seq, k=self.k),
+                    np.asarray(pseaac.transform(protein_seq)),
+                ]
+            )
+            for aptamer_seq, protein_seq in zip(
+                X[self.aptamer_col], X[self.protein_col], strict=True
+            )
+        ]
+        return pd.DataFrame(np.vstack(feats).astype(np.float32), index=X.index)

--- a/pyaptamer/aptanet/tests/test_aptanet.py
+++ b/pyaptamer/aptanet/tests/test_aptanet.py
@@ -1,4 +1,4 @@
-__author__ = ["nennomp", "satvshr"]
+__author__ = ["nennomp", "satvshr", "siddharth7113"]
 
 
 import numpy as np
@@ -6,6 +6,7 @@ import pytest
 from sklearn.utils.estimator_checks import parametrize_with_checks
 
 from pyaptamer.aptanet import AptaNetClassifier, AptaNetPipeline, AptaNetRegressor
+from pyaptamer.data import MoleculeLoader
 
 params = [
     (
@@ -13,6 +14,13 @@ params = [
         "ACDEFGHIKLMNPQRSTVWYACDEFGHIKLMNPQRSTVWY",
     )
 ]
+
+
+def _make_loader(aptamer_seq, protein_seq, n):
+    """Build a MoleculeLoader of n identical aptamer/protein pairs."""
+    return MoleculeLoader(
+        data={"aptamer": [aptamer_seq] * n, "protein": [protein_seq] * n}
+    )
 
 
 @pytest.mark.parametrize("aptamer_seq, protein_seq", params)
@@ -23,7 +31,7 @@ def test_pipeline_fit_and_predict_classification(aptamer_seq, protein_seq):
     """
     pipe = AptaNetPipeline(k=4)
 
-    X_raw = [(aptamer_seq, protein_seq) for _ in range(40)]
+    X_raw = _make_loader(aptamer_seq, protein_seq, 40)
     y = np.array([0] * 20 + [1] * 20, dtype=np.float32)
 
     pipe.fit(X_raw, y)
@@ -41,7 +49,7 @@ def test_pipeline_fit_and_predict_proba(aptamer_seq, protein_seq):
     """
     pipe = AptaNetPipeline()
 
-    X_raw = [(aptamer_seq, protein_seq) for _ in range(40)]
+    X_raw = _make_loader(aptamer_seq, protein_seq, 40)
     y = np.array([0] * 20 + [1] * 20, dtype=np.float32)
 
     pipe.fit(X_raw, y)
@@ -60,7 +68,7 @@ def test_pipeline_fit_and_predict_regression(aptamer_seq, protein_seq):
     """
     pipe = AptaNetPipeline(estimator=AptaNetRegressor())
 
-    X_raw = [(aptamer_seq, protein_seq) for _ in range(40)]
+    X_raw = _make_loader(aptamer_seq, protein_seq, 40)
     y = np.linspace(0, 1, 40).astype(np.float32)
 
     pipe.fit(X_raw, y)

--- a/pyaptamer/aptanet/tests/test_pairs_to_features.py
+++ b/pyaptamer/aptanet/tests/test_pairs_to_features.py
@@ -1,0 +1,42 @@
+"""Tests for the PairsToFeatures transform."""
+
+__author__ = ["siddharth7113"]
+
+import pandas as pd
+import pytest
+
+from pyaptamer.aptanet import PairsToFeatures
+from pyaptamer.data import MoleculeLoader
+
+APTAMER = "AGCTTAGCGTACAGCTTAAAAGGGTTTCCCCTGCCCGCGTAC"
+PROTEIN = "ACDEFGHIKLMNPQRSTVWYACDEFGHIKLMNPQRSTVWY"
+
+
+def test_pairs_to_features_from_moleculeloader():
+    """A MoleculeLoader of aptamer/protein pairs becomes a numeric feature table."""
+    X = MoleculeLoader(data={"aptamer": [APTAMER] * 3, "protein": [PROTEIN] * 3})
+    Xt = PairsToFeatures(k=4).fit_transform(X)
+
+    assert isinstance(Xt, pd.DataFrame)
+    assert len(Xt) == 3
+    assert Xt.shape[1] > 1  # concatenated k-mer + PSeAAC features
+
+
+def test_pairs_to_features_custom_columns():
+    """Column names are configurable, not hardcoded to aptamer/protein."""
+    X = MoleculeLoader(
+        data={"aptamer_sequence": [APTAMER] * 2, "target_sequence": [PROTEIN] * 2}
+    )
+    transform = PairsToFeatures(
+        aptamer_col="aptamer_sequence", protein_col="target_sequence"
+    )
+    Xt = transform.fit_transform(X)
+
+    assert len(Xt) == 2
+
+
+def test_pairs_to_features_rejects_non_moleculeloader():
+    """Only a MoleculeLoader is accepted; a plain DataFrame is rejected."""
+    X = pd.DataFrame({"aptamer": [APTAMER], "protein": [PROTEIN]})
+    with pytest.raises(TypeError, match="only a MoleculeLoader"):
+        PairsToFeatures().fit_transform(X)

--- a/pyaptamer/utils/_aptanet_utils.py
+++ b/pyaptamer/utils/_aptanet_utils.py
@@ -1,12 +1,9 @@
-__author__ = "satvshr"
-__all__ = ["generate_kmer_vecs", "pairs_to_features"]
+__author__ = ["satvshr", "siddharth7113"]
+__all__ = ["generate_kmer_vecs"]
 
 from itertools import product
 
 import numpy as np
-import pandas as pd
-
-from pyaptamer.pseaac import AptaNetPSeAAC
 
 
 def generate_kmer_vecs(aptamer_sequence, k=4):
@@ -55,46 +52,3 @@ def generate_kmer_vecs(aptamer_sequence, k=4):
     )
 
     return kmer_freq
-
-
-def pairs_to_features(X, k=4):
-    """
-    Convert a list of (aptamer_sequence, protein_sequence) pairs into feature vectors.
-    Also supports a pandas DataFrame with 'aptamer' and 'protein' columns.
-
-    This function generates feature vectors for each (aptamer, protein) pair using:
-
-    - k-mer representation of the aptamer sequence
-    - Pseudo amino acid composition (PSeAAC) representation of the protein sequence
-
-    Parameters
-    ----------
-    X : list of tuple of str or pandas.DataFrame
-        A list where each element is a tuple `(aptamer_sequence, protein_sequence)`,
-        or a DataFrame containing 'aptamer' and 'protein' columns.
-
-    k : int, optional
-        The k-mer size used to generate the k-mer vector from the aptamer sequence.
-        Default is 4.
-
-    Returns
-    -------
-    np.ndarray
-        A 2D NumPy array where each row corresponds to the concatenated feature vector
-        for a given (aptamer, protein) pair.
-    """
-    pseaac = AptaNetPSeAAC()
-    feats = []
-
-    if isinstance(X, pd.DataFrame):
-        pairs = zip(X["aptamer"], X["protein"], strict=False)
-    else:
-        pairs = X
-
-    for aptamer_seq, protein_seq in pairs:
-        kmer = generate_kmer_vecs(aptamer_seq, k=k)
-        pseaac_vec = np.asarray(pseaac.transform(protein_seq))
-        feats.append(np.concatenate([kmer, pseaac_vec]))
-
-    # Ensure float32 for PyTorch compatibility
-    return np.vstack(feats).astype(np.float32)


### PR DESCRIPTION
#### Reference Issues/PRs

Part of #682. Stacks on `feat/molecule-loader-migrate-consumers`.

#### What does this implement/fix? Explain your changes.

Makes `AptaNetPipeline` consume a `MoleculeLoader` instead of raw `(aptamer, protein)` tuples.

- Adds `PairsToFeatures`, a `BaseTransform` converting a `MoleculeLoader` of aptamer/protein pairs into AptaNet feature vectors (aptamer k-mer + protein PSeAAC). Accepts only a `MoleculeLoader`; `k`, `aptamer_col`, `protein_col` are configurable.
- Rewires `AptaNetPipeline` to use `PairsToFeatures` (replacing `FunctionTransformer(pairs_to_features)`) and adds `aptamer_col` / `protein_col` params.
- Removes the now-unused `pairs_to_features` function (keeps `generate_kmer_vecs`).
- Updates the pipeline doctest and `test_aptanet.py` to `MoleculeLoader` inputs.

`AptaTransPipeline` (inference only) and `APIDataset` deletion are out of scope.

#### What should a reviewer concentrate their feedback on?

- `PairsToFeatures` accepting only a `MoleculeLoader`, not plain DataFrames.
- Known issue: a skbase `BaseTransform` inside an sklearn `Pipeline` raises a `__sklearn_tags__` DeprecationWarning (skbase lacks it; becomes an error in sklearn 1.8). A base-class fix is planned separately.

#### Did you add any tests for the change?

`test_pairs_to_features.py` (3 tests) and updated `test_aptanet.py`. Full aptanet suite: 108 passed, ruff clean.

#### PR checklist

- [x] PR title starts with `[ENH]`.
- [x] Added/modified tests.
- [x] Ran pre-commit hooks.