### PR TITLE
[MNT] add coverage for datasets.dataclasses._api

### DIFF
--- a/pyaptamer/datasets/dataclasses/tests/__init__.py
+++ b/pyaptamer/datasets/dataclasses/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for PyTorch compatible dataset classes."""

--- a/pyaptamer/datasets/dataclasses/tests/test_api.py
+++ b/pyaptamer/datasets/dataclasses/tests/test_api.py
@@ -1,5 +1,7 @@
 """Tests for APIDataset."""
 
+__author__ = ["Elimartain"]
+
 import numpy as np
 import pytest
 import torch

--- a/pyaptamer/datasets/dataclasses/tests/test_api.py
+++ b/pyaptamer/datasets/dataclasses/tests/test_api.py
@@ -1,0 +1,73 @@
+"""Tests for APIDataset."""
+
+import numpy as np
+import pytest
+import torch
+
+from pyaptamer.datasets.dataclasses._api import APIDataset
+
+APTA_MAX_LEN = 10
+PROT_MAX_LEN = 5
+PROT_WORDS = {"A": 1, "C": 2, "D": 3, "AC": 4}
+
+X_APTA = np.array(["AUGCAUGC", "GCUAGCUA"])
+X_PROT = np.array(["ACD", "DCA"])
+Y = np.array(["positive", "negative"])
+
+
+def make_dataset(split="train", x_apta=X_APTA, x_prot=X_PROT, y=Y):
+    """Build an APIDataset from the module-level fixtures."""
+    return APIDataset(
+        x_apta=x_apta,
+        x_prot=x_prot,
+        y=y,
+        apta_max_len=APTA_MAX_LEN,
+        prot_max_len=PROT_MAX_LEN,
+        prot_words=PROT_WORDS,
+        split=split,
+    )
+
+
+def test_unknown_split_raises():
+    """An unrecognised split is rejected before any data is prepared."""
+    with pytest.raises(ValueError, match="Unknown split: valid"):
+        make_dataset(split="valid")
+
+
+@pytest.mark.parametrize(
+    "split, expected_len",
+    [
+        ("train", 2 * len(X_APTA)),  # reversed sequences are appended
+        ("test", len(X_APTA)),  # no augmentation
+    ],
+)
+def test_split_controls_augmentation(split, expected_len):
+    """Split train doubles the dataset with reversed aptamers, test does not."""
+    dataset = make_dataset(split=split)
+    assert len(dataset) == expected_len
+    assert dataset.x_apta.shape == (expected_len, APTA_MAX_LEN)
+    assert dataset.x_prot.shape == (expected_len, PROT_MAX_LEN)
+    assert dataset.y.shape == (expected_len,)
+
+
+def test_train_split_duplicates_proteins_and_labels():
+    """Augmentation repeats x_prot and y so all three arrays stay aligned."""
+    dataset = make_dataset(split="train")
+    n = len(X_APTA)
+    assert torch.equal(dataset.x_prot[:n], dataset.x_prot[n:])
+    assert torch.equal(dataset.y[:n], dataset.y[n:])
+
+
+def test_labels_are_encoded_as_binary():
+    """Labels equal to positive map to 1 and anything else maps to 0."""
+    dataset = make_dataset(split="test")
+    assert torch.equal(dataset.y, torch.tensor([1, 0]))
+
+
+def test_getitem_returns_aligned_triple():
+    """__getitem__ returns the aptamer, protein and label at the same index."""
+    dataset = make_dataset(split="test")
+    x_apta, x_prot, y = dataset[1]
+    assert torch.equal(x_apta, dataset.x_apta[1])
+    assert torch.equal(x_prot, dataset.x_prot[1])
+    assert torch.equal(y, dataset.y[1])


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #721. Part of #719.

#### What does this implement/fix? Explain your changes.

`APIDataset` had no tests, so `pyaptamer/datasets/dataclasses/_api.py` sat at 39% with lines 47-59, 84-103, 106 and 109 uncovered.

Adds `pyaptamer/datasets/dataclasses/tests/test_api.py` with six tests covering:

- the `ValueError` raised for a split other than "train" or "test"
- "train" appending reversed aptamers and doubling the dataset, "test" leaving it unchanged
- `x_prot` and `y` being duplicated alongside the augmented aptamers, so all three arrays stay aligned
- "positive" labels encoding to 1 and everything else to 0
- `__len__` and `__getitem__` returning the triple at the right index

Measured locally with the CI command on Python 3.12:

| | `_api.py` | repo total | suite |
| --- | --- | --- | --- |
| before | 31 stmts, 19 missed, 39% | 90% | 388 passed, 5 skipped |
| after | 31 stmts, 0 missed, 100% | 92% | 394 passed, 5 skipped |

No existing files are modified, only the two new test files are added.

#### What should a reviewer concentrate their feedback on?

- Whether these should wait for #430 (moving `APIDataset` onto a base dataset object). I asked on the issue and have not heard back yet, so they are written against the current shape. Happy to rework them if you would rather they land after that.
- The `prot_words` mapping in the fixture. I reused the small one from the `encode_rna` docstring rather than a realistic 3-mer table, since these tests only need the encoding to be deterministic.

#### Did you add any tests for the change?

Yes, this PR is only tests. Run with:

```
pytest pyaptamer/datasets/dataclasses/tests/test_api.py -p no:warnings --cov=pyaptamer --cov-report=term-missing
```
