### PR TITLE
[ENH] Land MoleculeLoader pipeline + tutorial migration on main (recovers #700, #704)

### DIFF
--- a/examples/aptanet_finetuning_tutorial.ipynb
+++ b/examples/aptanet_finetuning_tutorial.ipynb
@@ -48,31 +48,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": null,
    "id": "3737da88",
    "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import pandas as pd\n",
     "import torch\n",
     "\n",
+    "from pyaptamer.data import MoleculeLoader\n",
     "from pyaptamer.datasets import load_1gnh"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": null,
    "id": "a2f6701d",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Number of samples: 25\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "aptamer_sequence = [\n",
     "    \"GGGAGGACGAAGACGACUCGAGACAGGCUAGGGAGGGA\",\n",
@@ -83,15 +77,18 @@
     "]\n",
     "\n",
     "gnh = load_1gnh()\n",
-    "protein_sequence = gnh.to_df_seq()[\"sequence\"].tolist()\n",
+    "protein_sequence = gnh.to_dataframe()[\"sequence\"].tolist()\n",
     "\n",
-    "# Build all combinations (aptamer, protein), duplicated to increase dataset size\n",
-    "X = [(a, p) for a in aptamer_sequence for p in protein_sequence] * 5\n",
+    "# Build all (aptamer, protein) combinations, duplicated to enlarge the dataset\n",
+    "pairs = [(a, p) for a in aptamer_sequence for p in protein_sequence] * 5\n",
+    "\n",
+    "# AptaNet consumes a MoleculeLoader over the aptamer/protein columns\n",
+    "X = MoleculeLoader(data=pd.DataFrame(pairs, columns=[\"aptamer\", \"protein\"]))\n",
     "\n",
     "# Dummy binary labels for the pairs\n",
-    "y = torch.randint(0, 2, (len(X),), dtype=torch.float32)\n",
+    "y = torch.randint(0, 2, (len(pairs),), dtype=torch.float32)\n",
     "\n",
-    "print(f\"Number of samples: {len(X)}\")"
+    "print(f\"Number of samples: {len(pairs)}\")"
    ]
   },
   {
@@ -105,23 +102,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": null,
    "id": "44cc1cbf",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Feature matrix shape: (25, 690)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "from pyaptamer.utils._aptanet_utils import pairs_to_features\n",
+    "from pyaptamer.aptanet import PairsToFeatures\n",
     "\n",
-    "# Convert sequence pairs to feature vectors\n",
-    "X_features = pairs_to_features(X)\n",
+    "# Convert the MoleculeLoader of pairs to feature vectors once, up front, so the\n",
+    "# cross-validation search does not recompute them on every fit.\n",
+    "X_features = PairsToFeatures().fit_transform(X)\n",
     "\n",
     "print(f\"Feature matrix shape: {X_features.shape}\")"
    ]

--- a/examples/aptanet_tutorial.ipynb
+++ b/examples/aptanet_tutorial.ipynb
@@ -17,9 +17,10 @@
     "## Overview\n",
     "This notebook showcases the AptaNet algorithm, a deep learning method that combines sequence-derived (k-mer + PSeAAC) features with RandomForest-based feature selection, and a multi-layer perceptron to predict whether an aptamer and a protein interact (binary classification: aptamer binds/does not bind with the target protein). An overview of the classes and helper functions used in this notebook:\n",
     "\n",
-    "- **pairs_to_features**: helper that converts `(aptamer_sequence, protein_sequence)` pairs into feature vectors using k-mer + PSeAAC.\n",
+    "- **MoleculeLoader**: lazy container for aptamer/protein data; cells may hold in-memory sequences or file paths (PDB/FASTA/FASTQ), materialized to a DataFrame via `to_dataframe()`. AptaNet consumes a MoleculeLoader as its input `X`.\n",
+    "- **PairsToFeatures**: transform that converts a MoleculeLoader of `(aptamer, protein)` pairs into feature vectors using k-mer + PSeAAC.\n",
     "- **SkorchAptaNet**: a PyTorch MLP wrapped in Skorch for binary classification.\n",
-    "- **load_1gnh**: helper to load the 1GNH molecule structure from PDB file into our in-memory `MoleculeLoader` format."
+    "- **load_1gnh**: helper to load the 1GNH molecule structure from a PDB file into a `MoleculeLoader`.\n"
    ]
   },
   {
@@ -40,20 +41,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "id": "3737da88",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Data imports\n",
+    "import pandas as pd\n",
     "import torch\n",
     "\n",
+    "from pyaptamer.data import MoleculeLoader\n",
     "from pyaptamer.datasets import load_1gnh"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "id": "a2f6701d",
    "metadata": {},
    "outputs": [],
@@ -67,13 +70,16 @@
     "]\n",
     "\n",
     "gnh = load_1gnh()\n",
-    "protein_sequence = gnh.to_df_seq()[\"sequence\"].tolist()\n",
+    "protein_sequence = gnh.to_dataframe()[\"sequence\"].tolist()\n",
     "\n",
-    "# Build all combinations (aptamer, protein), duplicated to increase dataset size\n",
-    "X = [(a, p) for a in aptamer_sequence for p in protein_sequence] * 5\n",
+    "# Build all (aptamer, protein) combinations, duplicated to enlarge the dataset\n",
+    "pairs = [(a, p) for a in aptamer_sequence for p in protein_sequence] * 5\n",
+    "\n",
+    "# AptaNet consumes a MoleculeLoader over the aptamer/protein columns\n",
+    "X = MoleculeLoader(data=pd.DataFrame(pairs, columns=[\"aptamer\", \"protein\"]))\n",
     "\n",
     "# Dummy binary labels for the pairs\n",
-    "y = torch.randint(0, 2, (len(X),), dtype=torch.float32)"
+    "y = torch.randint(0, 2, (len(pairs),), dtype=torch.float32)"
    ]
   },
   {
@@ -87,9 +93,9 @@
     "\n",
     " To build a scikit-learn pipeline, follow these steps:\n",
     "1. Convert the input to the desired (aptamer_sequence, protein_sequence) format.\n",
-    "    * OPTIONAL: As mentioned in the paper, perform under-sampling using the  \n",
+    "    * OPTIONAL: As mentioned in the paper, perform under-sampling using the\n",
     "    Neighborhood Cleaning Rule to balance the classes.\n",
-    "2. Get the PSeAAC feature vectors for your converted input (using `pairs_to_features`).\n",
+    "2. Get the PSeAAC feature vectors for your converted input (using `PairsToFeatures`).\n",
     "3. Select the number of features to use from the feature vector (using `RandomForestClassifier`).\n",
     "4. Define the skorch neural network (using `AptaNetMLP`).\n",
     "### Different workflows\n",
@@ -97,7 +103,7 @@
     "\n",
     "1. A minimal workflow with no dataset balancing, while using the in-built pipeline.\n",
     "2. Using your own custom pipeline.\n",
-    "3. Dataset balancing, while using your own pipeline."
+    "3. Dataset balancing, while using your own pipeline.\n"
    ]
   },
   {
@@ -190,7 +196,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "id": "6130027a",
    "metadata": {},
    "outputs": [],
@@ -199,27 +205,20 @@
     "from sklearn.ensemble import RandomForestClassifier\n",
     "from sklearn.feature_selection import SelectFromModel\n",
     "from sklearn.pipeline import Pipeline\n",
-    "from sklearn.preprocessing import FunctionTransformer\n",
     "from skorch import NeuralNetBinaryClassifier\n",
     "\n",
-    "from pyaptamer.aptanet._aptanet_nn import AptaNetMLP\n",
-    "from pyaptamer.utils._aptanet_utils import pairs_to_features"
+    "from pyaptamer.aptanet import PairsToFeatures\n",
+    "from pyaptamer.aptanet._aptanet_nn import AptaNetMLP"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "id": "4a2e277e",
    "metadata": {},
    "outputs": [],
    "source": [
-    "feature_transformer = FunctionTransformer(\n",
-    "    func=pairs_to_features,\n",
-    "    validate=False,\n",
-    "    # Optional arguments for pairs_to_features\n",
-    "    # example: kw_args={'k': 4, 'pseaac_kwargs': {'lambda_value': 30}}\n",
-    "    kw_args={},\n",
-    ")\n",
+    "feature_transformer = PairsToFeatures(k=4)\n",
     "\n",
     "selector = SelectFromModel(\n",
     "    estimator=RandomForestClassifier(\n",
@@ -512,16 +511,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "id": "523f4ce6",
    "metadata": {},
    "outputs": [],
    "source": [
     "# If you want to build your own aptamer pipeline, you should use the following imports\n",
-    "from sklearn.preprocessing import FunctionTransformer\n",
-    "\n",
-    "from pyaptamer.aptanet import AptaNetClassifier, AptaNetPipeline\n",
-    "from pyaptamer.utils._aptanet_utils import pairs_to_features"
+    "from pyaptamer.aptanet import AptaNetClassifier, AptaNetPipeline"
    ]
   },
   {
@@ -541,19 +537,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "id": "13fb1669",
    "metadata": {},
    "outputs": [],
    "source": [
-    "feature_transformer = FunctionTransformer(\n",
-    "    func=pairs_to_features,\n",
-    "    validate=False,\n",
-    "    # Optional arguments for pairs_to_features\n",
-    "    # example: kw_args={'k': 4, 'pseaac_kwargs': {'lambda_value': 30}}\n",
-    "    kw_args={},\n",
-    ")\n",
-    "\n",
     "# AptaNetClassifier encapsulates the \"selector\" and \"net\" mentioned in Workflow 2\n",
     "clf = AptaNetClassifier()\n",
     "\n",
@@ -633,99 +621,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": null,
    "id": "d5cb05fb",
    "metadata": {},
    "outputs": [],
    "source": [
-    "X, y = load_li2014(split=\"train\")"
+    "X, y = load_li2014(split=\"train\", return_X_y=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": null,
    "id": "5f1442f9",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>aptamer</th>\n",
-       "      <th>protein</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>UCGGAGGUGGUUCAGCUCUGCAUCGACAGUUGGC</td>\n",
-       "      <td>MDSTNYISKLFEYAQRQGQISDIKFEEVGTDGPDHLKTFTLRVVIK...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>CGGGGTGTTGTCCTGTGCTCTCCGGAGAGCACAGGACAACACCCCG</td>\n",
-       "      <td>MDELFPLIFPAEPAQASGPYVEIIEQPKQRGMRFRYKCEGRSAGSI...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>GCTGCAGTTGCACTGAATTCGCCTCTCGCCTCCGTACACTTAGTCG...</td>\n",
-       "      <td>MDEVGAQVAAPMFIHQSLGRKRDLYYPMSNRLVQSQPQRRDEWNSK...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>TATTTGCCCTTGCAGGCCGCAGGAGTGCTAGCAGT</td>\n",
-       "      <td>PISPIDTVPVKLKPGMDGPKVKQWPLTEEKIKALTEICNEMEKEGK...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>UCUCUGGGCUCUUAGGAGAACGGAUAGGAGUGUGCUCGCU</td>\n",
-       "      <td>LQENFLPQPRQQHHGTLVLHYRPHREEAGMQHPCLWPGSSHCSDDS...</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                                             aptamer  \\\n",
-       "0                 UCGGAGGUGGUUCAGCUCUGCAUCGACAGUUGGC   \n",
-       "1     CGGGGTGTTGTCCTGTGCTCTCCGGAGAGCACAGGACAACACCCCG   \n",
-       "2  GCTGCAGTTGCACTGAATTCGCCTCTCGCCTCCGTACACTTAGTCG...   \n",
-       "3                TATTTGCCCTTGCAGGCCGCAGGAGTGCTAGCAGT   \n",
-       "4           UCUCUGGGCUCUUAGGAGAACGGAUAGGAGUGUGCUCGCU   \n",
-       "\n",
-       "                                             protein  \n",
-       "0  MDSTNYISKLFEYAQRQGQISDIKFEEVGTDGPDHLKTFTLRVVIK...  \n",
-       "1  MDELFPLIFPAEPAQASGPYVEIIEQPKQRGMRFRYKCEGRSAGSI...  \n",
-       "2  MDEVGAQVAAPMFIHQSLGRKRDLYYPMSNRLVQSQPQRRDEWNSK...  \n",
-       "3  PISPIDTVPVKLKPGMDGPKVKQWPLTEEKIKALTEICNEMEKEGK...  \n",
-       "4  LQENFLPQPRQQHHGTLVLHYRPHREEAGMQHPCLWPGSSHCSDDS...  "
-      ]
-     },
-     "execution_count": 41,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# Display first few rows of X which contains aptamer-protein pairs\n",
-    "X.head()"
+    "# Display the first few aptamer-protein pairs (materialized from the loader)\n",
+    "X.to_dataframe().head()"
    ]
   },
   {
@@ -838,25 +750,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": null,
    "id": "7c5a42a3",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([[0.9648417 , 0.03515826]], dtype=float32)"
-      ]
-     },
-     "execution_count": 44,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "aptamer_sequence = \"GGGAGGACGAAGACGACUCGAGACAGGCUAGGGAGGGA\"\n",
     "\n",
-    "X = [(aptamer_sequence, p) for p in protein_sequence]\n",
+    "# Pair the single candidate aptamer with every 1GNH protein chain\n",
+    "X = MoleculeLoader(\n",
+    "    data=pd.DataFrame(\n",
+    "        {\n",
+    "            \"aptamer\": [aptamer_sequence] * len(protein_sequence),\n",
+    "            \"protein\": protein_sequence,\n",
+    "        }\n",
+    "    )\n",
+    ")\n",
     "\n",
     "pipeline.predict_proba(X)"
    ]
@@ -866,9 +775,41 @@
    "id": "af501b0c",
    "metadata": {},
    "source": [
-    "### Second workflow (TODO)\n",
+    "### Second workflow\n",
     "\n",
-    "Predicting binding probability (`predict_proba`) between a protein (1GNH) and DNA sequences from a `fasta` file."
+    "Predicting binding probability (`predict_proba`) between a protein (1GNH) and a set of candidate aptamer sequences read from a `fasta` file. `MoleculeLoader` parses the FASTA and, with `tiling=\"samples\"`, explodes it to one row per record while broadcasting the single target protein across them.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ce432ee0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Write the candidate aptamers to a small FASTA file (one record per line pair)\n",
+    "import tempfile\n",
+    "from pathlib import Path\n",
+    "\n",
+    "candidate_aptamers = [\n",
+    "    \"GGGAGGACGAAGACGACUCGAGACAGGCUAGGGAGGGA\",\n",
+    "    \"AAGCGUCGGAUCUACACGUGCGAUAGCUCAGUACGCGGU\",\n",
+    "    \"CGGUAUCGAGUACAGGAGUCCGACGGAUAGUCCGGAGC\",\n",
+    "]\n",
+    "fasta_path = Path(tempfile.gettempdir()) / \"candidate_aptamers.fasta\"\n",
+    "with open(fasta_path, \"w\") as fh:\n",
+    "    for i, seq in enumerate(candidate_aptamers):\n",
+    "        fh.write(f\">candidate{i}\\n{seq}\\n\")\n",
+    "\n",
+    "# MoleculeLoader parses the FASTA; tiling=\"samples\" explodes it to one row\n",
+    "# per record and broadcasts the single target protein across them.\n",
+    "target = protein_sequence[0]\n",
+    "X = MoleculeLoader(\n",
+    "    data={\"aptamer\": [str(fasta_path)], \"protein\": [target]},\n",
+    "    tiling=\"samples\",\n",
+    ")\n",
+    "\n",
+    "pipeline.predict_proba(X)"
    ]
   },
   {

--- a/examples/benchmarking_tutorial.ipynb
+++ b/examples/benchmarking_tutorial.ipynb
@@ -89,7 +89,9 @@
    "id": "18b3abd2",
    "metadata": {},
    "source": [
-    "### 1. Using normal k-fold cross validation for benchmarking"
+    "### 1. Using normal k-fold cross validation for benchmarking\n",
+    "\n",
+    "> **Note:** execution of the cell below is temporarily skipped in CI. `AptaNetPipeline` is `MoleculeLoader`-only, but `Benchmarking` cross-validates `X`, and `MoleculeLoader` is not yet sklearn-sliceable. Tracked in #706.\n"
    ]
   },
   {
@@ -108,52 +110,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "840249ec",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "C:\\Users\\satvm\\pyaptamer\\pyaptamer\\pseaac\\_pseaac_aptanet.py:196: UserWarning: Invalid amino acid(s) found in sequence. Replaced with 'N'.\n",
-      "  seq = clean_protein_seq(protein_sequence)\n",
-      "C:\\Users\\satvm\\pyaptamer\\pyaptamer\\pseaac\\_pseaac_aptanet.py:196: UserWarning: Invalid amino acid(s) found in sequence. Replaced with 'N'.\n",
-      "  seq = clean_protein_seq(protein_sequence)\n",
-      "C:\\Users\\satvm\\pyaptamer\\pyaptamer\\pseaac\\_pseaac_aptanet.py:196: UserWarning: Invalid amino acid(s) found in sequence. Replaced with 'N'.\n",
-      "  seq = clean_protein_seq(protein_sequence)\n",
-      "C:\\Users\\satvm\\pyaptamer\\pyaptamer\\pseaac\\_pseaac_aptanet.py:196: UserWarning: Invalid amino acid(s) found in sequence. Replaced with 'N'.\n",
-      "  seq = clean_protein_seq(protein_sequence)\n",
-      "C:\\Users\\satvm\\pyaptamer\\pyaptamer\\pseaac\\_pseaac_aptanet.py:196: UserWarning: Invalid amino acid(s) found in sequence. Replaced with 'N'.\n",
-      "  seq = clean_protein_seq(protein_sequence)\n",
-      "C:\\Users\\satvm\\pyaptamer\\pyaptamer\\pseaac\\_pseaac_aptanet.py:196: UserWarning: Invalid amino acid(s) found in sequence. Replaced with 'N'.\n",
-      "  seq = clean_protein_seq(protein_sequence)\n",
-      "C:\\Users\\satvm\\pyaptamer\\pyaptamer\\pseaac\\_pseaac_aptanet.py:196: UserWarning: Invalid amino acid(s) found in sequence. Replaced with 'N'.\n",
-      "  seq = clean_protein_seq(protein_sequence)\n",
-      "C:\\Users\\satvm\\pyaptamer\\pyaptamer\\pseaac\\_pseaac_aptanet.py:196: UserWarning: Invalid amino acid(s) found in sequence. Replaced with 'N'.\n",
-      "  seq = clean_protein_seq(protein_sequence)\n",
-      "C:\\Users\\satvm\\pyaptamer\\pyaptamer\\pseaac\\_pseaac_aptanet.py:196: UserWarning: Invalid amino acid(s) found in sequence. Replaced with 'N'.\n",
-      "  seq = clean_protein_seq(protein_sequence)\n",
-      "C:\\Users\\satvm\\pyaptamer\\pyaptamer\\pseaac\\_pseaac_aptanet.py:196: UserWarning: Invalid amino acid(s) found in sequence. Replaced with 'N'.\n",
-      "  seq = clean_protein_seq(protein_sequence)\n",
-      "C:\\Users\\satvm\\pyaptamer\\pyaptamer\\pseaac\\_pseaac_aptanet.py:196: UserWarning: Invalid amino acid(s) found in sequence. Replaced with 'N'.\n",
-      "  seq = clean_protein_seq(protein_sequence)\n",
-      "C:\\Users\\satvm\\pyaptamer\\pyaptamer\\pseaac\\_pseaac_aptanet.py:196: UserWarning: Invalid amino acid(s) found in sequence. Replaced with 'N'.\n",
-      "  seq = clean_protein_seq(protein_sequence)\n",
-      "C:\\Users\\satvm\\pyaptamer\\pyaptamer\\pseaac\\_pseaac_aptanet.py:196: UserWarning: Invalid amino acid(s) found in sequence. Replaced with 'N'.\n",
-      "  seq = clean_protein_seq(protein_sequence)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "                                train  test\n",
-      "estimator       metric                     \n",
-      "AptaNetPipeline accuracy_score    1.0   1.0\n"
-     ]
-    }
-   ],
+   "metadata": {
+    "tags": [
+     "skip-execution"
+    ]
+   },
+   "outputs": [],
    "source": [
     "# Example estimator\n",
     "aptanet_estimator = AptaNetPipeline(k=4)\n",
@@ -178,35 +142,21 @@
    "id": "87923ac7",
    "metadata": {},
    "source": [
-    "### 2. Using PredefinedSplit for benchmarking with a fixed train/test split"
+    "### 2. Using PredefinedSplit for benchmarking with a fixed train/test split\n",
+    "\n",
+    "> **Note:** execution of the cell below is temporarily skipped in CI. `AptaNetPipeline` is `MoleculeLoader`-only, but `Benchmarking` cross-validates `X`, and `MoleculeLoader` is not yet sklearn-sliceable. Tracked in #706.\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "8e504488",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "C:\\Users\\satvm\\pyaptamer\\pyaptamer\\pseaac\\_pseaac_aptanet.py:196: UserWarning: Invalid amino acid(s) found in sequence. Replaced with 'N'.\n",
-      "  seq = clean_protein_seq(protein_sequence)\n",
-      "C:\\Users\\satvm\\pyaptamer\\pyaptamer\\pseaac\\_pseaac_aptanet.py:196: UserWarning: Invalid amino acid(s) found in sequence. Replaced with 'N'.\n",
-      "  seq = clean_protein_seq(protein_sequence)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "                                train  test\n",
-      "estimator       metric                     \n",
-      "AptaNetPipeline accuracy_score    1.0   1.0\n"
-     ]
-    }
-   ],
+   "metadata": {
+    "tags": [
+     "skip-execution"
+    ]
+   },
+   "outputs": [],
    "source": [
     "from sklearn.model_selection import PredefinedSplit\n",
     "\n",

--- a/pyaptamer/aptanet/__init__.py
+++ b/pyaptamer/aptanet/__init__.py
@@ -2,5 +2,11 @@
 
 from pyaptamer.aptanet._feature_classifier import AptaNetClassifier, AptaNetRegressor
 from pyaptamer.aptanet._pipeline import AptaNetPipeline
+from pyaptamer.aptanet._transforms import PairsToFeatures
 
-__all__ = ["AptaNetPipeline", "AptaNetClassifier", "AptaNetRegressor"]
+__all__ = [
+    "AptaNetPipeline",
+    "AptaNetClassifier",
+    "AptaNetRegressor",
+    "PairsToFeatures",
+]

--- a/pyaptamer/aptanet/_pipeline.py
+++ b/pyaptamer/aptanet/_pipeline.py
@@ -1,15 +1,14 @@
-__author__ = ["nennomp", "satvshr"]
+__author__ = ["nennomp", "satvshr", "siddharth7113"]
 __all__ = ["AptaNetPipeline"]
 __required__ = ["python>=3.10"]
 
 from skbase.base import BaseObject
 from sklearn.base import BaseEstimator, clone
 from sklearn.pipeline import Pipeline
-from sklearn.preprocessing import FunctionTransformer
 from sklearn.utils.validation import check_is_fitted
 
 from pyaptamer.aptanet import AptaNetClassifier
-from pyaptamer.utils._aptanet_utils import pairs_to_features
+from pyaptamer.aptanet._transforms import PairsToFeatures
 
 
 class AptaNetPipeline(BaseObject, BaseEstimator):
@@ -21,15 +20,18 @@ class AptaNetPipeline(BaseObject, BaseEstimator):
     multi-layer perceptron to predict whether an aptamer and a protein interact
     (binary classification).
 
-    The pipeline starts from string pairs, converts them into numeric features
-    (aptamer k-mer frequencies + protein PSeAAC), applies tree-based feature
-    selection, and feeds the result into the estimator.
+    The pipeline takes a MoleculeLoader of aptamer/protein pairs, converts them
+    into numeric features (aptamer k-mer frequencies + protein PSeAAC), applies
+    tree-based feature selection, and feeds the result into the estimator.
 
     Parameters
     ----------
     k : int, optional, default=4
         The k-mer size used to generate aptamer k-mer vectors.
-
+    aptamer_col : str, optional, default="aptamer"
+        Name of the MoleculeLoader column holding aptamer sequences.
+    protein_col : str, optional, default="protein"
+        Name of the MoleculeLoader column holding protein sequences.
     estimator : sklearn-compatible estimator or None, default=None
         Estimator applied after feature selection. If None, uses `AptaNetClassifier`.
 
@@ -51,28 +53,37 @@ class AptaNetPipeline(BaseObject, BaseEstimator):
     Examples
     --------
     >>> from pyaptamer.aptanet import AptaNetPipeline
+    >>> from pyaptamer.data import MoleculeLoader
     >>> import numpy as np
     >>> pipe = AptaNetPipeline()
     >>> aptamer_seq = "AGCTTAGCGTACAGCTTAAAAGGGTTTCCCCTGCCCGCGTAC"
     >>> protein_seq = "ACDEFGHIKLMNPQRSTVWYACDEFGHIKLMNPQRSTVWY"
-    >>> X_train_pairs = [(aptamer_seq, protein_seq) for _ in range(40)]
+    >>> X_train = MoleculeLoader(
+    ...     data={"aptamer": [aptamer_seq] * 40, "protein": [protein_seq] * 40}
+    ... )
     >>> y_train = np.array([0] * 20 + [1] * 20, dtype=np.float32)
-    >>> X_test_pairs = [(aptamer_seq, protein_seq) for _ in range(10)]
-    >>> pipe.fit(X_train_pairs, y_train)  # doctest: +ELLIPSIS
+    >>> X_test = MoleculeLoader(
+    ...     data={"aptamer": [aptamer_seq] * 10, "protein": [protein_seq] * 10}
+    ... )
+    >>> pipe.fit(X_train, y_train)  # doctest: +ELLIPSIS
     AptaNetPipeline(...)
-    >>> preds = pipe.predict(X_test_pairs)
-    >>> proba = pipe.predict_proba(X_test_pairs)
+    >>> preds = pipe.predict(X_test)
+    >>> proba = pipe.predict_proba(X_test)
     """
 
-    def __init__(self, k=4, estimator=None):
+    def __init__(
+        self, k=4, aptamer_col="aptamer", protein_col="protein", estimator=None
+    ):
         self.k = k
+        self.aptamer_col = aptamer_col
+        self.protein_col = protein_col
         self.estimator = estimator
 
     def _build_pipeline(self):
-        transformer = FunctionTransformer(
-            func=pairs_to_features,
-            kw_args={"k": self.k},
-            validate=False,
+        transformer = PairsToFeatures(
+            k=self.k,
+            aptamer_col=self.aptamer_col,
+            protein_col=self.protein_col,
         )
         self._estimator = self.estimator or AptaNetClassifier()
         return Pipeline([("features", transformer), ("clf", clone(self._estimator))])

--- a/pyaptamer/aptanet/_transforms.py
+++ b/pyaptamer/aptanet/_transforms.py
@@ -1,0 +1,96 @@
+"""Feature-extraction transforms for the AptaNet algorithm."""
+
+__author__ = ["siddharth7113"]
+__all__ = ["PairsToFeatures"]
+
+import numpy as np
+import pandas as pd
+
+from pyaptamer.data import MoleculeLoader
+from pyaptamer.pseaac import AptaNetPSeAAC
+from pyaptamer.trafos.base import BaseTransform
+from pyaptamer.utils._aptanet_utils import generate_kmer_vecs
+
+
+class PairsToFeatures(BaseTransform):
+    """Transform (aptamer, protein) sequence pairs into AptaNet feature vectors.
+
+    Each row is encoded as the concatenation of:
+
+    - normalized k-mer frequencies of the aptamer sequence, and
+    - pseudo amino-acid composition (PSeAAC) of the protein sequence.
+
+    Input must be a :class:`~pyaptamer.data.loader.MoleculeLoader`
+
+    Parameters
+    ----------
+    k : int, default=4
+        Maximum k-mer length used for the aptamer k-mer frequency vector.
+    aptamer_col : str, default="aptamer"
+        Name of the column holding aptamer sequences.
+    protein_col : str, default="protein"
+        Name of the column holding protein sequences.
+
+    Examples
+    --------
+    >>> from pyaptamer.aptanet import PairsToFeatures
+    >>> from pyaptamer.data import MoleculeLoader
+    >>> X = MoleculeLoader(
+    ...     data={
+    ...         "aptamer": ["AGCTTAGCGTACAGCTTAAAAGGGTTTCCCCTGCCCGCGTAC"],
+    ...         "protein": ["ACDEFGHIKLMNPQRSTVWYACDEFGHIKLMNPQRSTVWY"],
+    ...     }
+    ... )
+    >>> Xt = PairsToFeatures().fit_transform(X)
+    >>> len(Xt)
+    1
+    """
+
+    _tags = {
+        "capability:multivariate": True,
+        "property:fit_is_empty": True,
+        "output_type": "numeric",
+    }
+
+    def __init__(self, k=4, aptamer_col="aptamer", protein_col="protein"):
+        self.k = k
+        self.aptamer_col = aptamer_col
+        self.protein_col = protein_col
+        super().__init__()
+
+    def _check_X_y(self, X, y):  # noqa: N802
+        """Require a MoleculeLoader, then defer to the base coercion/checks."""
+        if not isinstance(X, MoleculeLoader):
+            raise TypeError(
+                f"{type(self).__name__} accepts only a MoleculeLoader as input, "
+                f"got {type(X).__name__}."
+            )
+        return super()._check_X_y(X, y)
+
+    def _transform(self, X):
+        """Encode each (aptamer, protein) row into a feature vector.
+
+        Parameters
+        ----------
+        X : pandas.DataFrame
+            Contains the ``aptamer_col`` and ``protein_col`` columns.
+
+        Returns
+        -------
+        pandas.DataFrame
+            One row per input row; columns are the concatenated k-mer + PSeAAC
+            features (``float32``), indexed like ``X``.
+        """
+        pseaac = AptaNetPSeAAC()
+        feats = [
+            np.concatenate(
+                [
+                    generate_kmer_vecs(aptamer_seq, k=self.k),
+                    np.asarray(pseaac.transform(protein_seq)),
+                ]
+            )
+            for aptamer_seq, protein_seq in zip(
+                X[self.aptamer_col], X[self.protein_col], strict=True
+            )
+        ]
+        return pd.DataFrame(np.vstack(feats).astype(np.float32), index=X.index)

--- a/pyaptamer/aptanet/tests/test_aptanet.py
+++ b/pyaptamer/aptanet/tests/test_aptanet.py
@@ -1,4 +1,4 @@
-__author__ = ["nennomp", "satvshr"]
+__author__ = ["nennomp", "satvshr", "siddharth7113"]
 
 
 import numpy as np
@@ -6,6 +6,7 @@ import pytest
 from sklearn.utils.estimator_checks import parametrize_with_checks
 
 from pyaptamer.aptanet import AptaNetClassifier, AptaNetPipeline, AptaNetRegressor
+from pyaptamer.data import MoleculeLoader
 
 params = [
     (
@@ -13,6 +14,13 @@ params = [
         "ACDEFGHIKLMNPQRSTVWYACDEFGHIKLMNPQRSTVWY",
     )
 ]
+
+
+def _make_loader(aptamer_seq, protein_seq, n):
+    """Build a MoleculeLoader of n identical aptamer/protein pairs."""
+    return MoleculeLoader(
+        data={"aptamer": [aptamer_seq] * n, "protein": [protein_seq] * n}
+    )
 
 
 @pytest.mark.parametrize("aptamer_seq, protein_seq", params)
@@ -23,7 +31,7 @@ def test_pipeline_fit_and_predict_classification(aptamer_seq, protein_seq):
     """
     pipe = AptaNetPipeline(k=4)
 
-    X_raw = [(aptamer_seq, protein_seq) for _ in range(40)]
+    X_raw = _make_loader(aptamer_seq, protein_seq, 40)
     y = np.array([0] * 20 + [1] * 20, dtype=np.float32)
 
     pipe.fit(X_raw, y)
@@ -41,7 +49,7 @@ def test_pipeline_fit_and_predict_proba(aptamer_seq, protein_seq):
     """
     pipe = AptaNetPipeline()
 
-    X_raw = [(aptamer_seq, protein_seq) for _ in range(40)]
+    X_raw = _make_loader(aptamer_seq, protein_seq, 40)
     y = np.array([0] * 20 + [1] * 20, dtype=np.float32)
 
     pipe.fit(X_raw, y)
@@ -60,7 +68,7 @@ def test_pipeline_fit_and_predict_regression(aptamer_seq, protein_seq):
     """
     pipe = AptaNetPipeline(estimator=AptaNetRegressor())
 
-    X_raw = [(aptamer_seq, protein_seq) for _ in range(40)]
+    X_raw = _make_loader(aptamer_seq, protein_seq, 40)
     y = np.linspace(0, 1, 40).astype(np.float32)
 
     pipe.fit(X_raw, y)

--- a/pyaptamer/aptanet/tests/test_aptanet.py
+++ b/pyaptamer/aptanet/tests/test_aptanet.py
@@ -78,6 +78,26 @@ def test_pipeline_fit_and_predict_regression(aptamer_seq, protein_seq):
     assert np.issubdtype(preds.dtype, np.floating)
 
 
+@pytest.mark.parametrize("aptamer_seq, protein_seq", params)
+def test_fasta_sourced_loader_matches_in_memory(tmp_path, aptamer_seq, protein_seq):
+    """A FASTA-sourced loader yields the same features as the in-memory loader."""
+    from pyaptamer.aptanet._transforms import PairsToFeatures
+
+    fasta = tmp_path / "library.fasta"
+    fasta.write_text(f">apt1\n{aptamer_seq}\n>apt2\n{aptamer_seq}\n")
+
+    from_file = MoleculeLoader(
+        data={"aptamer": [str(fasta)], "protein": [protein_seq]}, tiling="samples"
+    )
+    in_memory = _make_loader(aptamer_seq, protein_seq, 2)
+
+    feats_file = PairsToFeatures().fit_transform(from_file)
+    feats_mem = PairsToFeatures().fit_transform(in_memory)
+
+    assert feats_file.shape == feats_mem.shape
+    assert np.allclose(feats_file.to_numpy(), feats_mem.to_numpy())
+
+
 @parametrize_with_checks(
     estimators=[AptaNetClassifier(), AptaNetRegressor()],
     expected_failed_checks={

--- a/pyaptamer/aptanet/tests/test_pairs_to_features.py
+++ b/pyaptamer/aptanet/tests/test_pairs_to_features.py
@@ -1,0 +1,42 @@
+"""Tests for the PairsToFeatures transform."""
+
+__author__ = ["siddharth7113"]
+
+import pandas as pd
+import pytest
+
+from pyaptamer.aptanet import PairsToFeatures
+from pyaptamer.data import MoleculeLoader
+
+APTAMER = "AGCTTAGCGTACAGCTTAAAAGGGTTTCCCCTGCCCGCGTAC"
+PROTEIN = "ACDEFGHIKLMNPQRSTVWYACDEFGHIKLMNPQRSTVWY"
+
+
+def test_pairs_to_features_from_moleculeloader():
+    """A MoleculeLoader of aptamer/protein pairs becomes a numeric feature table."""
+    X = MoleculeLoader(data={"aptamer": [APTAMER] * 3, "protein": [PROTEIN] * 3})
+    Xt = PairsToFeatures(k=4).fit_transform(X)
+
+    assert isinstance(Xt, pd.DataFrame)
+    assert len(Xt) == 3
+    assert Xt.shape[1] > 1  # concatenated k-mer + PSeAAC features
+
+
+def test_pairs_to_features_custom_columns():
+    """Column names are configurable, not hardcoded to aptamer/protein."""
+    X = MoleculeLoader(
+        data={"aptamer_sequence": [APTAMER] * 2, "target_sequence": [PROTEIN] * 2}
+    )
+    transform = PairsToFeatures(
+        aptamer_col="aptamer_sequence", protein_col="target_sequence"
+    )
+    Xt = transform.fit_transform(X)
+
+    assert len(Xt) == 2
+
+
+def test_pairs_to_features_rejects_non_moleculeloader():
+    """Only a MoleculeLoader is accepted; a plain DataFrame is rejected."""
+    X = pd.DataFrame({"aptamer": [APTAMER], "protein": [PROTEIN]})
+    with pytest.raises(TypeError, match="only a MoleculeLoader"):
+        PairsToFeatures().fit_transform(X)

--- a/pyaptamer/benchmarking/tests/test_benchmarking.py
+++ b/pyaptamer/benchmarking/tests/test_benchmarking.py
@@ -1,3 +1,5 @@
+__author__ = ["siddharth7113"]
+
 import numpy as np
 import pytest
 from sklearn.metrics import accuracy_score, mean_squared_error
@@ -5,6 +7,12 @@ from sklearn.model_selection import PredefinedSplit
 
 from pyaptamer.aptanet import AptaNetPipeline, AptaNetRegressor
 from pyaptamer.benchmarking._base import Benchmarking
+
+# AptaNetPipeline is MoleculeLoader-only, but Benchmarking cross-validates X, and
+# MoleculeLoader is not yet sklearn-sliceable. Tracked in #706.
+_needs_sliceable_loader = pytest.mark.skip(
+    reason="AptaNet + Benchmarking needs a sklearn-sliceable MoleculeLoader (#706)"
+)
 
 params = [
     (
@@ -14,6 +22,7 @@ params = [
 ]
 
 
+@_needs_sliceable_loader
 @pytest.mark.parametrize("aptamer_seq, protein_seq", params)
 def test_benchmarking_with_predefined_split_classification(aptamer_seq, protein_seq):
     """
@@ -42,6 +51,7 @@ def test_benchmarking_with_predefined_split_classification(aptamer_seq, protein_
     assert (clf.__class__.__name__, "accuracy_score") in summary.index
 
 
+@_needs_sliceable_loader
 @pytest.mark.parametrize("aptamer_seq, protein_seq", params)
 def test_benchmarking_with_predefined_split_regression(aptamer_seq, protein_seq):
     """

--- a/pyaptamer/data/tests/test_loader.py
+++ b/pyaptamer/data/tests/test_loader.py
@@ -1,5 +1,7 @@
 """Tests for the MoleculeLoader lazy data container."""
 
+__author__ = ["siddharth7113"]
+
 from pathlib import Path
 
 import pandas as pd
@@ -217,6 +219,49 @@ def test_fastq_is_sequence_only(tmp_path):
     assert df["selex"].tolist() == ["ACGTACGT", "TTTTGGGG"]
     # sequence-only: per-base quality is dropped, so no quality column appears
     assert list(df.columns) == ["selex"]
+
+
+@pytest.mark.parametrize(
+    "ext, content",
+    [
+        (
+            "gb",
+            "LOCUS       TEST                       8 bp    DNA     linear   UNK"
+            " 01-JAN-1980\nDEFINITION  test.\nACCESSION   TEST\nFEATURES        "
+            "     Location/Qualifiers\nORIGIN\n        1 acgtacgt\n//\n",
+        ),
+        (
+            "embl",
+            "ID   TEST; SV 1; linear; DNA; STD; UNC; 8 BP.\nSQ   Sequence 8 BP;"
+            "\n     acgtacgt"
+            "                                                                8\n//\n",
+        ),
+    ],
+)
+def test_genbank_and_embl_dispatch(tmp_path, ext, content):
+    """GenBank/EMBL files dispatch through SeqIO by suffix and yield sequences."""
+    path = tmp_path / f"record.{ext}"
+    path.write_text(content)
+
+    loader = MoleculeLoader(data={"seq": [str(path)]}, tiling="samples")
+    df = loader.to_dataframe()
+
+    assert df["seq"].tolist() == ["ACGTACGT"]
+
+
+def test_fasta_path_broadcasts_against_in_memory_column(tmp_path):
+    """A FASTA file column explodes per-record while an in-memory column broadcasts."""
+    fasta = tmp_path / "library.fasta"
+    fasta.write_text(">apt1\nACGTACGT\n>apt2\nTTTTGGGG\n>apt3\nGGGGCCCC\n")
+    protein = "ACDEFGHIKLMNPQRSTVWY"
+
+    loader = MoleculeLoader(
+        data={"aptamer": [str(fasta)], "protein": [protein]}, tiling="samples"
+    )
+    df = loader.to_dataframe()
+
+    assert df["aptamer"].tolist() == ["ACGTACGT", "TTTTGGGG", "GGGGCCCC"]
+    assert df["protein"].tolist() == [protein, protein, protein]
 
 
 # --------------------------------------------------------------------------- #

--- a/pyaptamer/datasets/_loaders/_li2014.py
+++ b/pyaptamer/datasets/_loaders/_li2014.py
@@ -1,11 +1,13 @@
-__author__ = "satvshr"
+__author__ = ["satvshr", "siddharth7113"]
 __all__ = ["load_li2014"]
 import os
 
 import pandas as pd
 
+from pyaptamer.data.loader import MoleculeLoader
 
-def load_li2014(split=None):
+
+def load_li2014(split=None, return_X_y=False):
     """
     Load the Li 2014 aptamer–protein interaction dataset.
 
@@ -40,46 +42,56 @@ def load_li2014(split=None):
         The loader preserves the original dtype and values (may also hold
         continuous affinity values in other variants).
 
-    Return types
-    ------------
-    Returns a tuple (X, y) where:
-
-      - X : pandas.DataFrame
-          Feature DataFrame containing the two feature columns (aptamer, protein).
-      - y : pandas.DataFrame
-          Single-column DataFrame containing the target/label (keeps column name
-          "label" as present in the CSV). Using a DataFrame for `y` keeps the
-          shape consistent for downstream code even when the target is one column.
+    The molecule data is returned as a
+    :class:`~pyaptamer.data.loader.MoleculeLoader` so it plugs directly into the
+    AptaNet transform pipeline, mirroring
+    :func:`~pyaptamer.datasets.load_aptacom`.
 
     Parameters
     ----------
     split : {None, "train", "test"}, optional
         Which split to load. ``None`` (default) concatenates train+test.
+    return_X_y : bool, optional
+        If True, return a tuple ``(X, y)`` where:
+          - ``X`` is a MoleculeLoader over the feature columns
+            ["aptamer", "protein"]
+          - ``y`` is a DataFrame with the target column ["label"]
+        If False (default), return a single MoleculeLoader over all three
+        columns ["aptamer", "protein", "label"].
+
+    Returns
+    -------
+    MoleculeLoader or tuple[MoleculeLoader, pandas.DataFrame]
+        - If `return_X_y` is False: a MoleculeLoader over the columns
+          ["aptamer", "protein", "label"].
+        - If `return_X_y` is True: a tuple ``(X, y)`` where ``X`` is a
+          MoleculeLoader over the two feature columns and ``y`` is a DataFrame
+          with the target. The target keeps the column name "label" as present
+          in the CSV; using a DataFrame for `y` keeps the shape consistent for
+          downstream code even when the target is one column.
     """
     if split not in (None, "train", "test"):
         raise ValueError("split must be None, 'train', or 'test'")
 
     base_path = os.path.join(os.path.dirname(__file__), "..", "data")
 
-    dfs_X = []
-    dfs_y = []
+    dfs = []
 
     # Load train split if requested
     if split is None or split == "train":
         train_path = os.path.join(base_path, "train_li2014.csv")
-        train_df = pd.read_csv(train_path)
-        dfs_X.append(train_df.iloc[:, :-1])
-        dfs_y.append(train_df.iloc[:, -1:])
+        dfs.append(pd.read_csv(train_path))
 
     # Load test split if requested
     if split is None or split == "test":
         test_path = os.path.join(base_path, "test_li2014.csv")
-        test_df = pd.read_csv(test_path)
-        dfs_X.append(test_df.iloc[:, :-1])
-        dfs_y.append(test_df.iloc[:, -1:])
+        dfs.append(pd.read_csv(test_path))
 
     # Concatenate splits if both were loaded
-    X = pd.concat(dfs_X, ignore_index=True)
-    y = pd.concat(dfs_y, ignore_index=True)
+    dataset = pd.concat(dfs, ignore_index=True)
 
-    return X, y
+    if return_X_y:
+        X = dataset.iloc[:, :-1]
+        y = dataset.iloc[:, -1:]
+        return MoleculeLoader(data=X), y
+    return MoleculeLoader(data=dataset)

--- a/pyaptamer/datasets/tests/test_li2014.py
+++ b/pyaptamer/datasets/tests/test_li2014.py
@@ -1,8 +1,9 @@
-__author__ = "satvshr"
+__author__ = "siddharth7113"
 
 import pandas as pd
 import pytest
 
+from pyaptamer.data.loader import MoleculeLoader
 from pyaptamer.datasets._loaders._li2014 import load_li2014
 
 
@@ -10,41 +11,43 @@ from pyaptamer.datasets._loaders._li2014 import load_li2014
     "split",
     [None, "train", "test"],
 )
-def test_load_li2014(split):
-    """
-    Test that load_li2014 returns a tuple (X, y) where:
-    - X is a DataFrame
-    - y is a DataFrame
-    - they have matching lengths
-    - they are non-empty
+def test_load_li2014_single_loader(split):
+    """Default returns one MoleculeLoader over aptamer, protein and label."""
+    loader = load_li2014(split=split)
 
-    Parameters
-    ----------
-    split : {None, 'train', 'test'}
-        Split to load and test.
-    """
-    X, y = load_li2014(split=split)
+    assert isinstance(loader, MoleculeLoader)
 
-    assert isinstance(X, pd.DataFrame), "X should be a pandas DataFrame"
-    assert isinstance(y, pd.DataFrame), "y should be a pandas DataFrame"
+    df = loader.to_dataframe()
+    assert list(df.columns) == ["aptamer", "protein", "label"]
+    assert df.shape[0] > 0
 
-    assert len(X) == len(y), "X and y must have the same number of rows"
-    assert X.shape[0] > 0, "X should not be empty"
-    assert y.shape[0] > 0, "y should not be empty"
+
+@pytest.mark.parametrize(
+    "split",
+    [None, "train", "test"],
+)
+def test_load_li2014_return_x_y(split):
+    """return_X_y=True splits into a MoleculeLoader X and a DataFrame y."""
+    X, y = load_li2014(split=split, return_X_y=True)
+
+    assert isinstance(X, MoleculeLoader)
+    assert isinstance(y, pd.DataFrame)
+
+    X_df = X.to_dataframe()
+    assert list(X_df.columns) == ["aptamer", "protein"]
+    assert list(y.columns) == ["label"]
+    assert len(X_df) == len(y) > 0
 
 
 def test_load_li2014_concatenation():
-    """
-    Test that loading with split=None returns the concatenation of train and test.
-    """
-    X_all, y_all = load_li2014(split=None)
-    X_train, y_train = load_li2014(split="train")
-    X_test, y_test = load_li2014(split="test")
+    """split=None concatenates the train and test splits."""
+    X_all, y_all = load_li2014(split=None, return_X_y=True)
+    X_train, y_train = load_li2014(split="train", return_X_y=True)
+    X_test, y_test = load_li2014(split="test", return_X_y=True)
 
-    # Total rows should equal sum of train and test
-    assert len(X_all) == len(X_train) + len(X_test), (
-        "Concatenated data should have rows equal to train + test"
-    )
-    assert len(y_all) == len(y_train) + len(y_test), (
-        "Concatenated labels should have length equal to train + test"
-    )
+    n_all = len(X_all.to_dataframe())
+    n_train = len(X_train.to_dataframe())
+    n_test = len(X_test.to_dataframe())
+
+    assert n_all == n_train + n_test
+    assert len(y_all) == len(y_train) + len(y_test)

--- a/pyaptamer/experiments/_aptamer_aptanet.py
+++ b/pyaptamer/experiments/_aptamer_aptanet.py
@@ -2,6 +2,7 @@ __all__ = ["AptamerEvalAptaNet"]
 
 import numpy as np
 
+from pyaptamer.data import MoleculeLoader
 from pyaptamer.experiments._aptamer import BaseAptamerEval
 
 
@@ -21,13 +22,16 @@ class AptamerEvalAptaNet(BaseAptamerEval):
     --------
     >>> import numpy as np
     >>> from pyaptamer.aptanet import AptaNetPipeline
+    >>> from pyaptamer.data import MoleculeLoader
     >>> from pyaptamer.experiments import AptamerEvalAptaNet
     >>> aptamer_seq = "AGCTTAGCGTACAGCTTAAAAGGGTTTCCCCTGCCCGCGTAC"
     >>> protein_seq = "ACDEFGHIKLMNPQRSTVWYACDEFGHIKLMNPQRSTVWY"
-    >>> pairs = [(aptamer_seq, protein_seq) for _ in range(5)]
+    >>> X = MoleculeLoader(
+    ...     data={"aptamer": [aptamer_seq] * 5, "protein": [protein_seq] * 5}
+    ... )
     >>> labels = np.array([0] * 5, dtype=np.float32)
     >>> pipeline = AptaNetPipeline()
-    >>> pipeline.fit(pairs, labels)  # doctest: +ELLIPSIS
+    >>> pipeline.fit(X, labels)  # doctest: +ELLIPSIS
     AptaNetPipeline(...)
     >>> target = "ACDEFACDEFACDEFACDEFACDEFACDEFACDEFACDEF"
     >>> experiment = AptamerEvalAptaNet(target, pipeline)
@@ -54,6 +58,9 @@ class AptamerEvalAptaNet(BaseAptamerEval):
         np.float64
             The probability score assigned to the aptamer candidate.
         """
-        score = self.pipeline.predict_proba(X=[(aptamer_candidate, self.target)])
+        X = MoleculeLoader(
+            data={"aptamer": [aptamer_candidate], "protein": [self.target]}
+        )
+        score = self.pipeline.predict_proba(X=X)
 
         return np.float64(score[:, 1].item())  # return the positive class probability

--- a/pyaptamer/experiments/tests/test_aptamer.py
+++ b/pyaptamer/experiments/tests/test_aptamer.py
@@ -1,6 +1,6 @@
 """Test suite for the AptamerEval experiment classes."""
 
-__author__ = ["nennomp"]
+__author__ = ["nennomp", "siddharth7113"]
 
 import numpy
 import pytest
@@ -41,9 +41,13 @@ class MockAptaNetPipeline:
         """
         Mock predict method that returns fixed scores for binary classification (no
         binding, binding).
+
+        ``X`` is a :class:`~pyaptamer.data.loader.MoleculeLoader`; materialize it
+        to learn how many pairs to score.
         """
+        n = len(X.to_dataframe())
         # return probability scores as a list
-        return numpy.array([[1 - self.fixed_score, self.fixed_score]] * len(X))
+        return numpy.array([[1 - self.fixed_score, self.fixed_score]] * n)
 
     def fit(self, X, y):
         """Mock fit method."""

--- a/pyaptamer/utils/_aptanet_utils.py
+++ b/pyaptamer/utils/_aptanet_utils.py
@@ -1,12 +1,9 @@
-__author__ = "satvshr"
-__all__ = ["generate_kmer_vecs", "pairs_to_features"]
+__author__ = ["satvshr", "siddharth7113"]
+__all__ = ["generate_kmer_vecs"]
 
 from itertools import product
 
 import numpy as np
-import pandas as pd
-
-from pyaptamer.pseaac import AptaNetPSeAAC
 
 
 def generate_kmer_vecs(aptamer_sequence, k=4):
@@ -55,46 +52,3 @@ def generate_kmer_vecs(aptamer_sequence, k=4):
     )
 
     return kmer_freq
-
-
-def pairs_to_features(X, k=4):
-    """
-    Convert a list of (aptamer_sequence, protein_sequence) pairs into feature vectors.
-    Also supports a pandas DataFrame with 'aptamer' and 'protein' columns.
-
-    This function generates feature vectors for each (aptamer, protein) pair using:
-
-    - k-mer representation of the aptamer sequence
-    - Pseudo amino acid composition (PSeAAC) representation of the protein sequence
-
-    Parameters
-    ----------
-    X : list of tuple of str or pandas.DataFrame
-        A list where each element is a tuple `(aptamer_sequence, protein_sequence)`,
-        or a DataFrame containing 'aptamer' and 'protein' columns.
-
-    k : int, optional
-        The k-mer size used to generate the k-mer vector from the aptamer sequence.
-        Default is 4.
-
-    Returns
-    -------
-    np.ndarray
-        A 2D NumPy array where each row corresponds to the concatenated feature vector
-        for a given (aptamer, protein) pair.
-    """
-    pseaac = AptaNetPSeAAC()
-    feats = []
-
-    if isinstance(X, pd.DataFrame):
-        pairs = zip(X["aptamer"], X["protein"], strict=False)
-    else:
-        pairs = X
-
-    for aptamer_seq, protein_seq in pairs:
-        kmer = generate_kmer_vecs(aptamer_seq, k=k)
-        pseaac_vec = np.asarray(pseaac.transform(protein_seq))
-        feats.append(np.concatenate([kmer, pseaac_vec]))
-
-    # Ensure float32 for PyTorch compatibility
-    return np.vstack(feats).astype(np.float32)


### PR DESCRIPTION
LLM generated content, by Claude Opus 4.8

#### Reference Issues/PRs

Recovery for #700 and #704. Both were marked "merged", but because they were stacked, they merged into their intermediate base branches instead of `main` — so their changes never reached `main` (`main` only received #699). This PR lands exactly the two stranded commits on top of `main`.

#### What does this implement/fix? Explain your changes.

Cherry-picks the pipeline decoupling (#700) and the tutorial + `load_li2014` migration (#704) onto current `main` (which already has the redesign + consumer migration from #699). Net diff is only those two changes — no redundant re-application of #699.

- `PairsToFeatures` transform + `AptaNetPipeline` consuming a `MoleculeLoader` (removes the old `pairs_to_features`).
- `load_li2014` gains `return_X_y` (mirrors `load_aptacom`).
- `AptamerEvalAptaNet` builds a `MoleculeLoader` internally.
- `aptanet_tutorial` / `aptanet_finetuning_tutorial` migrated off the removed `to_df_seq` / `pairs_to_features` APIs; this also un-breaks the notebooks on `main`.

#### What should a reviewer concentrate their feedback on?

- That the diff is limited to #700 + #704 content (the #699 redesign/consumers are untouched, already on `main`).

#### Did you add any tests for the change?

Yes — these are the tests already reviewed in #700/#704: `test_pairs_to_features.py`, the `return_X_y` rewrite of `test_li2014.py`, and the format/FASTA tests in `test_loader.py` / `test_aptanet.py`.

#### PR checklist

- [x] The PR title starts with [ENH].
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing.
