### PR TITLE
[BUG] Track fitted state, pin sklearn < 1.8 along with adding test for base class.

### DIFF
--- a/pyaptamer/trafos/base/_base.py
+++ b/pyaptamer/trafos/base/_base.py
@@ -1,7 +1,10 @@
 """Base transformation class."""
 
+__author__ = ["fkiraly", "siddharth7113"]
+
 import pandas as pd
 from skbase.base import BaseEstimator
+from sklearn.utils import InputTags, Tags, TargetTags, TransformerTags
 
 from pyaptamer.data import MoleculeLoader
 
@@ -38,11 +41,12 @@ class BaseTransform(BaseEstimator):
         self : object
             Returns self.
         """
-        if self.get_tag("property:fit_is_empty", False):
-            return self
-
         X_inner, y_inner = self._check_X_y(X, y)
-        self._fit(X=X_inner, y=y_inner)
+
+        if not self.get_tag("property:fit_is_empty", False):
+            self._fit(X=X_inner, y=y_inner)
+
+        self._is_fitted = True
         return self
 
     def _fit(self, X, y=None):
@@ -77,7 +81,13 @@ class BaseTransform(BaseEstimator):
         -------
         X : array-like, shape (n_samples, n_features_transformed)
             Transformed data.
+
+        Raises
+        ------
+        NotFittedError
+            If ``fit`` has not been called before.
         """
+        self.check_is_fitted(method_name="transform")
         X_inner = self._check_X(X)
         Xt = self._transform(X=X_inner)
         return Xt
@@ -141,6 +151,30 @@ class BaseTransform(BaseEstimator):
             Transformed data.
         """
         return self.fit(X, y).transform(X)
+
+    def __sklearn_tags__(self):
+        """Return the sklearn tags of this transformer.
+
+        ``BaseTransform`` extends skbase's ``BaseEstimator``,so
+        sklearn has no ``__sklearn_tags__`` to inherit. This adds the tags
+        directly, so meta-estimators such as ``sklearn.pipeline.Pipeline`` can
+        introspect transformers.
+
+        Returns
+        -------
+        tags : sklearn.utils.Tags
+            Tags describing this transformer to sklearn.
+        """
+        return Tags(
+            estimator_type="transformer",
+            target_tags=TargetTags(required=False),
+            transformer_tags=TransformerTags(),
+            classifier_tags=None,
+            regressor_tags=None,
+            # X is a MoleculeLoader or a pd.DataFrame of sequence strings,
+            # never a numeric 2D array
+            input_tags=InputTags(two_d_array=False, string=True),
+        )
 
     def _check_X_y(self, X, y):  # noqa: N802
         """Check X and y inputs.

--- a/pyaptamer/trafos/base/_base.py
+++ b/pyaptamer/trafos/base/_base.py
@@ -4,7 +4,6 @@ __author__ = ["fkiraly", "siddharth7113"]
 
 import pandas as pd
 from skbase.base import BaseEstimator
-from sklearn.utils import InputTags, Tags, TargetTags, TransformerTags
 
 from pyaptamer.data import MoleculeLoader
 
@@ -151,30 +150,6 @@ class BaseTransform(BaseEstimator):
             Transformed data.
         """
         return self.fit(X, y).transform(X)
-
-    def __sklearn_tags__(self):
-        """Return the sklearn tags of this transformer.
-
-        ``BaseTransform`` extends skbase's ``BaseEstimator``,so
-        sklearn has no ``__sklearn_tags__`` to inherit. This adds the tags
-        directly, so meta-estimators such as ``sklearn.pipeline.Pipeline`` can
-        introspect transformers.
-
-        Returns
-        -------
-        tags : sklearn.utils.Tags
-            Tags describing this transformer to sklearn.
-        """
-        return Tags(
-            estimator_type="transformer",
-            target_tags=TargetTags(required=False),
-            transformer_tags=TransformerTags(),
-            classifier_tags=None,
-            regressor_tags=None,
-            # X is a MoleculeLoader or a pd.DataFrame of sequence strings,
-            # never a numeric 2D array
-            input_tags=InputTags(two_d_array=False, string=True),
-        )
 
     def _check_X_y(self, X, y):  # noqa: N802
         """Check X and y inputs.

--- a/pyaptamer/trafos/base/tests/__init__.py
+++ b/pyaptamer/trafos/base/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the transformer base class."""

--- a/pyaptamer/trafos/base/tests/test_base.py
+++ b/pyaptamer/trafos/base/tests/test_base.py
@@ -1,0 +1,168 @@
+"""Contract tests for BaseTransform descendants.
+
+Checks the fitted-state and sklearn tag contract against every transformer in
+the package:
+
+    test_scenario_applies             - every transformer is matched by a scenario
+    test_not_fitted_before_fit        - is_fitted is False before fit
+    test_raises_not_fitted_error      - transform before fit raises NotFittedError
+    test_fit_sets_is_fitted           - fit sets is_fitted and returns self
+    test_fit_transform_sets_is_fitted - fit_transform leaves the state fitted
+    test_sklearn_tags                 - sklearn reads tags off the transformer
+
+Transformers are discovered with ``all_objects``, and the input each is checked
+against comes from a scenario, after sktime's test design: a scenario supplies
+the ``args`` for ``fit`` and ``transform``, and declares in ``is_applicable``
+which transformers it applies to, by reading their tags.
+
+Adding a transformer therefore needs no change here, as long as a scenario
+applies to it - ``test_scenario_applies`` fails if none does. A transformer
+taking a new kind of input needs a new scenario class.
+"""
+
+__author__ = ["siddharth7113"]
+
+import warnings
+
+import pandas as pd
+import pytest
+from skbase._exceptions import NotFittedError
+from skbase.lookup import all_objects
+from sklearn.utils import Tags, get_tags
+
+from pyaptamer.data import MoleculeLoader
+from pyaptamer.trafos.base import BaseTransform
+
+
+class _RowCounter(BaseTransform):
+    """Transformer with fitted state, covering the non-empty ``_fit`` branch.
+
+    No transformer in the package currently has fitted state, so the branch of
+    ``fit`` dispatching to ``_fit`` would otherwise go untested.
+
+    Note: Remove this when a transformer covering this case is present.
+    """
+
+    _tags = {"property:fit_is_empty": False}
+
+    def _fit(self, X, y=None):
+        self.n_rows_ = len(X)
+        return self
+
+    def _transform(self, X):
+        return pd.DataFrame({"n_rows": [self.n_rows_] * len(X)}, index=X.index)
+
+
+class _SequenceFrameScenario:
+    """A single column of sequence strings, for univariate transformers."""
+
+    def is_applicable(self, cls):
+        return not cls.get_class_tag("capability:multivariate", False)
+
+    @property
+    def args(self):
+        return {
+            "fit": {"X": pd.DataFrame({"seq": ["ACGU", "GUAC"]})},
+            "transform": {"X": pd.DataFrame({"seq": ["GUAC", "ACGU"]})},
+        }
+
+
+class _MoleculePairsScenario:
+    """A MoleculeLoader of (aptamer, protein) pairs, for multivariate transformers."""
+
+    def is_applicable(self, cls):
+        return cls.get_class_tag("capability:multivariate", False)
+
+    @property
+    def args(self):
+        def loader():
+            return MoleculeLoader(
+                data={
+                    "aptamer": ["AGCTTAGCGTACAGCTTAAAAGGGTTTCCCCTGCCCGCGTAC"],
+                    "protein": ["ACDEFGHIKLMNPQRSTVWYACDEFGHIKLMNPQRSTVWY"],
+                }
+            )
+
+        return {"fit": {"X": loader()}, "transform": {"X": loader()}}
+
+
+def _transformers():
+    """Every transformer in the package, plus the local stateful one."""
+    found = all_objects(
+        package_name="pyaptamer",
+        object_types=BaseTransform,
+        return_names=False,
+    )
+    return found + [_RowCounter]
+
+
+def _scenarios():
+    """Every transformer scenario known to the contract tests."""
+    return [_SequenceFrameScenario(), _MoleculePairsScenario()]
+
+
+def _cases():
+    """(transformer, scenario) pairs the contract is checked on."""
+    return [
+        pytest.param(cls, scenario, id=f"{cls.__name__}-{type(scenario).__name__}")
+        for cls in _transformers()
+        for scenario in _scenarios()
+        if scenario.is_applicable(cls)
+    ]
+
+
+@pytest.mark.parametrize("cls", _transformers(), ids=lambda cls: cls.__name__)
+def test_scenario_applies(cls):
+    """Every transformer is matched by at least one scenario, so none goes unchecked."""
+    assert any(scenario.is_applicable(cls) for scenario in _scenarios())
+
+
+@pytest.mark.parametrize("cls", _transformers(), ids=lambda cls: cls.__name__)
+def test_not_fitted_before_fit(cls):
+    """A freshly constructed transformer reports itself as not fitted."""
+    est = cls.create_test_instance()
+    assert est.is_fitted is False
+    with pytest.raises(NotFittedError, match="has not been fitted"):
+        est.check_is_fitted()
+
+
+@pytest.mark.parametrize("cls", _transformers(), ids=lambda cls: cls.__name__)
+def test_sklearn_tags(cls):
+    """sklearn reads tags off a transformer instead of falling back to defaults."""
+    est = cls.create_test_instance()
+    with warnings.catch_warnings(action="error", category=DeprecationWarning):
+        tags = get_tags(est)
+    assert isinstance(tags, Tags)
+    assert tags.estimator_type == "transformer"
+    assert tags.transformer_tags is not None
+
+
+@pytest.mark.parametrize("cls, scenario", _cases())
+def test_raises_not_fitted_error(cls, scenario):
+    """transform before fit raises NotFittedError, not a bare AttributeError."""
+    est = cls.create_test_instance()
+    with pytest.raises(NotFittedError, match="has not been fitted"):
+        est.transform(**scenario.args["transform"])
+
+
+@pytest.mark.parametrize("cls, scenario", _cases())
+def test_fit_sets_is_fitted(cls, scenario):
+    """fit returns self and marks the transformer fitted, even if fit_is_empty."""
+    est = cls.create_test_instance()
+    assert est.fit(**scenario.args["fit"]) is est
+    assert est.is_fitted is True
+    est.check_is_fitted()
+
+
+@pytest.mark.parametrize("cls, scenario", _cases())
+def test_fit_transform_sets_is_fitted(cls, scenario):
+    """fit_transform leaves the transformer in a fitted state."""
+    est = cls.create_test_instance()
+    est.fit_transform(**scenario.args["fit"])
+    assert est.is_fitted is True
+
+
+def test_stateful_transform_uses_fitted_state():
+    """A transformer with fitted state can read that state back in transform."""
+    Xt = _RowCounter().fit_transform(pd.DataFrame({"seq": ["ACGU", "GUAC"]}))
+    assert Xt["n_rows"].tolist() == [2, 2]

--- a/pyaptamer/trafos/base/tests/test_base.py
+++ b/pyaptamer/trafos/base/tests/test_base.py
@@ -130,7 +130,8 @@ def test_not_fitted_before_fit(cls):
 def test_sklearn_tags(cls):
     """sklearn reads tags off a transformer instead of falling back to defaults."""
     est = cls.create_test_instance()
-    with warnings.catch_warnings(action="error", category=DeprecationWarning):
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
         tags = get_tags(est)
     assert isinstance(tags, Tags)
     assert tags.estimator_type == "transformer"

--- a/pyaptamer/trafos/base/tests/test_base.py
+++ b/pyaptamer/trafos/base/tests/test_base.py
@@ -1,21 +1,9 @@
-"""Contract tests for BaseTransform descendants.
+"""Test collection for all BaseTransform transformers in pyaptamer.
 
-Checks the fitted-state contract against every transformer in the package:
-
-    test_scenario_applies             - every transformer is matched by a scenario
-    test_not_fitted_before_fit        - is_fitted is False before fit
-    test_raises_not_fitted_error      - transform before fit raises NotFittedError
-    test_fit_sets_is_fitted           - fit sets is_fitted and returns self
-    test_fit_transform_sets_is_fitted - fit_transform leaves the state fitted
-
-Transformers are discovered with ``all_objects``, and the input each is checked
-against comes from a scenario, after sktime's test design: a scenario supplies
-the ``args`` for ``fit`` and ``transform``, and declares in ``is_applicable``
-which transformers it applies to, by reading their tags.
-
-Adding a transformer therefore needs no change here, as long as a scenario
-applies to it - ``test_scenario_applies`` fails if none does. A transformer
-taking a new kind of input needs a new scenario class.
+skbase's ``BaseFixtureGenerator`` finds the transformers and builds one test
+instance per ``get_test_params`` entry; ``TestAllObjects`` adds the skbase
+tests, and the fitted-state tests below run with them.
+Scenarios give each transformer its fit/transform input data, matched by tags.
 """
 
 __author__ = ["siddharth7113"]
@@ -23,7 +11,7 @@ __author__ = ["siddharth7113"]
 import pandas as pd
 import pytest
 from skbase._exceptions import NotFittedError
-from skbase.lookup import all_objects
+from skbase.testing import BaseFixtureGenerator, TestAllObjects
 
 from pyaptamer.data import MoleculeLoader
 from pyaptamer.trafos.base import BaseTransform
@@ -32,8 +20,8 @@ from pyaptamer.trafos.base import BaseTransform
 class _RowCounter(BaseTransform):
     """Transformer with fitted state, covering the non-empty ``_fit`` branch.
 
-    No transformer in the package currently has fitted state, so the branch of
-    ``fit`` dispatching to ``_fit`` would otherwise go untested.
+    No transformer in the package currently has fitted state, so the branch
+    of ``fit`` that calls ``_fit`` would otherwise go untested.
 
     Note: Remove this when a transformer covering this case is present.
     """
@@ -81,69 +69,79 @@ class _MoleculePairsScenario:
         return {"fit": {"X": loader()}, "transform": {"X": loader()}}
 
 
-def _transformers():
-    """Every transformer in the package, plus the local stateful one."""
-    found = all_objects(
-        package_name="pyaptamer",
-        object_types=BaseTransform,
-        return_names=False,
-    )
-    return found + [_RowCounter]
-
-
 def _scenarios():
-    """Every transformer scenario known to the contract tests."""
+    """All scenarios the tests can use."""
     return [_SequenceFrameScenario(), _MoleculePairsScenario()]
 
 
-def _cases():
-    """(transformer, scenario) pairs the contract is checked on."""
-    return [
-        pytest.param(cls, scenario, id=f"{cls.__name__}-{type(scenario).__name__}")
-        for cls in _transformers()
-        for scenario in _scenarios()
-        if scenario.is_applicable(cls)
+def _scenario_for(obj):
+    """The first scenario that fits obj's class; test_scenario_applies checks one exists."""  # noqa: E501
+    return next(s for s in _scenarios() if s.is_applicable(type(obj)))
+
+
+class PackageConfig:
+    """Config that the skbase test classes read."""
+
+    package_name = "pyaptamer"
+
+    # all tags used in the package; test_object_tags fails on unlisted tags
+    valid_tags = [
+        "object_type",
+        "authors",
+        "maintainers",
+        "capability:y",
+        "capability:multivariate",
+        "property:fit_is_empty",
+        "property:elementwise",
+        "output_type",
     ]
 
 
-@pytest.mark.parametrize("cls", _transformers(), ids=lambda cls: cls.__name__)
-def test_scenario_applies(cls):
-    """Every transformer is matched by at least one scenario, so none goes unchecked."""
-    assert any(scenario.is_applicable(cls) for scenario in _scenarios())
+class TransformerFixtureGenerator(PackageConfig, BaseFixtureGenerator):
+    """Creates the object_class and object_instance test arguments.
+
+    Classes come from searching pyaptamer for BaseTransform subclasses, plus
+    the local _RowCounter, which the search cannot find. Instances are built
+    fresh for every test, one per get_test_params entry.
+    """
+
+    object_type_filter = BaseTransform
+
+    def _all_objects(self):
+        return super()._all_objects() + [_RowCounter]
 
 
-@pytest.mark.parametrize("cls", _transformers(), ids=lambda cls: cls.__name__)
-def test_not_fitted_before_fit(cls):
-    """A freshly constructed transformer reports itself as not fitted."""
-    est = cls.create_test_instance()
-    assert est.is_fitted is False
-    with pytest.raises(NotFittedError, match="has not been fitted"):
-        est.check_is_fitted()
+class TestAllTransformers(TransformerFixtureGenerator, TestAllObjects):
+    """The fitted-state tests, plus the standard skbase tests by inheritance."""
 
+    def test_scenario_applies(self, object_class):
+        """Every transformer is matched by at least one scenario, so none goes unchecked."""  # noqa: E501
+        assert any(s.is_applicable(object_class) for s in _scenarios())
 
-@pytest.mark.parametrize("cls, scenario", _cases())
-def test_raises_not_fitted_error(cls, scenario):
-    """transform before fit raises NotFittedError"""
-    est = cls.create_test_instance()
-    with pytest.raises(NotFittedError, match="has not been fitted"):
-        est.transform(**scenario.args["transform"])
+    def test_not_fitted_before_fit(self, object_instance):
+        """A freshly constructed transformer reports itself as not fitted."""
+        assert object_instance.is_fitted is False
+        with pytest.raises(NotFittedError, match="has not been fitted"):
+            object_instance.check_is_fitted()
 
+    def test_raises_not_fitted_error(self, object_instance):
+        """transform before fit raises NotFittedError"""
+        scenario = _scenario_for(object_instance)
+        with pytest.raises(NotFittedError, match="has not been fitted"):
+            object_instance.transform(**scenario.args["transform"])
 
-@pytest.mark.parametrize("cls, scenario", _cases())
-def test_fit_sets_is_fitted(cls, scenario):
-    """fit returns self and marks the transformer fitted, even if fit_is_empty."""
-    est = cls.create_test_instance()
-    assert est.fit(**scenario.args["fit"]) is est
-    assert est.is_fitted is True
-    est.check_is_fitted()
+    def test_fit_sets_is_fitted(self, object_instance):
+        """fit returns self and marks the transformer fitted, even if fit_is_empty."""
+        scenario = _scenario_for(object_instance)
+        assert object_instance.fit(**scenario.args["fit"]) is object_instance
+        assert object_instance.is_fitted is True
+        object_instance.check_is_fitted()
 
-
-@pytest.mark.parametrize("cls, scenario", _cases())
-def test_fit_transform_sets_is_fitted(cls, scenario):
-    """fit_transform leaves the transformer in a fitted state."""
-    est = cls.create_test_instance()
-    est.fit_transform(**scenario.args["fit"])
-    assert est.is_fitted is True
+    def test_fit_transform_sets_is_fitted(self, object_instance):
+        """fit_transform leaves the transformer in a fitted state."""
+        scenario = _scenario_for(object_instance)
+        object_instance.fit_transform(**scenario.args["fit"])
+        assert object_instance.is_fitted is True
 
 
 def test_stateful_transform_uses_fitted_state():

--- a/pyaptamer/trafos/base/tests/test_base.py
+++ b/pyaptamer/trafos/base/tests/test_base.py
@@ -1,14 +1,12 @@
 """Contract tests for BaseTransform descendants.
 
-Checks the fitted-state and sklearn tag contract against every transformer in
-the package:
+Checks the fitted-state contract against every transformer in the package:
 
     test_scenario_applies             - every transformer is matched by a scenario
     test_not_fitted_before_fit        - is_fitted is False before fit
     test_raises_not_fitted_error      - transform before fit raises NotFittedError
     test_fit_sets_is_fitted           - fit sets is_fitted and returns self
     test_fit_transform_sets_is_fitted - fit_transform leaves the state fitted
-    test_sklearn_tags                 - sklearn reads tags off the transformer
 
 Transformers are discovered with ``all_objects``, and the input each is checked
 against comes from a scenario, after sktime's test design: a scenario supplies
@@ -22,13 +20,10 @@ taking a new kind of input needs a new scenario class.
 
 __author__ = ["siddharth7113"]
 
-import warnings
-
 import pandas as pd
 import pytest
 from skbase._exceptions import NotFittedError
 from skbase.lookup import all_objects
-from sklearn.utils import Tags, get_tags
 
 from pyaptamer.data import MoleculeLoader
 from pyaptamer.trafos.base import BaseTransform
@@ -126,21 +121,9 @@ def test_not_fitted_before_fit(cls):
         est.check_is_fitted()
 
 
-@pytest.mark.parametrize("cls", _transformers(), ids=lambda cls: cls.__name__)
-def test_sklearn_tags(cls):
-    """sklearn reads tags off a transformer instead of falling back to defaults."""
-    est = cls.create_test_instance()
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", DeprecationWarning)
-        tags = get_tags(est)
-    assert isinstance(tags, Tags)
-    assert tags.estimator_type == "transformer"
-    assert tags.transformer_tags is not None
-
-
 @pytest.mark.parametrize("cls, scenario", _cases())
 def test_raises_not_fitted_error(cls, scenario):
-    """transform before fit raises NotFittedError, not a bare AttributeError."""
+    """transform before fit raises NotFittedError"""
     est = cls.create_test_instance()
     with pytest.raises(NotFittedError, match="has not been fitted"):
         est.transform(**scenario.args["transform"])

--- a/pyaptamer/trafos/encode/_greedy.py
+++ b/pyaptamer/trafos/encode/_greedy.py
@@ -139,7 +139,8 @@ class GreedyEncoder(BaseTransform):
 
         return result_df
 
-    def get_test_params(self):
+    @classmethod
+    def get_test_params(cls):
         """Get test parameters for GreedyEncoder.
 
         Returns

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "pandas>=2.3.3",
     "scikit-base",
     "torch>=2.12.1",
+    # <1.8.0: transformers lack __sklearn_tags__ (extend skbase); 1.8 errors. #735
     "scikit-learn>=1.7.2,<1.8.0",
     "skorch",
     "imblearn",
@@ -77,3 +78,9 @@ omit = [
 
 [tool.coverage.report]
 show_missing = true
+
+[tool.pytest.ini_options]
+filterwarnings = [
+    # transformers lack __sklearn_tags__; deferred, sklearn<1.8.0 pin guards. #735
+    "ignore:.*__sklearn_tags__.*:DeprecationWarning",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "numpy>=2.2.6",
     "pandas>=2.3.3",
     "scikit-base",
-    "torch>=2.13,
+    "torch>=2.13",
     # <1.8.0: see issue #735 for sklearn upperbound #TODO: fix it later
     "scikit-learn>=1.7.2,<1.8.0",
     "skorch",


### PR DESCRIPTION
Closes #735 

- Adds `self._is_fitted=True` in `trafos/base.py` which ultimately inherits from `skbase` object.
- pinning `scikit-learn<1.8` for estimator and core-dependiecs like sktime to not break the pipeline.