### PR TITLE
[ENH] Migrate tutorials and li2014 loader to the MoleculeLoader API

### DIFF
--- a/examples/aptanet_finetuning_tutorial.ipynb
+++ b/examples/aptanet_finetuning_tutorial.ipynb
@@ -48,31 +48,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": null,
    "id": "3737da88",
    "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import pandas as pd\n",
     "import torch\n",
     "\n",
+    "from pyaptamer.data import MoleculeLoader\n",
     "from pyaptamer.datasets import load_1gnh"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": null,
    "id": "a2f6701d",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Number of samples: 25\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "aptamer_sequence = [\n",
     "    \"GGGAGGACGAAGACGACUCGAGACAGGCUAGGGAGGGA\",\n",
@@ -83,15 +77,18 @@
     "]\n",
     "\n",
     "gnh = load_1gnh()\n",
-    "protein_sequence = gnh.to_df_seq()[\"sequence\"].tolist()\n",
+    "protein_sequence = gnh.to_dataframe()[\"sequence\"].tolist()\n",
     "\n",
-    "# Build all combinations (aptamer, protein), duplicated to increase dataset size\n",
-    "X = [(a, p) for a in aptamer_sequence for p in protein_sequence] * 5\n",
+    "# Build all (aptamer, protein) combinations, duplicated to enlarge the dataset\n",
+    "pairs = [(a, p) for a in aptamer_sequence for p in protein_sequence] * 5\n",
+    "\n",
+    "# AptaNet consumes a MoleculeLoader over the aptamer/protein columns\n",
+    "X = MoleculeLoader(data=pd.DataFrame(pairs, columns=[\"aptamer\", \"protein\"]))\n",
     "\n",
     "# Dummy binary labels for the pairs\n",
-    "y = torch.randint(0, 2, (len(X),), dtype=torch.float32)\n",
+    "y = torch.randint(0, 2, (len(pairs),), dtype=torch.float32)\n",
     "\n",
-    "print(f\"Number of samples: {len(X)}\")"
+    "print(f\"Number of samples: {len(pairs)}\")"
    ]
   },
   {
@@ -105,23 +102,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": null,
    "id": "44cc1cbf",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Feature matrix shape: (25, 690)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "from pyaptamer.utils._aptanet_utils import pairs_to_features\n",
+    "from pyaptamer.aptanet import PairsToFeatures\n",
     "\n",
-    "# Convert sequence pairs to feature vectors\n",
-    "X_features = pairs_to_features(X)\n",
+    "# Convert the MoleculeLoader of pairs to feature vectors once, up front, so the\n",
+    "# cross-validation search does not recompute them on every fit.\n",
+    "X_features = PairsToFeatures().fit_transform(X)\n",
     "\n",
     "print(f\"Feature matrix shape: {X_features.shape}\")"
    ]

--- a/examples/aptanet_tutorial.ipynb
+++ b/examples/aptanet_tutorial.ipynb
@@ -17,9 +17,10 @@
     "## Overview\n",
     "This notebook showcases the AptaNet algorithm, a deep learning method that combines sequence-derived (k-mer + PSeAAC) features with RandomForest-based feature selection, and a multi-layer perceptron to predict whether an aptamer and a protein interact (binary classification: aptamer binds/does not bind with the target protein). An overview of the classes and helper functions used in this notebook:\n",
     "\n",
-    "- **pairs_to_features**: helper that converts `(aptamer_sequence, protein_sequence)` pairs into feature vectors using k-mer + PSeAAC.\n",
+    "- **MoleculeLoader**: lazy container for aptamer/protein data; cells may hold in-memory sequences or file paths (PDB/FASTA/FASTQ), materialized to a DataFrame via `to_dataframe()`. AptaNet consumes a MoleculeLoader as its input `X`.\n",
+    "- **PairsToFeatures**: transform that converts a MoleculeLoader of `(aptamer, protein)` pairs into feature vectors using k-mer + PSeAAC.\n",
     "- **SkorchAptaNet**: a PyTorch MLP wrapped in Skorch for binary classification.\n",
-    "- **load_1gnh**: helper to load the 1GNH molecule structure from PDB file into our in-memory `MoleculeLoader` format."
+    "- **load_1gnh**: helper to load the 1GNH molecule structure from a PDB file into a `MoleculeLoader`.\n"
    ]
   },
   {
@@ -40,20 +41,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "id": "3737da88",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Data imports\n",
+    "import pandas as pd\n",
     "import torch\n",
     "\n",
+    "from pyaptamer.data import MoleculeLoader\n",
     "from pyaptamer.datasets import load_1gnh"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "id": "a2f6701d",
    "metadata": {},
    "outputs": [],
@@ -67,13 +70,16 @@
     "]\n",
     "\n",
     "gnh = load_1gnh()\n",
-    "protein_sequence = gnh.to_df_seq()[\"sequence\"].tolist()\n",
+    "protein_sequence = gnh.to_dataframe()[\"sequence\"].tolist()\n",
     "\n",
-    "# Build all combinations (aptamer, protein), duplicated to increase dataset size\n",
-    "X = [(a, p) for a in aptamer_sequence for p in protein_sequence] * 5\n",
+    "# Build all (aptamer, protein) combinations, duplicated to enlarge the dataset\n",
+    "pairs = [(a, p) for a in aptamer_sequence for p in protein_sequence] * 5\n",
+    "\n",
+    "# AptaNet consumes a MoleculeLoader over the aptamer/protein columns\n",
+    "X = MoleculeLoader(data=pd.DataFrame(pairs, columns=[\"aptamer\", \"protein\"]))\n",
     "\n",
     "# Dummy binary labels for the pairs\n",
-    "y = torch.randint(0, 2, (len(X),), dtype=torch.float32)"
+    "y = torch.randint(0, 2, (len(pairs),), dtype=torch.float32)"
    ]
   },
   {
@@ -87,9 +93,9 @@
     "\n",
     " To build a scikit-learn pipeline, follow these steps:\n",
     "1. Convert the input to the desired (aptamer_sequence, protein_sequence) format.\n",
-    "    * OPTIONAL: As mentioned in the paper, perform under-sampling using the  \n",
+    "    * OPTIONAL: As mentioned in the paper, perform under-sampling using the\n",
     "    Neighborhood Cleaning Rule to balance the classes.\n",
-    "2. Get the PSeAAC feature vectors for your converted input (using `pairs_to_features`).\n",
+    "2. Get the PSeAAC feature vectors for your converted input (using `PairsToFeatures`).\n",
     "3. Select the number of features to use from the feature vector (using `RandomForestClassifier`).\n",
     "4. Define the skorch neural network (using `AptaNetMLP`).\n",
     "### Different workflows\n",
@@ -97,7 +103,7 @@
     "\n",
     "1. A minimal workflow with no dataset balancing, while using the in-built pipeline.\n",
     "2. Using your own custom pipeline.\n",
-    "3. Dataset balancing, while using your own pipeline."
+    "3. Dataset balancing, while using your own pipeline.\n"
    ]
   },
   {
@@ -190,7 +196,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "id": "6130027a",
    "metadata": {},
    "outputs": [],
@@ -199,27 +205,20 @@
     "from sklearn.ensemble import RandomForestClassifier\n",
     "from sklearn.feature_selection import SelectFromModel\n",
     "from sklearn.pipeline import Pipeline\n",
-    "from sklearn.preprocessing import FunctionTransformer\n",
     "from skorch import NeuralNetBinaryClassifier\n",
     "\n",
-    "from pyaptamer.aptanet._aptanet_nn import AptaNetMLP\n",
-    "from pyaptamer.utils._aptanet_utils import pairs_to_features"
+    "from pyaptamer.aptanet import PairsToFeatures\n",
+    "from pyaptamer.aptanet._aptanet_nn import AptaNetMLP"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "id": "4a2e277e",
    "metadata": {},
    "outputs": [],
    "source": [
-    "feature_transformer = FunctionTransformer(\n",
-    "    func=pairs_to_features,\n",
-    "    validate=False,\n",
-    "    # Optional arguments for pairs_to_features\n",
-    "    # example: kw_args={'k': 4, 'pseaac_kwargs': {'lambda_value': 30}}\n",
-    "    kw_args={},\n",
-    ")\n",
+    "feature_transformer = PairsToFeatures(k=4)\n",
     "\n",
     "selector = SelectFromModel(\n",
     "    estimator=RandomForestClassifier(\n",
@@ -512,16 +511,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "id": "523f4ce6",
    "metadata": {},
    "outputs": [],
    "source": [
     "# If you want to build your own aptamer pipeline, you should use the following imports\n",
-    "from sklearn.preprocessing import FunctionTransformer\n",
-    "\n",
-    "from pyaptamer.aptanet import AptaNetClassifier, AptaNetPipeline\n",
-    "from pyaptamer.utils._aptanet_utils import pairs_to_features"
+    "from pyaptamer.aptanet import AptaNetClassifier, AptaNetPipeline"
    ]
   },
   {
@@ -541,19 +537,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "id": "13fb1669",
    "metadata": {},
    "outputs": [],
    "source": [
-    "feature_transformer = FunctionTransformer(\n",
-    "    func=pairs_to_features,\n",
-    "    validate=False,\n",
-    "    # Optional arguments for pairs_to_features\n",
-    "    # example: kw_args={'k': 4, 'pseaac_kwargs': {'lambda_value': 30}}\n",
-    "    kw_args={},\n",
-    ")\n",
-    "\n",
     "# AptaNetClassifier encapsulates the \"selector\" and \"net\" mentioned in Workflow 2\n",
     "clf = AptaNetClassifier()\n",
     "\n",
@@ -633,99 +621,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": null,
    "id": "d5cb05fb",
    "metadata": {},
    "outputs": [],
    "source": [
-    "X, y = load_li2014(split=\"train\")"
+    "X, y = load_li2014(split=\"train\", return_X_y=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": null,
    "id": "5f1442f9",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>aptamer</th>\n",
-       "      <th>protein</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>UCGGAGGUGGUUCAGCUCUGCAUCGACAGUUGGC</td>\n",
-       "      <td>MDSTNYISKLFEYAQRQGQISDIKFEEVGTDGPDHLKTFTLRVVIK...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>CGGGGTGTTGTCCTGTGCTCTCCGGAGAGCACAGGACAACACCCCG</td>\n",
-       "      <td>MDELFPLIFPAEPAQASGPYVEIIEQPKQRGMRFRYKCEGRSAGSI...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>GCTGCAGTTGCACTGAATTCGCCTCTCGCCTCCGTACACTTAGTCG...</td>\n",
-       "      <td>MDEVGAQVAAPMFIHQSLGRKRDLYYPMSNRLVQSQPQRRDEWNSK...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>TATTTGCCCTTGCAGGCCGCAGGAGTGCTAGCAGT</td>\n",
-       "      <td>PISPIDTVPVKLKPGMDGPKVKQWPLTEEKIKALTEICNEMEKEGK...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>UCUCUGGGCUCUUAGGAGAACGGAUAGGAGUGUGCUCGCU</td>\n",
-       "      <td>LQENFLPQPRQQHHGTLVLHYRPHREEAGMQHPCLWPGSSHCSDDS...</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                                             aptamer  \\\n",
-       "0                 UCGGAGGUGGUUCAGCUCUGCAUCGACAGUUGGC   \n",
-       "1     CGGGGTGTTGTCCTGTGCTCTCCGGAGAGCACAGGACAACACCCCG   \n",
-       "2  GCTGCAGTTGCACTGAATTCGCCTCTCGCCTCCGTACACTTAGTCG...   \n",
-       "3                TATTTGCCCTTGCAGGCCGCAGGAGTGCTAGCAGT   \n",
-       "4           UCUCUGGGCUCUUAGGAGAACGGAUAGGAGUGUGCUCGCU   \n",
-       "\n",
-       "                                             protein  \n",
-       "0  MDSTNYISKLFEYAQRQGQISDIKFEEVGTDGPDHLKTFTLRVVIK...  \n",
-       "1  MDELFPLIFPAEPAQASGPYVEIIEQPKQRGMRFRYKCEGRSAGSI...  \n",
-       "2  MDEVGAQVAAPMFIHQSLGRKRDLYYPMSNRLVQSQPQRRDEWNSK...  \n",
-       "3  PISPIDTVPVKLKPGMDGPKVKQWPLTEEKIKALTEICNEMEKEGK...  \n",
-       "4  LQENFLPQPRQQHHGTLVLHYRPHREEAGMQHPCLWPGSSHCSDDS...  "
-      ]
-     },
-     "execution_count": 41,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# Display first few rows of X which contains aptamer-protein pairs\n",
-    "X.head()"
+    "# Display the first few aptamer-protein pairs (materialized from the loader)\n",
+    "X.to_dataframe().head()"
    ]
   },
   {
@@ -838,25 +750,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": null,
    "id": "7c5a42a3",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([[0.9648417 , 0.03515826]], dtype=float32)"
-      ]
-     },
-     "execution_count": 44,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "aptamer_sequence = \"GGGAGGACGAAGACGACUCGAGACAGGCUAGGGAGGGA\"\n",
     "\n",
-    "X = [(aptamer_sequence, p) for p in protein_sequence]\n",
+    "# Pair the single candidate aptamer with every 1GNH protein chain\n",
+    "X = MoleculeLoader(\n",
+    "    data=pd.DataFrame(\n",
+    "        {\n",
+    "            \"aptamer\": [aptamer_sequence] * len(protein_sequence),\n",
+    "            \"protein\": protein_sequence,\n",
+    "        }\n",
+    "    )\n",
+    ")\n",
     "\n",
     "pipeline.predict_proba(X)"
    ]
@@ -866,9 +775,41 @@
    "id": "af501b0c",
    "metadata": {},
    "source": [
-    "### Second workflow (TODO)\n",
+    "### Second workflow\n",
     "\n",
-    "Predicting binding probability (`predict_proba`) between a protein (1GNH) and DNA sequences from a `fasta` file."
+    "Predicting binding probability (`predict_proba`) between a protein (1GNH) and a set of candidate aptamer sequences read from a `fasta` file. `MoleculeLoader` parses the FASTA and, with `tiling=\"samples\"`, explodes it to one row per record while broadcasting the single target protein across them.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ce432ee0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Write the candidate aptamers to a small FASTA file (one record per line pair)\n",
+    "import tempfile\n",
+    "from pathlib import Path\n",
+    "\n",
+    "candidate_aptamers = [\n",
+    "    \"GGGAGGACGAAGACGACUCGAGACAGGCUAGGGAGGGA\",\n",
+    "    \"AAGCGUCGGAUCUACACGUGCGAUAGCUCAGUACGCGGU\",\n",
+    "    \"CGGUAUCGAGUACAGGAGUCCGACGGAUAGUCCGGAGC\",\n",
+    "]\n",
+    "fasta_path = Path(tempfile.gettempdir()) / \"candidate_aptamers.fasta\"\n",
+    "with open(fasta_path, \"w\") as fh:\n",
+    "    for i, seq in enumerate(candidate_aptamers):\n",
+    "        fh.write(f\">candidate{i}\\n{seq}\\n\")\n",
+    "\n",
+    "# MoleculeLoader parses the FASTA; tiling=\"samples\" explodes it to one row\n",
+    "# per record and broadcasts the single target protein across them.\n",
+    "target = protein_sequence[0]\n",
+    "X = MoleculeLoader(\n",
+    "    data={\"aptamer\": [str(fasta_path)], \"protein\": [target]},\n",
+    "    tiling=\"samples\",\n",
+    ")\n",
+    "\n",
+    "pipeline.predict_proba(X)"
    ]
   },
   {

--- a/pyaptamer/aptanet/tests/test_aptanet.py
+++ b/pyaptamer/aptanet/tests/test_aptanet.py
@@ -78,6 +78,26 @@ def test_pipeline_fit_and_predict_regression(aptamer_seq, protein_seq):
     assert np.issubdtype(preds.dtype, np.floating)
 
 
+@pytest.mark.parametrize("aptamer_seq, protein_seq", params)
+def test_fasta_sourced_loader_matches_in_memory(tmp_path, aptamer_seq, protein_seq):
+    """A FASTA-sourced loader yields the same features as the in-memory loader."""
+    from pyaptamer.aptanet._transforms import PairsToFeatures
+
+    fasta = tmp_path / "library.fasta"
+    fasta.write_text(f">apt1\n{aptamer_seq}\n>apt2\n{aptamer_seq}\n")
+
+    from_file = MoleculeLoader(
+        data={"aptamer": [str(fasta)], "protein": [protein_seq]}, tiling="samples"
+    )
+    in_memory = _make_loader(aptamer_seq, protein_seq, 2)
+
+    feats_file = PairsToFeatures().fit_transform(from_file)
+    feats_mem = PairsToFeatures().fit_transform(in_memory)
+
+    assert feats_file.shape == feats_mem.shape
+    assert np.allclose(feats_file.to_numpy(), feats_mem.to_numpy())
+
+
 @parametrize_with_checks(
     estimators=[AptaNetClassifier(), AptaNetRegressor()],
     expected_failed_checks={

--- a/pyaptamer/data/tests/test_loader.py
+++ b/pyaptamer/data/tests/test_loader.py
@@ -1,5 +1,7 @@
 """Tests for the MoleculeLoader lazy data container."""
 
+__author__ = ["siddharth7113"]
+
 from pathlib import Path
 
 import pandas as pd
@@ -217,6 +219,49 @@ def test_fastq_is_sequence_only(tmp_path):
     assert df["selex"].tolist() == ["ACGTACGT", "TTTTGGGG"]
     # sequence-only: per-base quality is dropped, so no quality column appears
     assert list(df.columns) == ["selex"]
+
+
+@pytest.mark.parametrize(
+    "ext, content",
+    [
+        (
+            "gb",
+            "LOCUS       TEST                       8 bp    DNA     linear   UNK"
+            " 01-JAN-1980\nDEFINITION  test.\nACCESSION   TEST\nFEATURES        "
+            "     Location/Qualifiers\nORIGIN\n        1 acgtacgt\n//\n",
+        ),
+        (
+            "embl",
+            "ID   TEST; SV 1; linear; DNA; STD; UNC; 8 BP.\nSQ   Sequence 8 BP;"
+            "\n     acgtacgt"
+            "                                                                8\n//\n",
+        ),
+    ],
+)
+def test_genbank_and_embl_dispatch(tmp_path, ext, content):
+    """GenBank/EMBL files dispatch through SeqIO by suffix and yield sequences."""
+    path = tmp_path / f"record.{ext}"
+    path.write_text(content)
+
+    loader = MoleculeLoader(data={"seq": [str(path)]}, tiling="samples")
+    df = loader.to_dataframe()
+
+    assert df["seq"].tolist() == ["ACGTACGT"]
+
+
+def test_fasta_path_broadcasts_against_in_memory_column(tmp_path):
+    """A FASTA file column explodes per-record while an in-memory column broadcasts."""
+    fasta = tmp_path / "library.fasta"
+    fasta.write_text(">apt1\nACGTACGT\n>apt2\nTTTTGGGG\n>apt3\nGGGGCCCC\n")
+    protein = "ACDEFGHIKLMNPQRSTVWY"
+
+    loader = MoleculeLoader(
+        data={"aptamer": [str(fasta)], "protein": [protein]}, tiling="samples"
+    )
+    df = loader.to_dataframe()
+
+    assert df["aptamer"].tolist() == ["ACGTACGT", "TTTTGGGG", "GGGGCCCC"]
+    assert df["protein"].tolist() == [protein, protein, protein]
 
 
 # --------------------------------------------------------------------------- #

--- a/pyaptamer/datasets/_loaders/_li2014.py
+++ b/pyaptamer/datasets/_loaders/_li2014.py
@@ -1,11 +1,13 @@
-__author__ = "satvshr"
+__author__ = ["satvshr", "siddharth7113"]
 __all__ = ["load_li2014"]
 import os
 
 import pandas as pd
 
+from pyaptamer.data.loader import MoleculeLoader
 
-def load_li2014(split=None):
+
+def load_li2014(split=None, return_X_y=False):
     """
     Load the Li 2014 aptamer–protein interaction dataset.
 
@@ -40,46 +42,56 @@ def load_li2014(split=None):
         The loader preserves the original dtype and values (may also hold
         continuous affinity values in other variants).
 
-    Return types
-    ------------
-    Returns a tuple (X, y) where:
-
-      - X : pandas.DataFrame
-          Feature DataFrame containing the two feature columns (aptamer, protein).
-      - y : pandas.DataFrame
-          Single-column DataFrame containing the target/label (keeps column name
-          "label" as present in the CSV). Using a DataFrame for `y` keeps the
-          shape consistent for downstream code even when the target is one column.
+    The molecule data is returned as a
+    :class:`~pyaptamer.data.loader.MoleculeLoader` so it plugs directly into the
+    AptaNet transform pipeline, mirroring
+    :func:`~pyaptamer.datasets.load_aptacom`.
 
     Parameters
     ----------
     split : {None, "train", "test"}, optional
         Which split to load. ``None`` (default) concatenates train+test.
+    return_X_y : bool, optional
+        If True, return a tuple ``(X, y)`` where:
+          - ``X`` is a MoleculeLoader over the feature columns
+            ["aptamer", "protein"]
+          - ``y`` is a DataFrame with the target column ["label"]
+        If False (default), return a single MoleculeLoader over all three
+        columns ["aptamer", "protein", "label"].
+
+    Returns
+    -------
+    MoleculeLoader or tuple[MoleculeLoader, pandas.DataFrame]
+        - If `return_X_y` is False: a MoleculeLoader over the columns
+          ["aptamer", "protein", "label"].
+        - If `return_X_y` is True: a tuple ``(X, y)`` where ``X`` is a
+          MoleculeLoader over the two feature columns and ``y`` is a DataFrame
+          with the target. The target keeps the column name "label" as present
+          in the CSV; using a DataFrame for `y` keeps the shape consistent for
+          downstream code even when the target is one column.
     """
     if split not in (None, "train", "test"):
         raise ValueError("split must be None, 'train', or 'test'")
 
     base_path = os.path.join(os.path.dirname(__file__), "..", "data")
 
-    dfs_X = []
-    dfs_y = []
+    dfs = []
 
     # Load train split if requested
     if split is None or split == "train":
         train_path = os.path.join(base_path, "train_li2014.csv")
-        train_df = pd.read_csv(train_path)
-        dfs_X.append(train_df.iloc[:, :-1])
-        dfs_y.append(train_df.iloc[:, -1:])
+        dfs.append(pd.read_csv(train_path))
 
     # Load test split if requested
     if split is None or split == "test":
         test_path = os.path.join(base_path, "test_li2014.csv")
-        test_df = pd.read_csv(test_path)
-        dfs_X.append(test_df.iloc[:, :-1])
-        dfs_y.append(test_df.iloc[:, -1:])
+        dfs.append(pd.read_csv(test_path))
 
     # Concatenate splits if both were loaded
-    X = pd.concat(dfs_X, ignore_index=True)
-    y = pd.concat(dfs_y, ignore_index=True)
+    dataset = pd.concat(dfs, ignore_index=True)
 
-    return X, y
+    if return_X_y:
+        X = dataset.iloc[:, :-1]
+        y = dataset.iloc[:, -1:]
+        return MoleculeLoader(data=X), y
+    return MoleculeLoader(data=dataset)

--- a/pyaptamer/datasets/tests/test_li2014.py
+++ b/pyaptamer/datasets/tests/test_li2014.py
@@ -1,8 +1,9 @@
-__author__ = "satvshr"
+__author__ = "siddharth7113"
 
 import pandas as pd
 import pytest
 
+from pyaptamer.data.loader import MoleculeLoader
 from pyaptamer.datasets._loaders._li2014 import load_li2014
 
 
@@ -10,41 +11,43 @@ from pyaptamer.datasets._loaders._li2014 import load_li2014
     "split",
     [None, "train", "test"],
 )
-def test_load_li2014(split):
-    """
-    Test that load_li2014 returns a tuple (X, y) where:
-    - X is a DataFrame
-    - y is a DataFrame
-    - they have matching lengths
-    - they are non-empty
+def test_load_li2014_single_loader(split):
+    """Default returns one MoleculeLoader over aptamer, protein and label."""
+    loader = load_li2014(split=split)
 
-    Parameters
-    ----------
-    split : {None, 'train', 'test'}
-        Split to load and test.
-    """
-    X, y = load_li2014(split=split)
+    assert isinstance(loader, MoleculeLoader)
 
-    assert isinstance(X, pd.DataFrame), "X should be a pandas DataFrame"
-    assert isinstance(y, pd.DataFrame), "y should be a pandas DataFrame"
+    df = loader.to_dataframe()
+    assert list(df.columns) == ["aptamer", "protein", "label"]
+    assert df.shape[0] > 0
 
-    assert len(X) == len(y), "X and y must have the same number of rows"
-    assert X.shape[0] > 0, "X should not be empty"
-    assert y.shape[0] > 0, "y should not be empty"
+
+@pytest.mark.parametrize(
+    "split",
+    [None, "train", "test"],
+)
+def test_load_li2014_return_x_y(split):
+    """return_X_y=True splits into a MoleculeLoader X and a DataFrame y."""
+    X, y = load_li2014(split=split, return_X_y=True)
+
+    assert isinstance(X, MoleculeLoader)
+    assert isinstance(y, pd.DataFrame)
+
+    X_df = X.to_dataframe()
+    assert list(X_df.columns) == ["aptamer", "protein"]
+    assert list(y.columns) == ["label"]
+    assert len(X_df) == len(y) > 0
 
 
 def test_load_li2014_concatenation():
-    """
-    Test that loading with split=None returns the concatenation of train and test.
-    """
-    X_all, y_all = load_li2014(split=None)
-    X_train, y_train = load_li2014(split="train")
-    X_test, y_test = load_li2014(split="test")
+    """split=None concatenates the train and test splits."""
+    X_all, y_all = load_li2014(split=None, return_X_y=True)
+    X_train, y_train = load_li2014(split="train", return_X_y=True)
+    X_test, y_test = load_li2014(split="test", return_X_y=True)
 
-    # Total rows should equal sum of train and test
-    assert len(X_all) == len(X_train) + len(X_test), (
-        "Concatenated data should have rows equal to train + test"
-    )
-    assert len(y_all) == len(y_train) + len(y_test), (
-        "Concatenated labels should have length equal to train + test"
-    )
+    n_all = len(X_all.to_dataframe())
+    n_train = len(X_train.to_dataframe())
+    n_test = len(X_test.to_dataframe())
+
+    assert n_all == n_train + n_test
+    assert len(y_all) == len(y_train) + len(y_test)

--- a/pyaptamer/experiments/_aptamer_aptanet.py
+++ b/pyaptamer/experiments/_aptamer_aptanet.py
@@ -2,6 +2,7 @@ __all__ = ["AptamerEvalAptaNet"]
 
 import numpy as np
 
+from pyaptamer.data import MoleculeLoader
 from pyaptamer.experiments._aptamer import BaseAptamerEval
 
 
@@ -21,13 +22,16 @@ class AptamerEvalAptaNet(BaseAptamerEval):
     --------
     >>> import numpy as np
     >>> from pyaptamer.aptanet import AptaNetPipeline
+    >>> from pyaptamer.data import MoleculeLoader
     >>> from pyaptamer.experiments import AptamerEvalAptaNet
     >>> aptamer_seq = "AGCTTAGCGTACAGCTTAAAAGGGTTTCCCCTGCCCGCGTAC"
     >>> protein_seq = "ACDEFGHIKLMNPQRSTVWYACDEFGHIKLMNPQRSTVWY"
-    >>> pairs = [(aptamer_seq, protein_seq) for _ in range(5)]
+    >>> X = MoleculeLoader(
+    ...     data={"aptamer": [aptamer_seq] * 5, "protein": [protein_seq] * 5}
+    ... )
     >>> labels = np.array([0] * 5, dtype=np.float32)
     >>> pipeline = AptaNetPipeline()
-    >>> pipeline.fit(pairs, labels)  # doctest: +ELLIPSIS
+    >>> pipeline.fit(X, labels)  # doctest: +ELLIPSIS
     AptaNetPipeline(...)
     >>> target = "ACDEFACDEFACDEFACDEFACDEFACDEFACDEFACDEF"
     >>> experiment = AptamerEvalAptaNet(target, pipeline)
@@ -54,6 +58,9 @@ class AptamerEvalAptaNet(BaseAptamerEval):
         np.float64
             The probability score assigned to the aptamer candidate.
         """
-        score = self.pipeline.predict_proba(X=[(aptamer_candidate, self.target)])
+        X = MoleculeLoader(
+            data={"aptamer": [aptamer_candidate], "protein": [self.target]}
+        )
+        score = self.pipeline.predict_proba(X=X)
 
         return np.float64(score[:, 1].item())  # return the positive class probability

--- a/pyaptamer/experiments/tests/test_aptamer.py
+++ b/pyaptamer/experiments/tests/test_aptamer.py
@@ -1,6 +1,6 @@
 """Test suite for the AptamerEval experiment classes."""
 
-__author__ = ["nennomp"]
+__author__ = ["nennomp", "siddharth7113"]
 
 import numpy
 import pytest
@@ -41,9 +41,13 @@ class MockAptaNetPipeline:
         """
         Mock predict method that returns fixed scores for binary classification (no
         binding, binding).
+
+        ``X`` is a :class:`~pyaptamer.data.loader.MoleculeLoader`; materialize it
+        to learn how many pairs to score.
         """
+        n = len(X.to_dataframe())
         # return probability scores as a list
-        return numpy.array([[1 - self.fixed_score, self.fixed_score]] * len(X))
+        return numpy.array([[1 - self.fixed_score, self.fixed_score]] * n)
 
     def fit(self, X, y):
         """Mock fit method."""


### PR DESCRIPTION
LLM generated content, by Claude Opus 4.8

#### Reference Issues/PRs

Final PR of the MoleculeLoader stack. Stacks on #700 (PR3) — please review/merge that first; the base of this PR is `feat/molecule-loader-migrate-pipelines`.

#### What does this implement/fix? Explain your changes.

Threads the new `MoleculeLoader` through the last remaining consumers and the example notebooks.

- **`load_li2014`** now mirrors `load_aptacom`: a `return_X_y` flag. Default returns a single `MoleculeLoader` over `[aptamer, protein, label]`; `return_X_y=True` returns `(MoleculeLoader X, DataFrame y)`.
- **`AptamerEvalAptaNet`** builds a `MoleculeLoader` internally instead of a raw list of pairs, so it works with the now MoleculeLoader-only `PairsToFeatures` (this also fixes a doctest that broke in #700).
- **Notebooks** `aptanet_tutorial` and `aptanet_finetuning_tutorial` migrated off the removed `to_df_seq` / `pairs_to_features` APIs; the FASTA "predict from a fasta file" stub is now a real worked example using `tiling="samples"`.

`APIDataset` and `aptatrans_tutorial` are intentionally left untouched — that notebook is not affected by the redesign and `APIDataset` does real encoding (`rna2vec`/`encode_rna`/augmentation) that `MoleculeLoader` does not replace.

#### What should a reviewer concentrate their feedback on?

- The `load_li2014` signature change (`return_X_y`) and that it matches `load_aptacom`.
- Whether the FASTA worked example is the right way to showcase file-based input.

#### Did you add any tests for the change?

Yes:
- `test_li2014.py` rewritten for the `return_X_y` contract.
- `test_loader.py`: GenBank/EMBL dispatch and FASTA-column broadcast pairing against an in-memory column.
- `test_aptanet.py`: end-to-end check that a FASTA-sourced loader yields the same features as the in-memory loader.

Notebook cells were smoke-tested on small data (not a full `nbconvert` run, which trains for hours).

#### PR checklist

- [x] The PR title starts with [ENH].
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing.
