### PR TITLE
[BUG] MoleculeLoader: read pathlib.Path cells as files

### DIFF
--- a/pyaptamer/data/loader.py
+++ b/pyaptamer/data/loader.py
@@ -3,6 +3,7 @@
 __all__ = ["MoleculeLoader"]
 __author__ = ["fkiraly", "satvshr", "siddharth7113"]
 
+import os
 from itertools import product
 from pathlib import Path
 
@@ -22,6 +23,9 @@ class MoleculeLoader:
     data : dict, list of lists, or pandas.DataFrame
         2D data coercible by ``pandas.DataFrame``. Keys (or columns) become
         column names; cells hold file paths, sequence strings, or primitives.
+        A file path may be a ``str`` or any :class:`os.PathLike`. A
+        ``PathLike`` is always read as a file; a ``str`` is read as a file
+        only when it has a suffix, so that sequence strings stay literal.
     tiling : str, default="bag"
         How multi-sequence files are materialized. One of ``"bag"``,
         ``"features"``, ``"samples"``, ``"samples_product"``, ``"first"``,
@@ -212,18 +216,25 @@ class MoleculeLoader:
         return sequences[0] if len(sequences) == 1 else sequences
 
     def _is_path_like(self, value):
-        """Return True if ``value`` looks like a file reference.
+        """Return True if ``value`` is a file reference.
 
-        A cell is treated as a file when it is a string with a non-empty
-        suffix (e.g. ``"1gnh.pdb"``). Sequence strings such as ``"ACGT"`` have
-        no suffix and are left untouched.
+        An :class:`os.PathLike` is always one. Wrapping a value in ``Path``
+        states the intent, so nothing has to be guessed and a filename with no
+        suffix is still a filename.
+
+        A ``str`` is ambiguous, because a cell may equally hold a sequence such
+        as ``"ACGT"``. Strings are therefore read as files only when they carry
+        a non-empty suffix, for example ``"1gnh.pdb"``.
 
         Notes
         -----
-        Failure mode: a sequence string that happens to contain a dot would be
-        misread as a path. Biological sequences do not contain dots, so this
-        heuristic is acceptable for the initial implementation.
+        Failure mode of the string heuristic: a sequence that happens to
+        contain a dot would be misread as a path. Biological sequences do not
+        contain dots, so this is acceptable. Wrap the value in ``Path`` to
+        bypass the heuristic in either direction.
         """
+        if isinstance(value, os.PathLike):
+            return True
         return isinstance(value, str) and Path(value).suffix != ""
 
     def _tile_features(self, df):
@@ -398,7 +409,14 @@ class MoleculeLoader:
         fmt = self._determine_type(path)
 
         if fmt is None:
-            raise ValueError(f"Could not determine file format for '{path}'.")
+            raise ValueError(
+                f"{type(self).__name__} picks the parser from the file suffix, "
+                f"and '{path}' has none. Give the file the suffix of the format "
+                "it is in, such as .fasta, .fastq or .pdb. If this cell was "
+                "meant to hold a sequence and not a filename, pass it as a str: "
+                "a Path is always read as a file, a str only when it has a "
+                "suffix."
+            )
 
         if fmt == "pdb":
             return self._load_pdb_seq(path)

--- a/pyaptamer/data/tests/test_loader.py
+++ b/pyaptamer/data/tests/test_loader.py
@@ -265,6 +265,56 @@ def test_fasta_path_broadcasts_against_in_memory_column(tmp_path):
 
 
 # --------------------------------------------------------------------------- #
+# path-like cells
+#
+# Cells may hold a str or any os.PathLike. A Path used to fall through to the
+# literal branch and be returned unparsed, which was silent rather than an
+# error, so both forms are checked against each other.
+# --------------------------------------------------------------------------- #
+def test_path_object_parses_like_str():
+    """A Path cell is parsed, not passed through as a literal."""
+    as_str = MoleculeLoader(data={"target": [PDB_SINGLE]}).to_dataframe()
+    as_path = MoleculeLoader(data={"target": [Path(PDB_SINGLE)]}).to_dataframe()
+
+    assert as_path.equals(as_str)
+    assert isinstance(as_path["target"].iloc[0], str)
+
+
+def test_path_object_explodes_to_rows_under_samples():
+    """A Path FASTQ expands to one row per read, like its str equivalent."""
+    fastq = DATA_DIR / "sample.fastq"
+
+    as_str = MoleculeLoader(data={"seq": [str(fastq)]}, tiling="samples").to_dataframe()
+    as_path = MoleculeLoader(data={"seq": [fastq]}, tiling="samples").to_dataframe()
+
+    assert len(as_path) == 10
+    assert as_path.equals(as_str)
+
+
+def test_suffixless_path_is_still_a_file():
+    """A Path states intent, so it is read as a file even without a suffix."""
+    with pytest.raises(ValueError, match="picks the parser from the file suffix"):
+        MoleculeLoader(data={"seq": [Path("reads")]}).to_dataframe()
+
+
+def test_suffixless_str_stays_a_literal():
+    """A str without a suffix is a sequence, not a file."""
+    df = MoleculeLoader(data={"seq": ["ACGT"]}).to_dataframe()
+
+    assert df["seq"].iloc[0] == "ACGT"
+
+
+def test_str_and_path_mix_in_one_column():
+    """Both spellings can appear in the same column."""
+    fastq = DATA_DIR / "sample.fastq"
+
+    loader = MoleculeLoader(data={"seq": [str(fastq), fastq]}, tiling="samples")
+    df = loader.to_dataframe()
+
+    assert len(df) == 20
+
+
+# --------------------------------------------------------------------------- #
 # validation / errors
 # --------------------------------------------------------------------------- #
 @pytest.mark.parametrize(


### PR DESCRIPTION
#### Reference Issues/PRs
Closes #768

#### What does this implement/fix? Explain your changes.
`_is_path_like` gated on `isinstance(value, str)`, so a `pathlib.Path` cell fell through to the literal branch and was returned unparsed. No error was raised, so the caller got a one-row frame holding a `PosixPath` instead of the parsed records.

`os.PathLike` is now always a file reference, suffix or not. A `str` keeps the suffix heuristic, so sequence strings such as `"ACGT"` stay literal.

The suffixless error now names the loader and says what to do, since a `Path` reaches it in a new way.

#### Did you add any tests for the change?
Yes, five in `pyaptamer/data/tests/test_loader.py`. Two fail without the fix.
