### PR TITLE
[BUG] BaseTransform: univariate transformers select their column by p…

### DIFF
--- a/pyaptamer/trafos/base/_base.py
+++ b/pyaptamer/trafos/base/_base.py
@@ -53,8 +53,10 @@ class BaseTransform(BaseEstimator):
 
         Parameters
         ----------
-        X : array-like, shape (n_samples, n_features)
-            Input data to fit the transformer.
+        X : pd.DataFrame, shape (n_samples, n_features)
+            Input data to fit the transformer. If the tag
+            ``capability:multivariate`` is False, X has exactly one column.
+            Select it by position. Its name is not fixed.
         y : array-like, shape (n_samples,), optional
             Target values. Only used if the transformer has
             the tag ``capability:y`` set to True.
@@ -96,8 +98,10 @@ class BaseTransform(BaseEstimator):
 
         Parameters
         ----------
-        X : array-like, shape (n_samples, n_features)
-            Input data to transform.
+        X : pd.DataFrame, shape (n_samples, n_features)
+            Input data to transform. If the tag ``capability:multivariate``
+            is False, X has exactly one column. Select it by position. Its
+            name is not fixed.
 
         Returns
         -------

--- a/pyaptamer/trafos/base/tests/test_base.py
+++ b/pyaptamer/trafos/base/tests/test_base.py
@@ -143,6 +143,15 @@ class TestAllTransformers(TransformerFixtureGenerator, TestAllObjects):
         object_instance.fit_transform(**scenario.args["fit"])
         assert object_instance.is_fitted is True
 
+    def test_univariate_accepts_any_column_name(self, object_instance):
+        """A univariate transformer works on its one column whatever it is called."""
+        if object_instance.get_tag("capability:multivariate", False):
+            pytest.skip("only univariate transformers receive a single column")
+        args = _scenario_for(object_instance).args
+        X_fit = args["fit"]["X"].set_axis(["reads"], axis=1)
+        X_transform = args["transform"]["X"].set_axis(["reads"], axis=1)
+        object_instance.fit(X_fit).transform(X_transform)
+
 
 def test_stateful_transform_uses_fitted_state():
     """A transformer with fitted state can read that state back in transform."""


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #770.

#### What does this implement/fix? Explain your changes.
The transformer test suite feeds univariate transformers ,a frame with a
column named `seq`. A transformer that selects its column by name fails
unless that name is `seq`, so the fixture was rigid.

The base class already rejects more than one column for univariate
transformers, so a column name parameter there can only match or raise.


This PR states the rule in the `_fit` and `_transform` docstrings: X has
one column, select it by position, its name is not fixed.

#### What should a reviewer concentrate their feedback on?
- The wording of the X parameter in `_fit` and `_transform`.

#### Did you add any tests for the change?
Yes. `test_univariate_accepts_any_column_name` renames the column and runs
fit then transform on every univariate transformer.

#### PR checklist
- [x] The PR title starts with [BUG].
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing.
