### PR TITLE
[ENH] Refactor AptaTrans onto the scikit-learn fit/predict contract

### DIFF
--- a/pyaptamer/aptatrans/__init__.py
+++ b/pyaptamer/aptatrans/__init__.py
@@ -10,6 +10,7 @@ __all__ = [
     "AptaTransEncoderLightning",
     "AptaTransPipeline",
     "EncoderPredictorConfig",
+    "PairsToTokens",
 ]
 
 from pyaptamer.aptatrans._model import AptaTrans
@@ -18,4 +19,5 @@ from pyaptamer.aptatrans._model_lightning import (
     AptaTransLightning,
 )
 from pyaptamer.aptatrans._pipeline import AptaTransPipeline
+from pyaptamer.aptatrans._transforms import PairsToTokens
 from pyaptamer.aptatrans.layers import EncoderPredictorConfig

--- a/pyaptamer/aptatrans/_transforms.py
+++ b/pyaptamer/aptatrans/_transforms.py
@@ -1,0 +1,111 @@
+"""Feature-extraction transforms for the AptaTrans algorithm."""
+
+__author__ = ["siddharth7113"]
+__all__ = ["PairsToTokens"]
+import numpy as np
+import pandas as pd
+from sklearn.utils.validation import check_is_fitted
+
+from pyaptamer.trafos.base import BaseTransform
+from pyaptamer.utils import encode_rna, rna2vec
+from pyaptamer.utils._base import filter_words
+
+
+class PairsToTokens(BaseTransform):
+    """Transform (aptamer, protein) sequence pairs into AptaTrans token ids.
+
+    Each row is encoded as the concatenation of:
+
+    - overlapping-triplet ids of the aptamer sequence, zero-padded to
+      ``apta_max_len``, and
+    - greedy longest-match token ids of the protein sequence, zero-padded to
+      ``prot_max_len``.
+
+    The two blocks sit side by side, so a row has ``apta_max_len + prot_max_len``
+    columns and the boundary between them is at index ``apta_max_len``.
+
+    Input must be a :class:`~pyaptamer.data.loader.MoleculeLoader`, or a
+    ``pandas.DataFrame`` holding the aptamer and protein columns.
+
+    Parameters
+    ----------
+    prot_words : dict[str, float]
+        Protein n-mer subsequences mapped to their frequency. Filtered during
+        ``fit``; see ``prot_words_``. Should come from the same dataset used to
+        pretrain the protein encoder.
+    apta_max_len : int, default=275
+        Width of the aptamer token block. Sequences are truncated or zero-padded
+        to this length.
+    prot_max_len : int, default=867
+        Width of the protein token block. Sequences are truncated or zero-padded
+        to this length.
+    aptamer_col : str, default="aptamer"
+        Name of the column holding aptamer sequences.
+    protein_col : str, default="protein"
+        Name of the column holding protein sequences.
+
+    Attributes
+    ----------
+    prot_words_ : dict[str, int]
+        Protein words with above-average frequency, mapped to unique integer ids.
+        Derived from ``prot_words`` during ``fit``.
+
+    Examples
+    --------
+    >>> from pyaptamer.aptatrans import PairsToTokens
+    >>> from pyaptamer.data import MoleculeLoader
+    >>> X = MoleculeLoader(
+    ...     data={"aptamer": ["AGCUUAGCGUAC"], "protein": ["ACDEFGHIKLMN"]}
+    ... )
+    >>> prot_words = {"ACD": 5.0, "EFG": 4.0, "HIK": 3.0, "LMN": 1.0}
+    >>> Xt = PairsToTokens(
+    ...     prot_words=prot_words, apta_max_len=10, prot_max_len=8
+    ... ).fit_transform(X)
+    >>> Xt.shape
+    (1, 18)
+    """
+
+    _tags = {
+        "capability:multivariate": True,
+        "property:fit_is_empty": False,
+        "output_type": "numeric",
+    }
+
+    def __init__(
+        self,
+        prot_words: dict[str, float],
+        apta_max_len: int = 275,
+        prot_max_len: int = 867,
+        aptamer_col: str = "aptamer",
+        protein_col: str = "protein",
+    ):
+        self.prot_words = prot_words
+        self.apta_max_len = apta_max_len
+        self.prot_max_len = prot_max_len
+        self.aptamer_col = aptamer_col
+        self.protein_col = protein_col
+        super().__init__()
+
+    def _transform(self, X):
+        """Encode each (aptamer, protein) row into token ids."""
+        check_is_fitted(self)
+        aptamers = X[self.aptamer_col].astype(str).tolist()
+        proteins = X[self.protein_col].astype(str).tolist()
+
+        aptamer_ids = rna2vec(
+            aptamers,
+            max_sequence_length=self.apta_max_len,
+        )
+        protein_ids = encode_rna(
+            proteins,
+            words=self.prot_words_,
+            max_len=self.prot_max_len,
+            return_type="numpy",
+        )
+
+        encoded = np.hstack([aptamer_ids, protein_ids])
+        return pd.DataFrame(encoded, index=X.index)
+
+    def _fit(self, X, y=None):
+        """Derive the filtered protein vocabulary. ``X`` is not used."""
+        self.prot_words_ = filter_words(self.prot_words)

--- a/pyaptamer/aptatrans/tests/test_transforms.py
+++ b/pyaptamer/aptatrans/tests/test_transforms.py
@@ -1,0 +1,101 @@
+"""Tests for the PairsToTokens transform."""
+
+__author__ = ["siddharth7113"]
+
+import numpy as np
+import pandas as pd
+import pytest
+from sklearn.exceptions import NotFittedError
+
+from pyaptamer.aptatrans import PairsToTokens
+from pyaptamer.data import MoleculeLoader
+from pyaptamer.utils import encode_rna, rna2vec
+from pyaptamer.utils._base import filter_words
+
+APTAMER = "AGCTTAGCGTACAGCTTAAAAGGGTTTCCCCTGCCCGCGTAC"
+PROTEIN = "ACDEFGHIKLMNPQRSTVWYACDEFGHIKLMNPQRSTVWY"
+PROT_WORDS = {"ACD": 5.0, "EFG": 4.0, "HIK": 3.0, "LMN": 1.0}
+
+
+def test_output_shape_and_dtype():
+    """Output is one row per pair, apta_max_len + prot_max_len integer columns."""
+    X = MoleculeLoader(data={"aptamer": [APTAMER] * 3, "protein": [PROTEIN] * 3})
+
+    Xt = PairsToTokens(
+        prot_words=PROT_WORDS, apta_max_len=10, prot_max_len=8
+    ).fit_transform(X)
+
+    assert isinstance(Xt, pd.DataFrame)
+    assert Xt.shape == (3, 18)
+    assert Xt.to_numpy().dtype == np.int64
+
+
+def test_column_blocks_split_at_apta_max_len():
+    """Columns before apta_max_len hold the aptamer block, those after the protein."""
+    X = MoleculeLoader(data={"aptamer": [APTAMER] * 3, "protein": [PROTEIN] * 3})
+
+    Xt = PairsToTokens(
+        prot_words=PROT_WORDS, apta_max_len=10, prot_max_len=8
+    ).fit_transform(X)
+
+    expected_apta = rna2vec([APTAMER] * 3, max_sequence_length=10)
+    expected_prot = encode_rna(
+        [PROTEIN] * 3,
+        words=filter_words(PROT_WORDS),
+        max_len=8,
+        return_type="numpy",
+    )
+
+    np.testing.assert_array_equal(Xt.to_numpy()[:, :10], expected_apta)
+    np.testing.assert_array_equal(Xt.to_numpy()[:, 10:], expected_prot)
+
+
+def test_custom_column_names():
+    """Column names are configurable, not hardcoded to aptamer/protein."""
+    X = MoleculeLoader(
+        data={"aptamer_sequence": [APTAMER] * 2, "target_sequence": [PROTEIN] * 2}
+    )
+
+    Xt = PairsToTokens(
+        prot_words=PROT_WORDS,
+        apta_max_len=10,
+        prot_max_len=8,
+        aptamer_col="aptamer_sequence",
+        protein_col="target_sequence",
+    ).fit_transform(X)
+
+    assert Xt.shape == (2, 18)
+
+
+def test_prot_words_derived_in_fit():
+    """prot_words_ is absent before fit and holds the filtered vocabulary after."""
+    X = MoleculeLoader(data={"aptamer": [APTAMER], "protein": [PROTEIN]})
+    transform = PairsToTokens(prot_words=PROT_WORDS, apta_max_len=10, prot_max_len=8)
+
+    assert not hasattr(transform, "prot_words_")
+
+    transform.fit(X)
+
+    assert transform.prot_words_ == filter_words(PROT_WORDS)
+    assert transform.prot_words == PROT_WORDS
+
+
+def test_transform_before_fit_raises():
+    """transform without fit raises NotFittedError, not a bare AttributeError."""
+    X = MoleculeLoader(data={"aptamer": [APTAMER], "protein": [PROTEIN]})
+    transform = PairsToTokens(prot_words=PROT_WORDS, apta_max_len=10, prot_max_len=8)
+
+    with pytest.raises(NotFittedError):
+        transform.transform(X)
+
+
+def test_fit_is_idempotent():
+    """Refitting derives prot_words_ from the raw vocabulary, not the filtered one."""
+    X = MoleculeLoader(data={"aptamer": [APTAMER], "protein": [PROTEIN]})
+    transform = PairsToTokens(prot_words=PROT_WORDS, apta_max_len=10, prot_max_len=8)
+
+    transform.fit(X)
+    first = dict(transform.prot_words_)
+    transform.fit(X)
+
+    assert transform.prot_words_ == first


### PR DESCRIPTION
AptaTrans onto the same estimator contract as AptaNet.


Each row of `PairsToTokens` output is the aptamer triplet ids (`rna2vec`) concatenated with the protein token ids (`encode_rna`)