### PR TITLE
[ENH] MoleculeLoader: stream file records, fast FASTQ reader, gzip support

### DIFF
--- a/pyaptamer/data/loader.py
+++ b/pyaptamer/data/loader.py
@@ -3,12 +3,14 @@
 __all__ = ["MoleculeLoader"]
 __author__ = ["fkiraly", "satvshr", "siddharth7113"]
 
+import gzip
 import os
 from itertools import product
 from pathlib import Path
 
 import pandas as pd
 from Bio import SeqIO
+from Bio.SeqIO.QualityIO import FastqGeneralIterator
 
 
 class MoleculeLoader:
@@ -45,6 +47,8 @@ class MoleculeLoader:
     Supported file formats are anything :func:`Bio.SeqIO.parse` can read
     (FASTA, GenBank, EMBL, FASTQ, ...); PDB files are read through the
     ``pdb-seqres`` parser. The format is inferred from the file suffix.
+    Gzipped files are read directly: ``reads.fastq.gz`` is decompressed
+    and parsed as FASTQ.
 
     Examples
     --------
@@ -159,14 +163,9 @@ class MoleculeLoader:
         if not self._is_path_like(value):
             return False, [(None, value)]
 
-        loaded = self._load_dispatch(Path(value))
-        records = list(
-            zip(
-                loaded["chain_id"].tolist(),
-                loaded["sequence"].tolist(),
-                strict=True,
-            )
-        )
+        records = list(self._iter_records(Path(value)))
+        if not records:
+            raise ValueError(f"No sequences found in {value}")
 
         if self.ignore_duplicates:
             seen = set()
@@ -275,25 +274,29 @@ class MoleculeLoader:
         """Explode file cells into rows (``samples`` / ``samples_product``).
 
         Each file cell contributes one row per sequence. Literal columns are
-        repeated. With several file columns in a row, ``samples`` zips them
-        (and requires matching counts), while ``samples_product`` takes their
-        cartesian product.
+        repeated. With several file columns in a row, ``samples`` raises,
+        while ``samples_product`` takes their cartesian product.
+
+        The output is collected as one list per column and turned into a
+        DataFrame once at the end. Building a dict per row and letting pandas
+        take it apart again is many times slower for large files.
         """
-        rows = []
+        cols = list(df.columns)
+        columns = {col: [] for col in cols}
         parents = []
         seq_ids = []
-        chain_id_cols = {col: [] for col in df.columns}
+        chain_id_cols = {col: [] for col in cols}
         expanded = False
 
         for pos, (_, row) in enumerate(df.iterrows()):
-            col_recs = {col: self._cell_records(row[col]) for col in df.columns}
-            file_cols = [col for col in df.columns if col_recs[col][0]]
+            col_recs = {col: self._cell_records(row[col]) for col in cols}
+            file_cols = [col for col in cols if col_recs[col][0]]
 
             if not file_cols:
-                rows.append({col: row[col] for col in df.columns})
                 parents.append(pos)
                 seq_ids.append(None)
-                for col in df.columns:
+                for col in cols:
+                    columns[col].append(row[col])
                     chain_id_cols[col].append(None)
                 continue
 
@@ -316,26 +319,24 @@ class MoleculeLoader:
                 expanded = True
 
             for combo in combos:
-                new_row = {}
                 cid_map = {}
-                for col in df.columns:
+                for col in cols:
                     if col in file_cols:
                         chain_id, seq = combo[file_cols.index(col)]
-                        new_row[col] = seq
+                        columns[col].append(seq)
                         cid_map[col] = chain_id
                     else:
-                        new_row[col] = row[col]
+                        columns[col].append(row[col])
                         cid_map[col] = None
-                rows.append(new_row)
                 parents.append(pos)
                 if len(file_cols) == 1:
                     seq_ids.append(cid_map[file_cols[0]])
                 else:
                     seq_ids.append(tuple(cid_map[col] for col in file_cols))
-                for col in df.columns:
+                for col in cols:
                     chain_id_cols[col].append(cid_map[col])
 
-        out = pd.DataFrame(rows, columns=list(df.columns))
+        out = pd.DataFrame(columns, columns=cols)
         return self._finalize_index(
             out, df.index, parents, seq_ids, chain_id_cols, expanded
         )
@@ -384,6 +385,8 @@ class MoleculeLoader:
     def _determine_type(self, path):
         """Return the format string inferred from the file suffix.
 
+        A trailing ``.gz`` is skipped, so ``reads.fastq.gz`` is ``"fastq"``.
+
         Parameters
         ----------
         path : Path
@@ -393,18 +396,27 @@ class MoleculeLoader:
         -------
         str or None
             Format string such as "pdb", "fasta", "genbank"; ``None`` when the
-            path has no suffix.
+            path has no format suffix (``reads`` or ``reads.gz``).
         """
-        suffix = path.suffix.lower()
-        return suffix.lstrip(".") if suffix else None
+        suffixes = [s.lower() for s in path.suffixes]
+        if suffixes and suffixes[-1] == ".gz":
+            suffixes = suffixes[:-1]
+        if not suffixes:
+            return None
+        return suffixes[-1].lstrip(".")
 
-    def _load_dispatch(self, path):
-        """Dispatch the loader based on file type.
+    def _open_text(self, path):
+        """Open a plain or gzipped file as text; the caller closes it."""
+        if path.suffix.lower() == ".gz":
+            return gzip.open(path, "rt")
+        return open(path)
 
-        Returns
-        -------
-        pd.DataFrame
-            DataFrame with columns ``["chain_id", "sequence"]``.
+    def _iter_records(self, path):
+        """Yield ``(chain_id, sequence)`` records from a file, one at a time.
+
+        The file suffix gives the format, and the format picks the reader.
+        The file stays open until the last record is read, so the ``with``
+        wraps the ``yield from``.
         """
         fmt = self._determine_type(path)
 
@@ -418,65 +430,43 @@ class MoleculeLoader:
                 "suffix."
             )
 
-        if fmt == "pdb":
-            return self._load_pdb_seq(path)
+        # Formats with a dedicated reader; everything else goes through SeqIO.
+        readers = {"pdb": self._read_pdb, "fastq": self._read_fastq}
 
-        return self._load_seqio(path, fmt)
+        with self._open_text(path) as handle:
+            reader = readers.get(fmt)
+            if reader is None:
+                yield from self._read_seqio(handle, fmt)
+            else:
+                yield from reader(handle)
 
-    def _load_pdb_seq(self, path):
-        """Load a PDB file and extract the amino-acid sequences.
+    def _read_pdb(self, handle):
+        """Yield ``(chain_id, sequence)`` from the SEQRES records of a PDB file.
 
-        Parameters
-        ----------
-        path : Path
-            path to PDB file
-
-        Returns
-        -------
-        pandas.DataFrame
-            DataFrame with columns ``["chain_id", "sequence"]``.
+        Biopython names each record ``<pdb_id>:<chain>``. Only the chain
+        part is kept as the chain ID.
         """
-        with open(path) as handle:
-            seqres_records = list(SeqIO.parse(handle, "pdb-seqres"))
+        for record in SeqIO.parse(handle, "pdb-seqres"):
+            chain_id = record.id.split(":")[1] if ":" in record.id else record.id
+            yield chain_id, str(record.seq)
 
-        records = [
-            {
-                "chain_id": record.id.split(":")[1] if ":" in record.id else record.id,
-                "sequence": str(record.seq),
-            }
-            for record in seqres_records
-        ]
-        if not records:
-            raise ValueError(f"No sequences found in {path}")
+    def _read_seqio(self, handle, fmt):
+        """Yield ``(chain_id, sequence)`` from any format ``Bio.SeqIO`` parses.
 
-        return pd.DataFrame.from_records(records, columns=["chain_id", "sequence"])
-
-    def _load_seqio(self, path, fmt):
-        """Load any non-PDB file format supported by Biopython SeqIO.
-
-        Notes
-        -----
-        For non-PDB formats there is usually no literal chain concept.
-        To preserve the existing abstract datatype, ``record.id`` is stored
-        in the ``chain_id`` column.
-
-        Returns
-        -------
-        pd.DataFrame
-            DataFrame with columns ``["chain_id", "sequence"]``.
+        Non-PDB formats have no chains, so ``record.id`` (the first word of
+        the header) is used as the chain ID.
         """
-        with open(path) as handle:
-            records = list(SeqIO.parse(handle, fmt))
+        for record in SeqIO.parse(handle, fmt):
+            yield record.id, str(record.seq)
 
-        rows = [
-            {
-                "chain_id": record.id,
-                "sequence": str(record.seq),
-            }
-            for record in records
-        ]
+    def _read_fastq(self, handle):
+        """Yield ``(chain_id, sequence)`` from a FASTQ file.
 
-        if not rows:
-            raise ValueError(f"No sequences found in {path}")
-
-        return pd.DataFrame.from_records(rows, columns=["chain_id", "sequence"])
+        Reads with ``FastqGeneralIterator``, which returns plain strings and
+        is much faster than building a ``SeqRecord`` per read. The chain ID
+        is the first word of the title line, the same as ``SeqRecord.id``.
+        The quality string is read but not used.
+        """
+        for title, sequence, _quality in FastqGeneralIterator(handle):
+            chain_id = title.split()[0]
+            yield chain_id, sequence

--- a/pyaptamer/data/tests/test_loader.py
+++ b/pyaptamer/data/tests/test_loader.py
@@ -15,11 +15,9 @@ PDB_SINGLE = str(DATA_DIR / "1brq.pdb")  # 1 chain A
 PDB_NO_SEQRES = str(DATA_DIR / "1gnh_no_seqres.pdb")
 
 
-# --------------------------------------------------------------------------- #
 # in-memory data
-# --------------------------------------------------------------------------- #
 def test_in_memory_data_is_noop():
-    """In-memory sequences/primitives round-trip into columns unchanged."""
+    """In-memory cells are returned as given: same columns, same values."""
     proteins = ["ASCJNBDSFBWUJBCW", "SDUWEIPBNVNEWVUBW", "IOJVDPOIJWIDNVIVNV"]
     aptamers = ["AAACTAATATAAAATAAT", "CTCTAGGGGGGGGGG", "GGGGCAAAAAACCC"]
     bindings = [0.4, 0.5, 0.6]
@@ -36,11 +34,9 @@ def test_in_memory_data_is_noop():
     assert df["binding"].to_list() == bindings
 
 
-# --------------------------------------------------------------------------- #
 # tiling: bag
-# --------------------------------------------------------------------------- #
 def test_bag_tiling_str_vs_list():
-    """bag: a multi-chain file -> list[str]; a single-chain file -> str."""
+    """bag: a multi-chain file gives list[str]; a single-chain file gives str."""
     loader = MoleculeLoader(data={"target": [PDB_MULTI, PDB_SINGLE]}, tiling="bag")
     df = loader.to_dataframe()
 
@@ -54,7 +50,7 @@ def test_bag_tiling_str_vs_list():
 
 
 def test_bag_ignore_duplicates_collapses_to_str():
-    """bag + ignore_duplicates: 10 identical chains dedup to 1 -> plain str."""
+    """bag + ignore_duplicates: 10 identical chains give one str."""
     loader = MoleculeLoader(
         data={"target": [PDB_MULTI]}, tiling="bag", ignore_duplicates=True
     )
@@ -64,11 +60,9 @@ def test_bag_ignore_duplicates_collapses_to_str():
     assert chain.startswith("QTDMSRK")
 
 
-# --------------------------------------------------------------------------- #
 # tiling: concat / first
-# --------------------------------------------------------------------------- #
 def test_concat_joins_sequences():
-    """concat: all chains joined into one string (length scales with count)."""
+    """concat: the cell is all chains joined into one string."""
     plain = MoleculeLoader(data={"target": [PDB_MULTI]}, tiling="concat")
     deduped = MoleculeLoader(
         data={"target": [PDB_MULTI]}, tiling="concat", ignore_duplicates=True
@@ -83,7 +77,7 @@ def test_concat_joins_sequences():
 
 
 def test_first_keeps_only_first_sequence():
-    """first: replace a multi-chain file with just its first sequence."""
+    """first: the cell is the first sequence of the file."""
     loader = MoleculeLoader(data={"target": [PDB_MULTI]}, tiling="first")
     chain = loader.to_dataframe()["target"].iloc[0]
 
@@ -91,11 +85,9 @@ def test_first_keeps_only_first_sequence():
     assert chain.startswith("QTDMSRK")
 
 
-# --------------------------------------------------------------------------- #
 # tiling: samples / samples_product
-# --------------------------------------------------------------------------- #
 def test_samples_explodes_to_rows():
-    """samples: one multi-chain file becomes one row per chain."""
+    """samples: a 10-chain file gives 10 rows, one per chain."""
     loader = MoleculeLoader(data={"target": [PDB_MULTI]}, tiling="samples")
     df = loader.to_dataframe()
 
@@ -104,7 +96,7 @@ def test_samples_explodes_to_rows():
 
 
 def test_samples_multiple_file_columns_raise():
-    """samples: expanding two file columns in one row is rejected as ambiguous."""
+    """samples: two file columns in one row raise ValueError."""
     loader = MoleculeLoader(
         data={"target": [PDB_MULTI], "ligand": [PDB_SINGLE]}, tiling="samples"
     )
@@ -112,8 +104,17 @@ def test_samples_multiple_file_columns_raise():
         loader.to_dataframe()
 
 
+def test_samples_literal_only_row_passes_through():
+    """samples: a row with no file cell gives one row; its label has no chain part."""
+    loader = MoleculeLoader(data={"seq": [PDB_SINGLE, "ACGT"]}, tiling="samples")
+    df = loader.to_dataframe()
+
+    assert df["seq"].tolist()[1] == "ACGT"
+    assert df.index.tolist() == ["0__A", "1"]
+
+
 def test_samples_product_is_cartesian():
-    """samples_product: two 10-chain files in a row -> 100 rows (10 x 10)."""
+    """samples_product: two 10-chain files in one row give 100 rows."""
     crossed = MoleculeLoader(
         data={"a": [PDB_MULTI], "b": [PDB_MULTI]}, tiling="samples_product"
     )
@@ -121,11 +122,9 @@ def test_samples_product_is_cartesian():
     assert len(crossed.to_dataframe()) == 100  # cartesian product
 
 
-# --------------------------------------------------------------------------- #
 # tiling: features
-# --------------------------------------------------------------------------- #
 def test_features_expands_to_columns():
-    """features: a 10-chain file spreads into target_0 ... target_9."""
+    """features: a 10-chain file gives columns target_0 to target_9."""
     loader = MoleculeLoader(data={"target": [PDB_MULTI]}, tiling="features")
     df = loader.to_dataframe()
 
@@ -133,11 +132,28 @@ def test_features_expands_to_columns():
     assert list(df.columns) == [f"target_{i}" for i in range(10)]
 
 
-# --------------------------------------------------------------------------- #
+def test_features_keeps_literal_and_single_sequence_columns():
+    """features: literal and single-sequence columns keep their name and values."""
+    loader = MoleculeLoader(
+        data={
+            "target": [PDB_MULTI, "ACGT"],
+            "ligand": [PDB_SINGLE, PDB_SINGLE],
+            "name": ["a", "b"],
+        },
+        tiling="features",
+    )
+    df = loader.to_dataframe()
+
+    assert list(df.columns) == [f"target_{i}" for i in range(10)] + ["ligand", "name"]
+    assert df["target_0"].iloc[1] == "ACGT"
+    assert pd.isna(df["target_1"].iloc[1])
+    assert df["ligand"].map(type).eq(str).all()
+    assert df["name"].tolist() == ["a", "b"]
+
+
 # indexing
-# --------------------------------------------------------------------------- #
 def test_indexing_new_gives_rangeindex():
-    """indexing='new': discard chain IDs, use a clean RangeIndex."""
+    """indexing='new': the index is a RangeIndex; chain IDs are dropped."""
     loader = MoleculeLoader(
         data={"target": [PDB_MULTI]}, tiling="samples", indexing="new"
     )
@@ -148,7 +164,7 @@ def test_indexing_new_gives_rangeindex():
 
 
 def test_indexing_preserve_flatten():
-    """indexing='preserve' + multiindex='flatten': index is 'row__chain'."""
+    """indexing='preserve' + multiindex='flatten': index labels are 'row__chain'."""
     loader = MoleculeLoader(
         data={"target": [PDB_MULTI]}, tiling="samples", indexing="preserve"
     )
@@ -158,7 +174,7 @@ def test_indexing_preserve_flatten():
 
 
 def test_indexing_keep_as_column():
-    """indexing='keep_as_column': chain IDs become a <col>_chain_id column."""
+    """indexing='keep_as_column': chain IDs are in a <col>_chain_id column."""
     loader = MoleculeLoader(
         data={"target": [PDB_MULTI]}, tiling="samples", indexing="keep_as_column"
     )
@@ -169,11 +185,9 @@ def test_indexing_keep_as_column():
     assert isinstance(df.index, pd.RangeIndex)
 
 
-# --------------------------------------------------------------------------- #
 # multiindex
-# --------------------------------------------------------------------------- #
 def test_multiindex_real():
-    """multiindex='multiindex': a real two-level (row, sequence) index."""
+    """multiindex='multiindex': the index is a (row, sequence) MultiIndex."""
     loader = MoleculeLoader(
         data={"target": [PDB_MULTI]}, tiling="samples", multiindex="multiindex"
     )
@@ -185,7 +199,7 @@ def test_multiindex_real():
 
 
 def test_multiindex_auto_stays_flat_without_expansion():
-    """multiindex='auto': single-sequence file does not trigger a MultiIndex."""
+    """multiindex='auto': a single-sequence file gives a flat index."""
     loader = MoleculeLoader(
         data={"target": [PDB_SINGLE]}, tiling="samples", multiindex="auto"
     )
@@ -194,33 +208,7 @@ def test_multiindex_auto_stays_flat_without_expansion():
     assert not isinstance(df.index, pd.MultiIndex)
 
 
-# --------------------------------------------------------------------------- #
-# format coverage: FASTA via SeqIO
-# --------------------------------------------------------------------------- #
-def test_fasta_multi_record_bag(tmp_path):
-    """A non-PDB format (FASTA) is parsed via SeqIO; 2 records -> list of 2."""
-    fasta = tmp_path / "library.fasta"
-    fasta.write_text(">seq1\nACGTACGT\n>seq2\nTTTTGGGG\n")
-
-    loader = MoleculeLoader(data={"aptamer": [str(fasta)]}, tiling="bag")
-    cell = loader.to_dataframe()["aptamer"].iloc[0]
-
-    assert cell == ["ACGTACGT", "TTTTGGGG"]
-
-
-def test_fastq_is_sequence_only(tmp_path):
-    """FASTQ is read sequence-only (quality dropped); reads explode to rows."""
-    fastq = tmp_path / "selex.fastq"
-    fastq.write_text("@read1\nACGTACGT\n+\nIIIIIIII\n@read2\nTTTTGGGG\n+\nIIIIIIII\n")
-
-    loader = MoleculeLoader(data={"selex": [str(fastq)]}, tiling="samples")
-    df = loader.to_dataframe()
-
-    assert df["selex"].tolist() == ["ACGTACGT", "TTTTGGGG"]
-    # sequence-only: per-base quality is dropped, so no quality column appears
-    assert list(df.columns) == ["selex"]
-
-
+# format coverage: the generic SeqIO reader
 @pytest.mark.parametrize(
     "ext, content",
     [
@@ -239,7 +227,7 @@ def test_fastq_is_sequence_only(tmp_path):
     ],
 )
 def test_genbank_and_embl_dispatch(tmp_path, ext, content):
-    """GenBank/EMBL files dispatch through SeqIO by suffix and yield sequences."""
+    """GenBank and EMBL files are read by SeqIO.parse, picked by suffix."""
     path = tmp_path / f"record.{ext}"
     path.write_text(content)
 
@@ -249,30 +237,31 @@ def test_genbank_and_embl_dispatch(tmp_path, ext, content):
     assert df["seq"].tolist() == ["ACGTACGT"]
 
 
-def test_fasta_path_broadcasts_against_in_memory_column(tmp_path):
-    """A FASTA file column explodes per-record while an in-memory column broadcasts."""
+def test_fasta_path_broadcasts_against_in_memory_columns(tmp_path):
+    """samples: one row per record; literal columns are repeated and keep dtype."""
     fasta = tmp_path / "library.fasta"
     fasta.write_text(">apt1\nACGTACGT\n>apt2\nTTTTGGGG\n>apt3\nGGGGCCCC\n")
     protein = "ACDEFGHIKLMNPQRSTVWY"
 
     loader = MoleculeLoader(
-        data={"aptamer": [str(fasta)], "protein": [protein]}, tiling="samples"
+        data={"aptamer": [str(fasta)], "protein": [protein], "binding": [0.5]},
+        tiling="samples",
     )
     df = loader.to_dataframe()
 
     assert df["aptamer"].tolist() == ["ACGTACGT", "TTTTGGGG", "GGGGCCCC"]
     assert df["protein"].tolist() == [protein, protein, protein]
+    assert df["binding"].tolist() == [0.5, 0.5, 0.5]
+    assert df["binding"].dtype == "float64"
 
 
-# --------------------------------------------------------------------------- #
 # path-like cells
 #
 # Cells may hold a str or any os.PathLike. A Path used to fall through to the
 # literal branch and be returned unparsed, which was silent rather than an
 # error, so both forms are checked against each other.
-# --------------------------------------------------------------------------- #
 def test_path_object_parses_like_str():
-    """A Path cell is parsed, not passed through as a literal."""
+    """A Path cell is read as a file and gives the same table as the str cell."""
     as_str = MoleculeLoader(data={"target": [PDB_SINGLE]}).to_dataframe()
     as_path = MoleculeLoader(data={"target": [Path(PDB_SINGLE)]}).to_dataframe()
 
@@ -281,7 +270,7 @@ def test_path_object_parses_like_str():
 
 
 def test_path_object_explodes_to_rows_under_samples():
-    """A Path FASTQ expands to one row per read, like its str equivalent."""
+    """samples: a Path FASTQ gives the same rows as the str path."""
     fastq = DATA_DIR / "sample.fastq"
 
     as_str = MoleculeLoader(data={"seq": [str(fastq)]}, tiling="samples").to_dataframe()
@@ -291,21 +280,15 @@ def test_path_object_explodes_to_rows_under_samples():
     assert as_path.equals(as_str)
 
 
-def test_suffixless_path_is_still_a_file():
-    """A Path states intent, so it is read as a file even without a suffix."""
-    with pytest.raises(ValueError, match="picks the parser from the file suffix"):
-        MoleculeLoader(data={"seq": [Path("reads")]}).to_dataframe()
-
-
 def test_suffixless_str_stays_a_literal():
-    """A str without a suffix is a sequence, not a file."""
+    """A str with no suffix is kept as a literal value."""
     df = MoleculeLoader(data={"seq": ["ACGT"]}).to_dataframe()
 
     assert df["seq"].iloc[0] == "ACGT"
 
 
 def test_str_and_path_mix_in_one_column():
-    """Both spellings can appear in the same column."""
+    """str and Path cells in one column are both read as files."""
     fastq = DATA_DIR / "sample.fastq"
 
     loader = MoleculeLoader(data={"seq": [str(fastq), fastq]}, tiling="samples")
@@ -314,9 +297,7 @@ def test_str_and_path_mix_in_one_column():
     assert len(df) == 20
 
 
-# --------------------------------------------------------------------------- #
 # validation / errors
-# --------------------------------------------------------------------------- #
 @pytest.mark.parametrize(
     "kwargs",
     [
@@ -326,21 +307,60 @@ def test_str_and_path_mix_in_one_column():
     ],
 )
 def test_invalid_options_raise(kwargs):
-    """Unknown tiling/indexing/multiindex values are rejected at construction."""
+    """Unknown tiling, indexing or multiindex values raise ValueError in __init__."""
     with pytest.raises(ValueError):
         MoleculeLoader(data={"target": [PDB_SINGLE]}, **kwargs)
 
 
 def test_no_seqres_pdb_raises():
-    """A PDB file without SEQRES records raises on materialization."""
+    """A PDB file with no SEQRES records raises ValueError in to_dataframe."""
     loader = MoleculeLoader(data={"target": [PDB_NO_SEQRES]})
     with pytest.raises(ValueError, match="No sequences found"):
         loader.to_dataframe()
 
 
-# --------------------------------------------------------------------------- #
-# file readers: gzip, fast FASTA/FASTQ paths
-# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "cell", [Path("reads"), "reads.gz"], ids=["bare-path", "gz-only"]
+)
+def test_missing_format_suffix_raises(cell):
+    """A file cell with no format suffix (bare Path, or only .gz) raises ValueError."""
+    with pytest.raises(ValueError, match="picks the parser from the file suffix"):
+        MoleculeLoader(data={"seq": [cell]}).to_dataframe()
+
+
+# file readers: suffix rule, gzip, reader dispatch
+@pytest.mark.parametrize(
+    "name, expected",
+    [
+        ("reads.fastq", "fastq"),
+        ("reads.fastq.gz", "fastq"),
+        ("READS.FASTA", "fasta"),
+        ("sample.v2.fastq", "fastq"),
+        ("reads.gz", None),
+        ("reads", None),
+    ],
+)
+def test_determine_type(name, expected):
+    """_determine_type: last suffix, lowercased, with a trailing .gz skipped."""
+    assert MoleculeLoader(data={})._determine_type(Path(name)) == expected
+
+
+def test_fastq_does_not_use_seqio_parse(tmp_path, monkeypatch):
+    """FASTQ files are read by FastqGeneralIterator, not SeqIO.parse."""
+    from pyaptamer.data import loader as loader_module
+
+    def fail(*args, **kwargs):
+        raise AssertionError("SeqIO.parse was called for a FASTQ file")
+
+    monkeypatch.setattr(loader_module.SeqIO, "parse", fail)
+    fastq = tmp_path / "selex.fastq"
+    fastq.write_text("@r1\nACGT\n+\nIIII\n")
+
+    df = MoleculeLoader(data={"seq": [str(fastq)]}, tiling="samples").to_dataframe()
+
+    assert df["seq"].tolist() == ["ACGT"]
+
+
 @pytest.mark.parametrize(
     "name, content",
     [
@@ -350,7 +370,7 @@ def test_no_seqres_pdb_raises():
     ids=["fasta", "fastq"],
 )
 def test_gzipped_file_is_read(tmp_path, name, content):
-    """A .gz file is decompressed and parsed by the format under the .gz."""
+    """A .gz file is decompressed and read by the reader for the suffix under .gz."""
     import gzip
 
     path = tmp_path / name
@@ -362,17 +382,8 @@ def test_gzipped_file_is_read(tmp_path, name, content):
     assert df["seq"].tolist() == ["ACGTACGT", "TTTTGGGG"]
 
 
-def test_gz_without_format_suffix_raises(tmp_path):
-    """reads.gz has no format under the .gz, so the suffix error is raised."""
-    path = tmp_path / "reads.gz"
-    path.write_bytes(b"")
-
-    with pytest.raises(ValueError, match="picks the parser from the file suffix"):
-        MoleculeLoader(data={"seq": [str(path)]}).to_dataframe()
-
-
 def test_fasta_id_is_first_word_of_header(tmp_path):
-    """FASTA chain_id is the first word of the header, as in SeqIO record.id."""
+    """FASTA chain_id is the first word of the header line, as in SeqIO record.id."""
     fasta = tmp_path / "library.fasta"
     fasta.write_text(
         ">apt1 first aptamer\nACGTACGT\n>apt2 second aptamer\nTTTT\nGGGG\n"
@@ -387,7 +398,7 @@ def test_fasta_id_is_first_word_of_header(tmp_path):
 
 
 def test_tricky_fastq_parses(tmp_path):
-    """Quality lines starting with '@' and repeated '+' titles do not split reads."""
+    """A '@' starting a quality line or a repeated '+' title does not split a read."""
     fastq = tmp_path / "tricky.fastq"
     fastq.write_text("@r1 desc\nACGT\n+r1 desc\n@III\n@r2\nTTTT\n+\n@@@@\n")
 
@@ -397,16 +408,3 @@ def test_tricky_fastq_parses(tmp_path):
 
     assert df["seq"].tolist() == ["ACGT", "TTTT"]
     assert df["seq_chain_id"].tolist() == ["r1", "r2"]
-
-
-def test_samples_literal_column_keeps_dtype(tmp_path):
-    """A numeric literal column stays numeric after a file column explodes."""
-    fastq = tmp_path / "selex.fastq"
-    fastq.write_text("@r1\nACGTACGT\n+\nIIIIIIII\n@r2\nTTTTGGGG\n+\nIIIIIIII\n")
-
-    df = MoleculeLoader(
-        data={"seq": [str(fastq)], "binding": [0.5]}, tiling="samples"
-    ).to_dataframe()
-
-    assert df["binding"].dtype == "float64"
-    assert df["binding"].tolist() == [0.5, 0.5]

--- a/pyaptamer/data/tests/test_loader.py
+++ b/pyaptamer/data/tests/test_loader.py
@@ -336,3 +336,77 @@ def test_no_seqres_pdb_raises():
     loader = MoleculeLoader(data={"target": [PDB_NO_SEQRES]})
     with pytest.raises(ValueError, match="No sequences found"):
         loader.to_dataframe()
+
+
+# --------------------------------------------------------------------------- #
+# file readers: gzip, fast FASTA/FASTQ paths
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "name, content",
+    [
+        ("library.fasta.gz", ">apt1\nACGTACGT\n>apt2\nTTTT\nGGGG\n"),
+        ("selex.fastq.gz", "@r1\nACGTACGT\n+\nIIIIIIII\n@r2\nTTTTGGGG\n+\nIIIIIIII\n"),
+    ],
+    ids=["fasta", "fastq"],
+)
+def test_gzipped_file_is_read(tmp_path, name, content):
+    """A .gz file is decompressed and parsed by the format under the .gz."""
+    import gzip
+
+    path = tmp_path / name
+    with gzip.open(path, "wt") as handle:
+        handle.write(content)
+
+    df = MoleculeLoader(data={"seq": [str(path)]}, tiling="samples").to_dataframe()
+
+    assert df["seq"].tolist() == ["ACGTACGT", "TTTTGGGG"]
+
+
+def test_gz_without_format_suffix_raises(tmp_path):
+    """reads.gz has no format under the .gz, so the suffix error is raised."""
+    path = tmp_path / "reads.gz"
+    path.write_bytes(b"")
+
+    with pytest.raises(ValueError, match="picks the parser from the file suffix"):
+        MoleculeLoader(data={"seq": [str(path)]}).to_dataframe()
+
+
+def test_fasta_id_is_first_word_of_header(tmp_path):
+    """FASTA chain_id is the first word of the header, as in SeqIO record.id."""
+    fasta = tmp_path / "library.fasta"
+    fasta.write_text(
+        ">apt1 first aptamer\nACGTACGT\n>apt2 second aptamer\nTTTT\nGGGG\n"
+    )
+
+    df = MoleculeLoader(
+        data={"seq": [str(fasta)]}, tiling="samples", indexing="keep_as_column"
+    ).to_dataframe()
+
+    assert df["seq_chain_id"].tolist() == ["apt1", "apt2"]
+    assert df["seq"].tolist() == ["ACGTACGT", "TTTTGGGG"]
+
+
+def test_tricky_fastq_parses(tmp_path):
+    """Quality lines starting with '@' and repeated '+' titles do not split reads."""
+    fastq = tmp_path / "tricky.fastq"
+    fastq.write_text("@r1 desc\nACGT\n+r1 desc\n@III\n@r2\nTTTT\n+\n@@@@\n")
+
+    df = MoleculeLoader(
+        data={"seq": [str(fastq)]}, tiling="samples", indexing="keep_as_column"
+    ).to_dataframe()
+
+    assert df["seq"].tolist() == ["ACGT", "TTTT"]
+    assert df["seq_chain_id"].tolist() == ["r1", "r2"]
+
+
+def test_samples_literal_column_keeps_dtype(tmp_path):
+    """A numeric literal column stays numeric after a file column explodes."""
+    fastq = tmp_path / "selex.fastq"
+    fastq.write_text("@r1\nACGTACGT\n+\nIIIIIIII\n@r2\nTTTTGGGG\n+\nIIIIIIII\n")
+
+    df = MoleculeLoader(
+        data={"seq": [str(fastq)], "binding": [0.5]}, tiling="samples"
+    ).to_dataframe()
+
+    assert df["binding"].dtype == "float64"
+    assert df["binding"].tolist() == [0.5, 0.5]


### PR DESCRIPTION
Part of #765

## What changed

- Files are read record by record. `_cell_records` used to get a DataFrame
  built from `list(SeqIO.parse(...))`, which held every `SeqRecord` in
  memory at once and then converted again from DataFrame into tuples. Now a
  reader yields `(chain_id, sequence)` tuples and `_cell_records` collects them at once.

- One reader per format behind a dispatch dict in `_iter_records`:
  `_read_pdb` (SEQRES, chain id split), `_read_fastq` (Biopython's
  `FastqGeneralIterator`, plain strings, no `SeqRecord`), and `_read_seqio`
  as the fallback for every other format `Bio.SeqIO` knows. Adding a reader
  is one dict entry and one method.
- `.gz` files are read directly. `_determine_type` looks past a trailing
  `.gz` and `_open_text` opens with `gzip.open(path, "rt")`. Files from ENA
  and SRA arrive gzipped, and until now they failed with
  `Unknown format 'gz'`.
- `_tile_samples` collects one list per column and builds the DataFrame
  once, instead of one dict per output row.

## Measured

BARX1 HT-SELEX cycle 1 from Jolma et al. 2013 (ENA ERR188678, 17.7 MB,
216,997 reads), `tiling="samples"`, timed with `time.perf_counter`:

File: https://www.ebi.ac.uk/ena/browser/view/ERR188678

| | before | after |
|---|---|---|
| `to_dataframe()` | 32.5 s | 0.82 s |
| memory growth during the call | ~290 MB | ~105 MB |

## Tests

`test_loader.py` now has one test per reader and tiling path.
New: gzipped FASTA and FASTQ are read; `_determine_type` is checked
directly on six filenames (plain, `.gz`, uppercase, extra dot, `.gz`
only, no suffix); FASTQ is read by `FastqGeneralIterator` and not parsed through
`SeqIO.parse`; In FASTA
chain id should be the first word of the header, as in `SeqRecord.id`; a FASTQ
whose quality lines start with `@` is parsed correctly; a `samples` row
with no file cell gives one row; `features` keeps literal and
single-sequence columns by name.
