### PR TITLE
[ENH] MoleculeLoader.iter_dataframe for chunked loading of large files

### DIFF
--- a/pyaptamer/data/loader.py
+++ b/pyaptamer/data/loader.py
@@ -16,7 +16,8 @@ class MoleculeLoader:
 
     Holds tabular data whose cells may be file references (FASTA, PDB,
     FASTQ, ...) or in-memory values (sequence strings, numbers). Files are
-    not parsed until ``to_dataframe`` is called.
+    not parsed until ``to_dataframe`` or ``iter_dataframe`` is called. For
+    files too large to hold in memory at once, use ``iter_dataframe``.
 
     Parameters
     ----------
@@ -138,6 +139,113 @@ class MoleculeLoader:
             return self._tile_features(df)
         return self._tile_samples(df, product_mode=self.tiling == "samples_product")
 
+    def iter_dataframe(self, chunksize=100_000):
+        """Yield the table as DataFrame chunks of at most ``chunksize`` rows.
+
+        Files are read while the chunks are consumed, so a file much larger
+        than memory can be processed chunk by chunk. Concatenating all chunks
+        gives the same table as :meth:`to_dataframe`.
+
+        Not every option can be chunked: ``tiling="features"`` and
+        ``multiindex="auto"`` need the whole table before the first chunk
+        can be built, so they raise ValueError here.
+
+        Parameters
+        ----------
+        chunksize : int, default=100_000
+            Maximum number of rows per yielded DataFrame.
+
+        Yields
+        ------
+        pandas.DataFrame
+            Consecutive row chunks of the table :meth:`to_dataframe` would
+            return.
+
+        Examples
+        --------
+        >>> from pyaptamer.data.loader import MoleculeLoader
+        >>> loader = MoleculeLoader(data={"target": ["ACGT", "TTGG", "CCAA"]})
+        >>> [len(chunk) for chunk in loader.iter_dataframe(chunksize=2)]
+        [2, 1]
+
+        The packaged sample FASTQ (10 reads) in chunks of 4 rows:
+
+        >>> from pyaptamer.datasets import load_sample_fastq
+        >>> loader = load_sample_fastq()
+        >>> [len(chunk) for chunk in loader.iter_dataframe(chunksize=4)]
+        [4, 4, 2]
+        """
+        if not isinstance(chunksize, int) or chunksize < 1:
+            raise ValueError(f"chunksize must be a positive integer, got {chunksize!r}")
+        if self.tiling == "features":
+            raise ValueError(
+                "iter_dataframe does not support tiling='features': the number "
+                "of output columns depends on all rows, so no chunk can be "
+                "built before the whole table is read. Use to_dataframe instead."
+            )
+        if self.multiindex == "auto" and self.tiling in {"samples", "samples_product"}:
+            raise ValueError(
+                "iter_dataframe does not support multiindex='auto': whether the "
+                "table expands is only known after all rows are read. Use "
+                "multiindex='flatten' or 'multiindex'."
+            )
+        return self._iter_chunks(chunksize)
+
+    def _iter_chunks(self, chunksize):
+        """Generator behind :meth:`iter_dataframe`."""
+        df = pd.DataFrame(self.data)
+
+        if self.tiling in {"bag", "concat", "first"}:
+            for start in range(0, len(df), chunksize):
+                yield df.iloc[start : start + chunksize].map(self._materialize_cell)
+            return
+
+        chain_cols = [
+            col for col in df.columns if df[col].map(self._is_path_like).any()
+        ]
+        product_mode = self.tiling == "samples_product"
+        offset = 0
+        rows, parents, seq_ids = [], [], []
+        chain_id_cols = {col: [] for col in df.columns}
+
+        for row_dict, pos, seq_id, cid_map in self._iter_sample_rows(df, product_mode):
+            rows.append(row_dict)
+            parents.append(pos)
+            seq_ids.append(seq_id)
+            for col in df.columns:
+                chain_id_cols[col].append(cid_map[col])
+
+            if len(rows) == chunksize:
+                yield self._finalize_chunk(
+                    df, rows, parents, seq_ids, chain_id_cols, chain_cols, offset
+                )
+                offset += len(rows)
+                rows, parents, seq_ids = [], [], []
+                chain_id_cols = {col: [] for col in df.columns}
+
+        if rows:
+            yield self._finalize_chunk(
+                df, rows, parents, seq_ids, chain_id_cols, chain_cols, offset
+            )
+
+    def _finalize_chunk(
+        self, df, rows, parents, seq_ids, chain_id_cols, chain_cols, offset
+    ):
+        """Build one chunk with row numbering that continues across chunks."""
+        out = pd.DataFrame(rows, columns=list(df.columns))
+        out = self._finalize_index(
+            out,
+            df.index,
+            parents,
+            seq_ids,
+            chain_id_cols,
+            expanded=False,
+            chain_cols=chain_cols,
+        )
+        if self.indexing in {"new", "keep_as_column"}:
+            out.index = pd.RangeIndex(offset, offset + len(out))
+        return out
+
     def _cell_records(self, value):
         """Normalize a cell to ``(is_file, [(chain_id, sequence), ...])``.
 
@@ -158,27 +266,22 @@ class MoleculeLoader:
         """
         if not self._is_path_like(value):
             return False, [(None, value)]
+        return True, list(self._iter_cell_records(value))
 
-        loaded = self._load_dispatch(Path(value))
-        records = list(
-            zip(
-                loaded["chain_id"].tolist(),
-                loaded["sequence"].tolist(),
-                strict=True,
-            )
-        )
+    def _iter_cell_records(self, value):
+        """Yield ``(chain_id, sequence)`` records of a file cell one at a time.
 
-        if self.ignore_duplicates:
-            seen = set()
-            unique = []
-            for chain_id, seq in records:
+        Streams the file, so only one record is in memory at once. When
+        ``ignore_duplicates`` is set, repeated sequences are skipped (first
+        occurrence wins).
+        """
+        seen = set()
+        for chain_id, seq in self._iter_file_records(Path(value)):
+            if self.ignore_duplicates:
                 if seq in seen:
                     continue
                 seen.add(seq)
-                unique.append((chain_id, seq))
-            records = unique
-
-        return True, records
+            yield chain_id, seq
 
     def _materialize_cell(self, value):
         """Render one cell for the per-cell tilings ``bag``/``concat``/``first``.
@@ -271,35 +374,32 @@ class MoleculeLoader:
 
         return pd.DataFrame(new_data, index=df.index)
 
-    def _tile_samples(self, df, product_mode):
-        """Explode file cells into rows (``samples`` / ``samples_product``).
+    def _iter_sample_rows(self, df, product_mode):
+        """Yield exploded rows one at a time for the ``samples`` tilings.
 
-        Each file cell contributes one row per sequence. Literal columns are
-        repeated. With several file columns in a row, ``samples`` zips them
-        (and requires matching counts), while ``samples_product`` takes their
-        cartesian product.
+        Yields ``(row_dict, parent_pos, seq_id, cid_map)``: the output row,
+        the position of its input row, the sequence ID used for indexing, and
+        a column -> chain ID map (None for literal columns). A row with one
+        file column is streamed record by record, so the file is never fully
+        in memory.
         """
-        rows = []
-        parents = []
-        seq_ids = []
-        chain_id_cols = {col: [] for col in df.columns}
-        expanded = False
-
         for pos, (_, row) in enumerate(df.iterrows()):
-            col_recs = {col: self._cell_records(row[col]) for col in df.columns}
-            file_cols = [col for col in df.columns if col_recs[col][0]]
+            file_cols = [col for col in df.columns if self._is_path_like(row[col])]
 
             if not file_cols:
-                rows.append({col: row[col] for col in df.columns})
-                parents.append(pos)
-                seq_ids.append(None)
-                for col in df.columns:
-                    chain_id_cols[col].append(None)
+                yield (
+                    {col: row[col] for col in df.columns},
+                    pos,
+                    None,
+                    dict.fromkeys(df.columns),
+                )
                 continue
 
-            recs_per_col = [col_recs[col][1] for col in file_cols]
             if product_mode:
-                combos = list(product(*recs_per_col))
+                recs_per_col = [
+                    list(self._iter_cell_records(row[col])) for col in file_cols
+                ]
+                combos = product(*recs_per_col)
             elif len(file_cols) > 1:
                 raise ValueError(
                     "tiling='samples' cannot expand more than one file column "
@@ -310,10 +410,7 @@ class MoleculeLoader:
                     "per-column tiling (planned)."
                 )
             else:
-                combos = list(zip(*recs_per_col, strict=True))
-
-            if len(combos) > 1:
-                expanded = True
+                combos = ((rec,) for rec in self._iter_cell_records(row[file_cols[0]]))
 
             for combo in combos:
                 new_row = {}
@@ -326,28 +423,63 @@ class MoleculeLoader:
                     else:
                         new_row[col] = row[col]
                         cid_map[col] = None
-                rows.append(new_row)
-                parents.append(pos)
                 if len(file_cols) == 1:
-                    seq_ids.append(cid_map[file_cols[0]])
+                    seq_id = cid_map[file_cols[0]]
                 else:
-                    seq_ids.append(tuple(cid_map[col] for col in file_cols))
-                for col in df.columns:
-                    chain_id_cols[col].append(cid_map[col])
+                    seq_id = tuple(cid_map[col] for col in file_cols)
+                yield new_row, pos, seq_id, cid_map
 
+    def _tile_samples(self, df, product_mode):
+        """Explode file cells into rows (``samples`` / ``samples_product``).
+
+        Each file cell contributes one row per sequence. Literal columns are
+        repeated. With several file columns in a row, ``samples`` raises,
+        while ``samples_product`` takes their cartesian product.
+        """
+        rows = []
+        parents = []
+        seq_ids = []
+        chain_id_cols = {col: [] for col in df.columns}
+
+        for row_dict, pos, seq_id, cid_map in self._iter_sample_rows(df, product_mode):
+            rows.append(row_dict)
+            parents.append(pos)
+            seq_ids.append(seq_id)
+            for col in df.columns:
+                chain_id_cols[col].append(cid_map[col])
+
+        expanded = len(parents) > len(set(parents))
         out = pd.DataFrame(rows, columns=list(df.columns))
         return self._finalize_index(
             out, df.index, parents, seq_ids, chain_id_cols, expanded
         )
 
     def _finalize_index(
-        self, out, orig_index, parents, seq_ids, chain_id_cols, expanded
+        self,
+        out,
+        orig_index,
+        parents,
+        seq_ids,
+        chain_id_cols,
+        expanded,
+        chain_cols=None,
     ):
-        """Apply ``indexing`` and ``multiindex`` to an exploded frame."""
+        """Apply ``indexing`` and ``multiindex`` to an exploded frame.
+
+        ``chain_cols`` fixes which columns get a ``<col>_chain_id`` column
+        under ``indexing='keep_as_column'``; by default those with any
+        non-None chain ID. Chunked loading passes it so every chunk gets the
+        same columns.
+        """
         if self.indexing == "keep_as_column":
-            for col, cids in chain_id_cols.items():
-                if any(cid is not None for cid in cids):
-                    out[f"{col}_chain_id"] = cids
+            if chain_cols is None:
+                chain_cols = [
+                    col
+                    for col, cids in chain_id_cols.items()
+                    if any(cid is not None for cid in cids)
+                ]
+            for col in chain_cols:
+                out[f"{col}_chain_id"] = chain_id_cols[col]
             out.index = pd.RangeIndex(len(out))
             return out
 
@@ -398,16 +530,15 @@ class MoleculeLoader:
         suffix = path.suffix.lower()
         return suffix.lstrip(".") if suffix else None
 
-    def _load_dispatch(self, path):
-        """Dispatch the loader based on file type.
+    def _iter_file_records(self, path):
+        """Yield ``(chain_id, sequence)`` pairs from a file, streaming.
 
-        Returns
-        -------
-        pd.DataFrame
-            DataFrame with columns ``["chain_id", "sequence"]``.
+        PDB files are read through the ``pdb-seqres`` parser and use the
+        chain ID; other formats go through :func:`Bio.SeqIO.parse` and use
+        ``record.id`` as the chain ID, since they have no chain concept.
+        Raises ValueError for a file with no records, after the stream ends.
         """
         fmt = self._determine_type(path)
-
         if fmt is None:
             raise ValueError(
                 f"{type(self).__name__} picks the parser from the file suffix, "
@@ -418,65 +549,14 @@ class MoleculeLoader:
                 "suffix."
             )
 
-        if fmt == "pdb":
-            return self._load_pdb_seq(path)
-
-        return self._load_seqio(path, fmt)
-
-    def _load_pdb_seq(self, path):
-        """Load a PDB file and extract the amino-acid sequences.
-
-        Parameters
-        ----------
-        path : Path
-            path to PDB file
-
-        Returns
-        -------
-        pandas.DataFrame
-            DataFrame with columns ``["chain_id", "sequence"]``.
-        """
+        seqio_fmt = "pdb-seqres" if fmt == "pdb" else fmt
+        count = 0
         with open(path) as handle:
-            seqres_records = list(SeqIO.parse(handle, "pdb-seqres"))
-
-        records = [
-            {
-                "chain_id": record.id.split(":")[1] if ":" in record.id else record.id,
-                "sequence": str(record.seq),
-            }
-            for record in seqres_records
-        ]
-        if not records:
+            for record in SeqIO.parse(handle, seqio_fmt):
+                count += 1
+                if fmt == "pdb" and ":" in record.id:
+                    yield record.id.split(":")[1], str(record.seq)
+                else:
+                    yield record.id, str(record.seq)
+        if count == 0:
             raise ValueError(f"No sequences found in {path}")
-
-        return pd.DataFrame.from_records(records, columns=["chain_id", "sequence"])
-
-    def _load_seqio(self, path, fmt):
-        """Load any non-PDB file format supported by Biopython SeqIO.
-
-        Notes
-        -----
-        For non-PDB formats there is usually no literal chain concept.
-        To preserve the existing abstract datatype, ``record.id`` is stored
-        in the ``chain_id`` column.
-
-        Returns
-        -------
-        pd.DataFrame
-            DataFrame with columns ``["chain_id", "sequence"]``.
-        """
-        with open(path) as handle:
-            records = list(SeqIO.parse(handle, fmt))
-
-        rows = [
-            {
-                "chain_id": record.id,
-                "sequence": str(record.seq),
-            }
-            for record in records
-        ]
-
-        if not rows:
-            raise ValueError(f"No sequences found in {path}")
-
-        return pd.DataFrame.from_records(rows, columns=["chain_id", "sequence"])

--- a/pyaptamer/data/tests/test_loader.py
+++ b/pyaptamer/data/tests/test_loader.py
@@ -336,3 +336,135 @@ def test_no_seqres_pdb_raises():
     loader = MoleculeLoader(data={"target": [PDB_NO_SEQRES]})
     with pytest.raises(ValueError, match="No sequences found"):
         loader.to_dataframe()
+
+
+# --------------------------------------------------------------------------- #
+# iter_dataframe: chunked loading
+# --------------------------------------------------------------------------- #
+SAMPLE_FASTQ = str(DATA_DIR / "sample.fastq")  # 10 reads
+
+
+@pytest.mark.parametrize("indexing", ["preserve", "new", "keep_as_column"])
+def test_iter_dataframe_chunks_equal_eager_result(indexing):
+    """samples: concatenated chunks equal to_dataframe for every indexing."""
+    kwargs = {
+        "data": {"selex": [SAMPLE_FASTQ], "binding": [0.5]},
+        "tiling": "samples",
+        "indexing": indexing,
+    }
+
+    eager = MoleculeLoader(**kwargs).to_dataframe()
+    chunks = list(MoleculeLoader(**kwargs).iter_dataframe(chunksize=4))
+
+    assert [len(c) for c in chunks] == [4, 4, 2]
+    pd.testing.assert_frame_equal(pd.concat(chunks), eager)
+
+
+def test_iter_dataframe_multiindex_chunks():
+    """samples + multiindex: chunks carry the two-level index and match eager."""
+    kwargs = {
+        "data": {"selex": [SAMPLE_FASTQ]},
+        "tiling": "samples",
+        "multiindex": "multiindex",
+    }
+
+    eager = MoleculeLoader(**kwargs).to_dataframe()
+    chunks = list(MoleculeLoader(**kwargs).iter_dataframe(chunksize=4))
+
+    assert all(isinstance(c.index, pd.MultiIndex) for c in chunks)
+    pd.testing.assert_frame_equal(pd.concat(chunks), eager)
+
+
+def test_iter_dataframe_on_load_sample_fastq():
+    """The packaged sample FASTQ loader chunks and matches its eager result."""
+    from pyaptamer.datasets import load_sample_fastq
+
+    eager = load_sample_fastq().to_dataframe()
+    chunks = list(load_sample_fastq().iter_dataframe(chunksize=5))
+
+    assert [len(c) for c in chunks] == [5, 5]
+    pd.testing.assert_frame_equal(pd.concat(chunks), eager)
+
+
+def test_iter_dataframe_samples_product():
+    """samples_product: chunks cover the full cartesian product."""
+    kwargs = {
+        "data": {"a": [PDB_MULTI], "b": [PDB_MULTI]},
+        "tiling": "samples_product",
+        "indexing": "new",
+    }
+
+    eager = MoleculeLoader(**kwargs).to_dataframe()
+    chunks = list(MoleculeLoader(**kwargs).iter_dataframe(chunksize=30))
+
+    assert [len(c) for c in chunks] == [30, 30, 30, 10]
+    pd.testing.assert_frame_equal(pd.concat(chunks), eager)
+
+
+@pytest.mark.parametrize("tiling", ["bag", "concat", "first"])
+def test_iter_dataframe_per_cell_tilings(tiling):
+    """bag/concat/first: chunks split by input row and match eager."""
+    kwargs = {"data": {"target": [PDB_MULTI, PDB_SINGLE]}, "tiling": tiling}
+
+    eager = MoleculeLoader(**kwargs).to_dataframe()
+    chunks = list(MoleculeLoader(**kwargs).iter_dataframe(chunksize=1))
+
+    assert len(chunks) == 2
+    pd.testing.assert_frame_equal(pd.concat(chunks), eager)
+
+
+def test_iter_dataframe_in_memory_data():
+    """In-memory columns chunk without touching any file."""
+    loader = MoleculeLoader(
+        data={"target": ["ACGT", "TTGG", "CCAA"], "binding": [1, 2, 3]}
+    )
+    chunks = list(loader.iter_dataframe(chunksize=2))
+
+    assert [len(c) for c in chunks] == [2, 1]
+
+
+def test_iter_dataframe_reads_rows_lazily(tmp_path):
+    """The first chunk arrives before a later, missing file is opened."""
+    loader = MoleculeLoader(
+        data={"selex": [SAMPLE_FASTQ, str(tmp_path / "missing.fastq")]},
+        tiling="samples",
+    )
+
+    chunks = loader.iter_dataframe(chunksize=10)
+    first = next(chunks)
+
+    assert len(first) == 10
+    with pytest.raises(FileNotFoundError):
+        next(chunks)
+
+
+def test_iter_dataframe_features_raises():
+    """features needs the whole table at once, so iter_dataframe rejects it."""
+    loader = MoleculeLoader(data={"target": [PDB_MULTI]}, tiling="features")
+    with pytest.raises(ValueError, match="features"):
+        loader.iter_dataframe(chunksize=2)
+
+
+def test_iter_dataframe_auto_multiindex_raises():
+    """multiindex='auto' cannot be decided per chunk, so it is rejected."""
+    loader = MoleculeLoader(
+        data={"target": [PDB_MULTI]}, tiling="samples", multiindex="auto"
+    )
+    with pytest.raises(ValueError, match="auto"):
+        loader.iter_dataframe(chunksize=2)
+
+
+def test_iter_dataframe_invalid_chunksize_raises():
+    """chunksize must be a positive integer."""
+    loader = MoleculeLoader(data={"target": ["ACGT"]})
+    with pytest.raises(ValueError, match="chunksize"):
+        loader.iter_dataframe(chunksize=0)
+
+
+def test_iter_dataframe_samples_two_file_columns_raise():
+    """samples: two file columns raise the same error as to_dataframe."""
+    loader = MoleculeLoader(
+        data={"target": [PDB_MULTI], "ligand": [PDB_SINGLE]}, tiling="samples"
+    )
+    with pytest.raises(ValueError, match="more than one file column"):
+        list(loader.iter_dataframe(chunksize=5))


### PR DESCRIPTION
Fixes #765.

Adds `MoleculeLoader.iter_dataframe(chunksize)`, which yields DataFrame chunks so GiB-scale FASTQ files can be processed without loading the whole table. Internally, files are now streamed record by record instead of read with `list(SeqIO.parse(...))`. `to_dataframe()` is unchanged, and concatenating all chunks gives the same table. `tiling="features"` and `multiindex="auto"` raise in `iter_dataframe`, since they need the whole table before the first chunk.

Stacked on #752 to use its `sample.fastq` / `load_sample_fastq()` in tests; will be rebased onto `main` once #752 merges. Only the last commit is new.
