### PR TITLE
[MNT] add coverage for datasets._loaders._hf_to_dataset_loader

### DIFF
--- a/pyaptamer/datasets/tests/test_hf_to_dataset.py
+++ b/pyaptamer/datasets/tests/test_hf_to_dataset.py
@@ -1,6 +1,46 @@
 import os
 
+import pytest
+import requests
+
 from pyaptamer.datasets import load_hf_to_dataset
+from pyaptamer.datasets._loaders import _hf_to_dataset_loader
+
+FASTA_URL = "https://example.invalid/datasets/dummy.fasta"
+FASTA_BYTES = b">seq1\nACGT\n"
+
+
+class _StubResponse:
+    """Stand-in for a ``requests`` response, exposing only what the loader uses."""
+
+    def __init__(self, content=FASTA_BYTES, error=None):
+        self.content = content
+        self._error = error
+
+    def raise_for_status(self):
+        """Raise the configured error, like a real response would on a bad status."""
+        if self._error is not None:
+            raise self._error
+
+
+def _patch_requests_get(monkeypatch, calls, error=None):
+    """Replace ``requests.get`` in the loader with a stub recording every call."""
+
+    def fake_get(url, *args, **kwargs):
+        calls.append(url)
+        return _StubResponse(error=error)
+
+    monkeypatch.setattr(_hf_to_dataset_loader.requests, "get", fake_get)
+
+
+def _patch_load_dataset(monkeypatch, calls, returns):
+    """Replace ``load_dataset`` in the loader so nothing reaches the HF Hub."""
+
+    def fake_load_dataset(*args, **kwargs):
+        calls.append((args, kwargs))
+        return returns
+
+    monkeypatch.setattr(_hf_to_dataset_loader, "load_dataset", fake_load_dataset)
 
 
 def test_hf_hub_dataset_load():
@@ -18,3 +58,63 @@ def test_load_pdb_local_file():
     )
     ds = load_hf_to_dataset(pdb_file)
     assert "text" in ds.column_names
+
+
+def test_download_locally_writes_file_and_loads_it(tmp_path, monkeypatch):
+    """download_locally=True saves the URL under ./hf_datasets/ and loads that copy."""
+    monkeypatch.chdir(tmp_path)
+    get_calls = []
+    load_calls = []
+    _patch_requests_get(monkeypatch, get_calls)
+    _patch_load_dataset(monkeypatch, load_calls, {"train": "a", "test": "b"})
+
+    ds = load_hf_to_dataset(FASTA_URL, download_locally=True)
+
+    local_path = tmp_path / "hf_datasets" / "dummy.fasta"
+    assert local_path.read_bytes() == FASTA_BYTES
+    assert get_calls == [FASTA_URL]
+    assert load_calls[0][0] == ("text",)
+    assert load_calls[0][1]["data_files"] == os.path.join("hf_datasets", "dummy.fasta")
+    assert ds == {"train": "a", "test": "b"}
+
+
+def test_download_locally_reuses_cached_file(tmp_path, monkeypatch):
+    """A second load of the same URL reads the cached file instead of downloading."""
+    monkeypatch.chdir(tmp_path)
+    get_calls = []
+    load_calls = []
+    _patch_requests_get(monkeypatch, get_calls)
+    _patch_load_dataset(monkeypatch, load_calls, {"train": "a", "test": "b"})
+
+    load_hf_to_dataset(FASTA_URL, download_locally=True)
+    load_hf_to_dataset(FASTA_URL, download_locally=True)
+
+    assert get_calls == [FASTA_URL]
+    assert len(load_calls) == 2
+    assert (tmp_path / "hf_datasets" / "dummy.fasta").read_bytes() == FASTA_BYTES
+
+
+def test_download_locally_propagates_http_error(tmp_path, monkeypatch):
+    """A failing download raises and leaves no partial file behind."""
+    monkeypatch.chdir(tmp_path)
+    get_calls = []
+    load_calls = []
+    _patch_requests_get(monkeypatch, get_calls, error=requests.HTTPError("404"))
+    _patch_load_dataset(monkeypatch, load_calls, {"train": "a"})
+
+    with pytest.raises(requests.HTTPError):
+        load_hf_to_dataset(FASTA_URL, download_locally=True)
+
+    assert not (tmp_path / "hf_datasets" / "dummy.fasta").exists()
+    assert load_calls == []
+
+
+def test_single_split_dict_is_unwrapped(monkeypatch):
+    """A dataset with one split is returned directly rather than as a mapping."""
+    load_calls = []
+    _patch_load_dataset(monkeypatch, load_calls, {"train": "only-split"})
+
+    ds = load_hf_to_dataset("some-org/some-dataset")
+
+    assert ds == "only-split"
+    assert load_calls[0][0] == ("some-org/some-dataset",)


### PR DESCRIPTION
LLM generated content, by Claude Opus 5

#### Reference Issues/PRs

Fixes #723.

#### What does this implement/fix? Explain your changes.

`datasets/_loaders/_hf_to_dataset_loader.py` was at 59% line coverage. Both existing tests load a real source through `load_dataset`, so `_download_to_cwd` never ran and neither did the `download_locally=True` branch of `load_hf_to_dataset`.

I added four tests to the existing `pyaptamer/datasets/tests/test_hf_to_dataset.py`. They stub `requests.get` and `load_dataset` inside the loader module and run under a `tmp_path` chdir, so nothing touches the network or the Hub. They check that the file lands in `./hf_datasets/<name>` and that the local path is what gets loaded, that a second call reuses the cached file instead of downloading again, that a failed `raise_for_status` propagates and leaves no partial file behind, and that a single split result is unwrapped.

The module is at 100% after this. No production code changed.

#### What should a reviewer concentrate their feedback on?

- Whether the two small stub helpers at the top of the file match the style you want, or whether you would rather see pytest fixtures.
- The two older tests in that file still reach the network. I left them alone, but I am happy to mock those too if you want the file fully offline.

#### Did you add any tests for the change?

The change is only tests. Four new ones, each with a one line docstring.

#### Any other comments?

Ran `python -m pytest pyaptamer/datasets/tests/test_hf_to_dataset.py -p no:warnings --cov=pyaptamer` locally, 6 passed, and the loader module reports 27 statements with 0 missed.

#### PR checklist

- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
- [x] Added/modified tests
- [x] Ran the pre-commit hook equivalents on the changed file: `ruff format`, `ruff check`, and LF line endings. All clean.