### PR TITLE
[MNT] Add pytest-cov and coverage reporting to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -162,4 +162,4 @@ jobs:
 
       - name: Run tests
         run: |
-          python -m pytest pyaptamer -p no:warnings
+          python -m pytest pyaptamer -p no:warnings --cov=pyaptamer --cov-report=term-missing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
 dev = [
     "ruff>=0.15.19",
     "pytest>=9.1.1",
+    "pytest-cov>=7.0",
     "pre-commit",
 ]
 docs = [
@@ -66,3 +67,13 @@ pyaptamer = ["datasets/data/*.csv", "datasets/data/*.pdb"]
 
 [tool.ruff.lint.per-file-ignores]
 "examples/*.ipynb" = ["T201"]
+
+[tool.coverage.run]
+source = ["pyaptamer"]
+omit = [
+    "*/tests/*",
+    "*/__init__.py",
+]
+
+[tool.coverage.report]
+show_missing = true


### PR DESCRIPTION
## What

Wire up `pytest-cov` so coverage is measured on every CI run.

- Add `pytest-cov>=7.0` to the `dev` extra
- Add `[tool.coverage.run]` (`source = ["pyaptamer"]`, omitting `*/tests/*` and
  `*/__init__.py`) and `[tool.coverage.report]` (`show_missing = true`)
- Add `--cov=pyaptamer --cov-report=term-missing` to the CI test step

## Why

The repo had no coverage tooling — CI ran `pytest pyaptamer` with no `--cov`, so
coverage was never measured and regressions (e.g. from the MoleculeLoader
migration) passed silently. Baseline measured locally: **93%** (376 passed,
5 skipped).


Closes #720. Part of #719.
