### PR TITLE
test: cover previously-uncovered branches in utils modules (issue #725)

### DIFF
--- a/pyaptamer/utils/tests/test_aa_str_to_letter.py
+++ b/pyaptamer/utils/tests/test_aa_str_to_letter.py
@@ -1,0 +1,35 @@
+"""Tests for the amino-acid three-letter to one-letter conversion utility.
+
+Targets the missing branch in ``pyaptamer/utils/_aa_str_to_letter.py``
+(issue #725): the fallback that maps an unknown three-letter code to "X".
+"""
+
+__author__ = ["gandzekas"]
+
+import pytest
+
+from pyaptamer.utils._aa_str_to_letter import aa_str_to_letter
+
+
+@pytest.mark.parametrize(
+    "code, expected",
+    [
+        ("ALA", "A"),
+        ("ala", "A"),  # lowercase is normalised
+        ("Trp", "W"),
+        ("TYR", "Y"),
+        ("SEC", "U"),  # selenocysteine
+        ("PYL", "O"),  # pyrrolysine
+    ],
+)
+def test_known_codes(code, expected):
+    """Known three-letter codes map to their one-letter equivalents."""
+    assert aa_str_to_letter(code) == expected
+
+
+def test_unknown_code_falls_back_to_x():
+    """Unknown three-letter codes return "X" (previously uncovered line)."""
+    assert aa_str_to_letter("ZZZ") == "X"
+    assert aa_str_to_letter("???") == "X"
+    # lowercase unknown is normalised before the lookup
+    assert aa_str_to_letter("xyz") == "X"

--- a/pyaptamer/utils/tests/test_aptatrans_utils.py
+++ b/pyaptamer/utils/tests/test_aptatrans_utils.py
@@ -1,0 +1,51 @@
+"""Tests for the generic sequence-to-vector utility.
+
+Targets the missing branches in ``pyaptamer/utils/_aptatrans_utils.py``
+(issue #725):
+  * lines 88-91  - splitting a sequence into chunks at ``seq_max_len``
+  * line 98      - skipping a primary character with no vocabulary match
+  * line 119     - returning empty (zero) arrays when nothing tokenizes
+"""
+
+__author__ = ["gandzekas"]
+
+import numpy as np
+import pytest
+
+from pyaptamer.utils._aptatrans_utils import seq2vec
+
+
+def test_seq2vec_splits_at_seq_max_len():
+    """A sequence longer than ``seq_max_len`` is split into chunks (lines 88-91)."""
+    # vocabulary: single "A" and digram "AA" so "AAAAA" tokenizes greedily
+    words = {"A": 1, "AA": 2}
+    sequences = (["AAAAA"], ["HHHHH"])
+    primary, secondary = seq2vec(sequences, words, seq_max_len=2)
+
+    # first chunk is exactly seq_max_len and holds the split boundary
+    assert primary.shape == (2, 2)
+    assert secondary.shape == (2, 2)
+    # first row is the full first chunk (digrams "AA","AA")
+    assert list(primary[0]) == [2, 2]
+    # second row is the remainder, padded
+    assert list(primary[1]) == [1, 0]
+
+
+def test_seq2vec_skips_unmatched_primary_char():
+    """A primary character absent from the vocabulary is skipped (line 98)."""
+    words = {"A": 1}
+    # "Z" is not in the vocabulary -> no match -> skipped, no crash
+    primary, secondary = seq2vec((["AZA"], ["HHH"]), words, seq_max_len=4)
+    assert primary.shape[1] == 4
+    # the two "A" tokens survive; "Z" is dropped
+    assert list(primary[0]) == [1, 1, 0, 0]
+
+
+def test_seq2vec_empty_when_nothing_tokenizes():
+    """No matches yields zero-shaped arrays (line 119)."""
+    words = {"A": 1}
+    primary, secondary = seq2vec((["Z"], ["H"]), words, seq_max_len=4)
+    assert primary.shape == (0, 4)
+    assert secondary.shape == (0, 4)
+    assert primary.dtype == np.float64
+    assert secondary.dtype == np.float64

--- a/pyaptamer/utils/tests/test_pseaac_utils.py
+++ b/pyaptamer/utils/tests/test_pseaac_utils.py
@@ -1,0 +1,57 @@
+"""Tests for the PSeAAC protein-sequence cleaning utility.
+
+Targets the missing branches in ``pyaptamer/utils/_pseaac_utils.py``
+(issue #725): replacing an invalid amino acid with "N" (lines 44-45)
+and emitting the UserWarning (line 48).
+"""
+
+__author__ = ["gandzekas"]
+
+import warnings
+
+import pytest
+
+from pyaptamer.utils._pseaac_utils import clean_protein_seq
+
+
+class _AssertNoWarning:
+    """Context manager that fails if any warning is emitted."""
+
+    def __enter__(self):
+        self._catcher = warnings.catch_warnings(record=True)
+        self._records = self._catcher.__enter__()
+        warnings.simplefilter("always")
+        return self
+
+    def __exit__(self, *exc):
+        self._catcher.__exit__(*exc)
+        assert not self._records, f"unexpected warning emitted: {self._records[0]}"
+
+
+def test_clean_valid_sequence_passthrough():
+    """A fully valid sequence is returned unchanged and warns nothing."""
+    seq = "ACDEFGHIKLMNPQRSTVWY"
+    with _AssertNoWarning():
+        result = clean_protein_seq(seq)
+    assert result == seq
+
+
+@pytest.mark.parametrize(
+    "seq, expected",
+    [
+        ("AXC", "ANC"),  # single invalid residue
+        ("X", "N"),  # entirely invalid
+        ("AC*DE", "ACNDE"),  # stray non-standard char
+        ("BZJ", "NNN"),  # ambiguous codes are not among the 20 standard
+    ],
+)
+def test_invalid_residues_replaced_with_n(seq, expected):
+    """Invalid residues are replaced with "N" and a warning is raised."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = clean_protein_seq(seq)
+
+    assert result == expected
+    assert any(issubclass(w.category, UserWarning) for w in caught), (
+        "expected a UserWarning for invalid residues"
+    )


### PR DESCRIPTION
## Summary
Closes part of #719 and addresses issue #725 ("Small utils coverage wins").

Adds targeted unit tests in `pyaptamer/utils/tests/` for the specific uncovered
lines called out in #725:

- **`_aa_str_to_letter.py` (line 43)** — unknown three-letter code now covered: falls back to `"X"`.
- **`_pseaac_utils.py` (lines 44-45, 48)** — invalid residues replaced with `"N"` and the `UserWarning` path is exercised.
- **`_aptatrans_utils.py` (lines 88-91, 98, 119)** — sequence splitting at `seq_max_len`, skipping an unmatched primary character, and the empty zero-array return.

## Verification
Tests follow the repo's existing `tests/` conventions (`pytest.mark.parametrize`,
`pytest.warns`). They can be run with:

```
pytest pyaptamer/utils/tests/test_aa_str_to_letter.py        pyaptamer/utils/tests/test_pseaac_utils.py        pyaptamer/utils/tests/test_aptatrans_utils.py --cov=pyaptamer.utils
```

## Test plan
- [x] `_aa_str_to_letter`: known codes + unknown -> "X"
- [x] `_pseaac_utils`: valid passthrough + invalid -> "N" with warning
- [x] `_aptatrans_utils`: split at `seq_max_len`, unmatched skip, empty zeros
